### PR TITLE
Escape server metadata in Streamable HTTP documentation HTML

### DIFF
--- a/typescript/packages/core/src/core/__tests__/transport.streamable.test.ts
+++ b/typescript/packages/core/src/core/__tests__/transport.streamable.test.ts
@@ -30,9 +30,9 @@ describe('StreamableHttpTransport', () => {
         st.loadLogo();
 
         st.setServerConfig({
-            name: 'DocTest',
+            name: 'Documentation<Server> Test',
             version: '1.0.0',
-            description: 'A test server'
+            description: 'This is a test <b>Server</b>'
         });
 
         st.setToolsCallback(async () => [
@@ -45,7 +45,8 @@ describe('StreamableHttpTransport', () => {
             'http://localhost:3060/mcp'
         );
 
-        expect(html).toContain('DocTest');
+        expect(html).toContain('Documentation&lt;Server&gt; Test');
+        expect(html).toContain('This is a test &lt;b&gt;Server&lt;/b&gt;');
         expect(html).toContain('1.0.0');
         expect(html).toContain('tool1');
         expect(html).toContain('Has UI Widget');

--- a/typescript/packages/core/src/core/transports/streamable-http.ts
+++ b/typescript/packages/core/src/core/transports/streamable-http.ts
@@ -985,9 +985,19 @@ export class StreamableHttpTransport implements Transport {
    * Generate HTML documentation page
    */
   private generateDocumentationPage(tools: McpTool[], mcpEndpoint: string): string {
-    const serverName = this.serverConfig?.name || 'NitroStack MCP Server';
-    const serverVersion = this.serverConfig?.version || '1.0.0';
-    const serverDescription = this.serverConfig?.description || 'A powerful MCP server built with NitroStack';
+    const serverName = this.escapeHtml(
+      this.serverConfig?.name || 'NitroStack MCP Server'
+    );
+
+    const serverVersion = this.escapeHtml(
+      this.serverConfig?.version || '1.0.0'
+    );
+
+    const serverDescription = this.escapeHtml(
+      this.serverConfig?.description || 'A powerful MCP server built with NitroStack'
+    );
+
+    const safeMcpEndpoint = this.escapeHtml(mcpEndpoint);
 
     return `<!DOCTYPE html>
 <html lang="en">
@@ -1394,7 +1404,7 @@ export class StreamableHttpTransport implements Transport {
         <h2>🔌 Connection Information</h2>
         <div class="connection-info">
           <p>MCP Endpoint</p>
-          <code>${mcpEndpoint}</code>
+          <code>${safeMcpEndpoint}</code>
           <p class="description">
             Connect to this MCP server using the endpoint above. The server supports Server-Sent Events (SSE) for real-time bidirectional communication following the Model Context Protocol specification.
           </p>


### PR DESCRIPTION
## Description

<!-- Explain what this PR changes and why -->

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Internal code change
- [ ] test: Test-only changes
- [ ] chore: Build, CI, or tooling changes

## Related Issues
Closes #12 

## Changes Made

- Escaped `serverName`, `serverVersion`, `serverDescription`, and `mcpEndpoint` using the existing escapeHtml helper.
- Added test coverage to verify that server metadata containing HTML special characters is rendered as text rather than interpreted as markup.


## Testing

- [x] `npm test`


## Screenshots / Recordings
- Executed the test coverage that checks `generateDocumentationPage()` method, The changes passes the test suite

<img width="973" height="322" alt="image" src="https://github.com/user-attachments/assets/31aa94c4-334c-4593-b04b-e948a623ea98" />


<!-- Add screenshots or GIFs for UI/UX changes -->

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [x] I have added/updated tests where appropriate
- [ ] I have updated docs where appropriate
- [x] I have kept this PR focused and scoped
- [x] I have used conventional commits
