### PR TITLE
fix(core): escape server metadata in documentation HTML

### DIFF
--- a/typescript/packages/core/src/core/__tests__/transport.streamable.test.ts
+++ b/typescript/packages/core/src/core/__tests__/transport.streamable.test.ts
@@ -54,6 +54,25 @@ describe('StreamableHttpTransport', () => {
         expect(st.escapeHtml('<script>')).toBe('&lt;script&gt;');
     });
 
+    it('escapes server metadata in generated documentation HTML', async () => {
+        const st = (transport as any);
+
+        st.setServerConfig({
+            name: 'Demo <Server> & Co',
+            version: '1.0.0 <beta>',
+            description: 'Docs for <script>alert(1)</script> & friends'
+        });
+
+        const html = st.generateDocumentationPage([], 'http://localhost:3060/mcp?x=<tag>&y=1');
+
+        expect(html).toContain('Demo &lt;Server&gt; &amp; Co');
+        expect(html).toContain('1.0.0 &lt;beta&gt;');
+        expect(html).toContain('Docs for &lt;script&gt;alert(1)&lt;/script&gt; &amp; friends');
+        expect(html).toContain('http://localhost:3060/mcp?x=&lt;tag&gt;&amp;y=1');
+        expect(html).not.toContain('<h1>Demo <Server> & Co</h1>');
+        expect(html).not.toContain('<script>alert(1)</script>');
+    });
+
     it('should handle session-based messaging and sessionless send', async () => {
         const st = (transport as any);
         const session = {

--- a/typescript/packages/core/src/core/transports/streamable-http.ts
+++ b/typescript/packages/core/src/core/transports/streamable-http.ts
@@ -988,13 +988,17 @@ export class StreamableHttpTransport implements Transport {
     const serverName = this.serverConfig?.name || 'NitroStack MCP Server';
     const serverVersion = this.serverConfig?.version || '1.0.0';
     const serverDescription = this.serverConfig?.description || 'A powerful MCP server built with NitroStack';
+    const escapedServerName = this.escapeHtml(serverName);
+    const escapedServerVersion = this.escapeHtml(serverVersion);
+    const escapedServerDescription = this.escapeHtml(serverDescription);
+    const escapedMcpEndpoint = this.escapeHtml(mcpEndpoint);
 
     return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${serverName} - MCP Server Documentation</title>
+  <title>${escapedServerName} - MCP Server Documentation</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
@@ -1384,9 +1388,9 @@ export class StreamableHttpTransport implements Transport {
         <img src="data:image/png;base64,${this.logoBase64}" alt="NitroCloud Logo" class="logo">
       </div>
       ` : ''}
-      <h1>${serverName}</h1>
-      <div class="version">v${serverVersion}</div>
-      <div class="description">${serverDescription}</div>
+      <h1>${escapedServerName}</h1>
+      <div class="version">v${escapedServerVersion}</div>
+      <div class="description">${escapedServerDescription}</div>
     </div>
     
     <div class="content">
@@ -1394,7 +1398,7 @@ export class StreamableHttpTransport implements Transport {
         <h2>🔌 Connection Information</h2>
         <div class="connection-info">
           <p>MCP Endpoint</p>
-          <code>${mcpEndpoint}</code>
+          <code>${escapedMcpEndpoint}</code>
           <p class="description">
             Connect to this MCP server using the endpoint above. The server supports Server-Sent Events (SSE) for real-time bidirectional communication following the Model Context Protocol specification.
           </p>


### PR DESCRIPTION
Escapes server metadata and the MCP endpoint before inserting them into the generated documentation page. Adds a regression test covering angle brackets and ampersands in server config and endpoint values.