### PR TITLE
Minor Contribution: improve error handling, logger portability, and server initialization patterns

### DIFF
--- a/typescript/packages/cli/src/commands/init.ts
+++ b/typescript/packages/cli/src/commands/init.ts
@@ -352,7 +352,7 @@ async function createProjectFromScratch(
   fs.writeJSONSync(path.join(targetDir, 'tsconfig.json'), tsconfig, { spaces: 2 });
   fs.mkdirSync(path.join(targetDir, 'src'), { recursive: true });
 
-  const indexTs = `import { createServer, createTool, z } from '@nitrostack/core';
+  const indexTs = `import { createServer, Tool, z } from '@nitrostack/core';
 
 const server = createServer({
   name: '${projectName}',
@@ -361,7 +361,7 @@ const server = createServer({
 });
 
 server.tool(
-  createTool({
+  new Tool({
     name: 'hello',
     description: 'Say hello to someone',
     inputSchema: z.object({
@@ -409,7 +409,7 @@ npm run build
 npm start
 \`\`\`
 
-Built with [NitroStack](https://nitrostack.dev) ⚡
+Built with [NitroStack](https://nitrostack.ai) ⚡
 `;
 
   fs.writeFileSync(path.join(targetDir, 'README.md'), readme);

--- a/typescript/packages/core/src/core/logger.ts
+++ b/typescript/packages/core/src/core/logger.ts
@@ -1,4 +1,5 @@
 import winston from 'winston';
+import os from 'os';
 import { Logger, LogMeta } from './types.js';
 import { EventEmitterTransport } from './events/log-emitter.js';
 
@@ -53,7 +54,7 @@ export function createLogger(options: {
     // Silent logger - logs nowhere (better than crashing)
     transports.push(
       new winston.transports.File({
-        filename: '/dev/null', // Discard logs
+        filename: os.devNull, // Cross-platform: works on Windows, macOS, Linux
         silent: true,
       })
     );

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -25,7 +25,7 @@ import {
   ResourceTemplateDefinition,
 } from './types.js';
 import { createLogger } from './logger.js';
-import { ToolExecutionError, ValidationError, ResourceNotFoundError } from './errors.js';
+import { ToolExecutionError, ValidationError, ResourceNotFoundError, PromptNotFoundError } from './errors.js';
 import { v4 as uuidv4 } from 'uuid';
 import { isModule, getModuleMetadata } from './module.js';
 import { buildController } from './builders.js';
@@ -773,6 +773,7 @@ export class NitroStackServer {
               mimeType: resource.mimeType || 'application/json',
               text: JSON.stringify(content.data, null, 2),
             };
+            break;
           default:
             // Fallback: if content doesn't match ResourceContent shape, treat as JSON
             responseContent = {
@@ -853,7 +854,7 @@ export class NitroStackServer {
       const prompt = this.prompts.get(name);
 
       if (!prompt) {
-        throw new Error(`Prompt not found: ${name}`);
+        throw new PromptNotFoundError(name);
       }
 
       const context = this.createContext();
@@ -914,7 +915,7 @@ export class NitroStackServer {
     // Use explicit transport if set, otherwise infer from NODE_ENV
     const transportType = explicitTransport || (isDevelopment ? 'stdio' : 'dual');
     this._transportType = transportType;
-    console.error(`[DEBUG] NitroStackServer.start(): NODE_ENV=${process.env.NODE_ENV}, MCP_TRANSPORT_TYPE=${explicitTransport}, transportType=${transportType}`);
+    this.logger.debug(`NitroStackServer.start(): NODE_ENV=${process.env.NODE_ENV}, MCP_TRANSPORT_TYPE=${explicitTransport}, transportType=${transportType}`);
 
     // Call onModuleInit for all modules
     for (const moduleClass of this.modules) {

--- a/typescript/packages/core/src/core/tool.ts
+++ b/typescript/packages/core/src/core/tool.ts
@@ -280,8 +280,9 @@ export class Tool<TInput = unknown, TOutput = unknown> {
           $refStrategy: 'none',
           target: 'jsonSchema7',
         }) as JsonSchema;
-      } catch (error) {
-        console.error('Error converting Zod schema:', error);
+      } catch (_error) {
+        // Silently fall back to permissive schema — console output is
+        // disabled in MCP servers as it breaks the JSON-RPC stdio protocol.
         return { type: 'object', properties: {}, additionalProperties: true };
       }
     }


### PR DESCRIPTION
## Description

<!-- Explain what this PR changes and why -->

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [x] docs: Documentation update
- [x] refactor: Internal code change
- [ ] test: Test-only changes
- [ ] chore: Build, CI, or tooling changes

## Related Issues

<!-- Use closing keywords when appropriate, e.g. Closes #123 -->

## Changes Made

- Fix missing break in resource content switch statement (server.ts)

The case 'json' branch was missing a break, causing fall-through to the default case. This silently overwrote JSON resource responses with double-serialized content.
Replace debug console.error with logger.debug (server.ts)

- A console.error('[DEBUG] NitroStackServer.start()...') was running on every server start. Since MCP uses STDIO for JSON-RPC, any stderr output can interfere with the protocol. Replaced with this.logger.debug() to follow the project's own logging conventions.
Use PromptNotFoundError instead of generic Error (server.ts)

- The GetPromptRequestSchema handler threw new Error('Prompt not found: ...') while tools and resources already use their dedicated error classes (ToolNotFoundError, ResourceNotFoundError). Updated to use the existing PromptNotFoundError class from errors.ts for consistency.
Remove console.error from Zod schema conversion (tool.ts)

- The toJsonSchema() catch block used console.error, which breaks MCP's STDIO protocol. Changed to a silent fallback with an explanatory comment.
Use os.devNull instead of hardcoded /dev/null (logger.ts)

- The fallback logger transport used filename: '/dev/null', which doesn't exist on Windows. Replaced with Node.js built-in os.devNull for cross-platform compatibility.
Bug Fixes (@nitrostack/cli)
Fix non-existent createTool in generated scaffold code (init.ts)

- The createProjectFromScratch fallback template imported createTool from @nitrostack/core, which doesn't exist in the public API. Updated to use new Tool({...}), which is the correct exported class.
Fix incorrect website URL in generated README (init.ts)

- Generated project READMEs linked to nitrostack.dev instead of nitrostack.ai


## Testing

- [x] `npm run lint`
- [x] `npm test`
- [x] Manual testing performed (if applicable)

## Screenshots / Recordings

<!-- Add screenshots or GIFs for UI/UX changes -->

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [x] I have added/updated tests where appropriate
- [x] I have updated docs where appropriate
- [x] I have kept this PR focused and scoped
- [ ] I have used conventional commits
