### PR TITLE
feat(core): support JWKS JWT validation, fix DI server lookup, and respect decorator transport settings

### DIFF
--- a/typescript/packages/core/src/core/app-decorator.ts
+++ b/typescript/packages/core/src/core/app-decorator.ts
@@ -269,6 +269,11 @@ export class McpApplicationFactory {
     // Register the server itself in DI so dynamic modules can inject it
     // Use string token since NitroStackServer has specific constructor signature
     container.registerValue('NitroStackServer', server);
+    // ALSO register under the class constructor token so design:paramtypes resolution works.
+    // OAuthModule injects NitroStackServer via design:paramtypes (no @Inject decorator),
+    // so the DI container looks it up by class reference, not the string token.
+    container.registerValue(NitroStackServer, server);
+
 
     // Now register and add dynamic modules (from forRoot() calls) to server
     for (const dynamicModule of dynamicModulesToAdd) {

--- a/typescript/packages/core/src/core/oauth-module.ts
+++ b/typescript/packages/core/src/core/oauth-module.ts
@@ -71,6 +71,12 @@ export interface OAuthModuleConfig {
   issuer?: string;
 
   /**
+   * JWKS URI for cryptographic signature verification
+   * Required for offline verification of JWT access tokens
+   */
+  jwksUri?: string;
+
+  /**
    * Custom token validation
    * Additional validation logic beyond spec requirements
    */
@@ -320,9 +326,19 @@ export class OAuthModule {
       throw new Error('OAuthModule: at least one authorizationServer is required');
     }
 
-    // Set default audience to resourceUri if not provided
+    // Set default jwksUri from environment if not explicitly provided
+    if (!config.jwksUri && process.env.JWKS_URI) {
+      config.jwksUri = process.env.JWKS_URI;
+    }
+
+    // Set default audience from environment or fallback to resourceUri
     if (!config.audience) {
-      config.audience = config.resourceUri;
+      config.audience = process.env.TOKEN_AUDIENCE || config.resourceUri;
+    }
+
+    // Set default issuer from environment if not explicitly provided
+    if (!config.issuer && process.env.TOKEN_ISSUER) {
+      config.issuer = process.env.TOKEN_ISSUER;
     }
 
     this.config = config;
@@ -380,6 +396,31 @@ export class OAuthModule {
       // If introspection endpoint is configured, use it
       if (this.config.tokenIntrospectionEndpoint) {
         return await this.introspectToken(token);
+      }
+
+      // If JWKS URI is configured, validate signature cryptographically
+      if (this.config.jwksUri) {
+        try {
+          const { jwtVerify, createRemoteJWKSet } = await import('jose');
+          const jwks = createRemoteJWKSet(new URL(this.config.jwksUri));
+          const { payload } = await jwtVerify(token, jwks, {
+            issuer: this.config.issuer,
+            audience: this.config.audience || this.config.resourceUri,
+            clockTolerance: 30,
+          });
+
+          // Custom validation
+          if (this.config.customValidation) {
+            const customValid = await this.config.customValidation(payload);
+            if (!customValid) {
+              return { valid: false, error: 'Custom validation failed' };
+            }
+          }
+
+          return { valid: true, payload: payload as Record<string, unknown> };
+        } catch (jwksError: any) {
+          return { valid: false, error: `JWT signature verification failed: ${jwksError.message}` };
+        }
       }
 
       // For JWT tokens without introspection, decode and validate
@@ -521,5 +562,3 @@ export class OAuthModule {
     }
   }
 }
-
-

--- a/typescript/packages/core/src/core/prompt.ts
+++ b/typescript/packages/core/src/core/prompt.ts
@@ -59,7 +59,8 @@ export class Prompt {
     context.logger.info(`Executing prompt: ${this.name}`, { args: args as unknown as JsonObject });
 
     try {
-      const messages = await this.definition.handler(args, context);
+      const messagesResult = await this.definition.handler(args, context);
+      const messages = Array.isArray(messagesResult) ? messagesResult : [messagesResult];
       
       context.logger.info(`Prompt executed successfully: ${this.name}`, {
         messageCount: messages.length,

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -1042,8 +1042,8 @@ export class NitroStackServer {
     const nodeEnv = process.env.NODE_ENV?.toLowerCase();
     const isDevelopment = nodeEnv === 'development' || nodeEnv === 'dev' || !nodeEnv;
 
-    // Use explicit transport if set, otherwise infer from NODE_ENV
-    const transportType = explicitTransport || (isDevelopment ? 'stdio' : 'dual');
+    // Use explicit transport if set, respect decorator setting, otherwise infer from NODE_ENV
+    const transportType = explicitTransport || this._transportType || (isDevelopment ? 'stdio' : 'dual');
     this._transportType = transportType;
     this.logger.debug(`NitroStackServer.start(): NODE_ENV=${process.env.NODE_ENV}, MCP_TRANSPORT_TYPE=${explicitTransport}, transportType=${transportType}`);
 


### PR DESCRIPTION
## Summary
This PR introduces offline cryptographic JWT validation in the `OAuthModule`, fixes Dependency Injection (DI) lookup for class-based injection of `NitroStackServer`, and ensures decorator-defined transport configurations are respected.

## Key Changes

### 🔐 OAuth & JWT Validation (`oauth-module.ts`)
* **JWKS Support**: Added `jwksUri` to `OAuthModuleConfig` to support offline cryptographic signature verification of JWT access tokens using JSON Web Key Sets (JWKS) via the `jose` package.
* **Env Fallbacks**: Added support to auto-detect OAuth configurations from environment variables if not explicitly provided:
  * `jwksUri` fallbacks to `process.env.JWKS_URI`
  * `issuer` fallbacks to `process.env.TOKEN_ISSUER`
  * `audience` fallbacks to `process.env.TOKEN_AUDIENCE` (then falls back to `config.resourceUri`)
* **Offline Verification**: Integrates `jose` to dynamically verify token signatures with a clock tolerance of 30 seconds.

### 💉 Dependency Injection Fix (`app-decorator.ts`)
* **Constructor Injection Resolution**: Registered `NitroStackServer` in the DI container using its class constructor token (in addition to the existing string token `'NitroStackServer'`). 
* **Why**: This enables modules that inject `NitroStackServer` using TypeScript's `design:paramtypes` (constructor-based parameter type references without `@Inject` decorators) to successfully resolve the dependency.

### 🌐 Transport Settings (`server.ts`)
* **Decorator Configuration Preservation**: Updated `NitroStackServer.start()` to respect `this._transportType` (set by decorators like `@McpApplication`).
* **Why**: Previously, decorator-configured transport modes could be ignored and overridden by environment defaults during startup.
