### PR TITLE
feat(core): enforce OAuth middleware on HTTP/dual transport and fix Express route and transport initialization order

### DIFF
--- a/typescript/packages/core/src/core/oauth-module.ts
+++ b/typescript/packages/core/src/core/oauth-module.ts
@@ -127,6 +127,7 @@ import { Injectable, Inject } from './di/injectable.decorator.js';
 import { NitroStackServer } from './server.js';
 import { Logger } from './types.js';
 import { DiscoveryHttpServer, DiscoveryServerOptions } from './transports/discovery-http-server.js';
+import { createAuthMiddleware } from '../auth/middleware.js';
 
 /**
  * OAuth discovery info that can be communicated to clients
@@ -238,6 +239,25 @@ export class OAuthModule {
       const httpTransport = (this.server as any)._httpTransport;
       if (httpTransport) {
         this.registerDiscoveryHandlers(httpTransport);
+        const app = (httpTransport as any).getApp?.();
+        if (app) {
+          const authMiddleware = createAuthMiddleware({
+            resourceUri: this.config.resourceUri,
+            authorizationServers: this.config.authorizationServers,
+            scopesSupported: this.config.scopesSupported,
+            tokenIntrospectionEndpoint: this.config.tokenIntrospectionEndpoint,
+            tokenIntrospectionClientId: this.config.tokenIntrospectionClientId,
+            tokenIntrospectionClientSecret: this.config.tokenIntrospectionClientSecret,
+            audience: this.config.audience,
+            issuer: this.config.issuer,
+            jwksUri: this.config.jwksUri,
+          });
+          const basePath = this.config.http?.basePath || '/mcp';
+          app.use(basePath, authMiddleware);
+          app.use(`${basePath}/*`, authMiddleware);
+          app.use('/sse', authMiddleware);
+          this.logger.info(`OAuthModule: Registered auth middleware on ${basePath}, ${basePath}/*, and /sse`);
+        }
         // In HTTP mode, use the configured port
         this.updateDiscoveryInfo(preferredPort);
       } else {

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -1055,19 +1055,19 @@ export class NitroStackServer {
       }
     }
 
-    // If HTTP transport is needed (dual mode), set it up BEFORE calling module.start()
+    // If HTTP transport is needed (dual or http mode), set it up BEFORE calling module.start()
     // This allows modules like OAuthModule to register endpoints on the HTTP server
-    if (transportType === 'dual') {
+    if (transportType === 'dual' || transportType === 'http') {
       const port = parseInt(process.env.PORT || '3000');
       const host = process.env.HOST || 'localhost';
 
-      // Create and start HTTP transport first
+      // Create HTTP transport first
       const { StreamableHttpTransport } = await import('./transports/streamable-http.js');
       const httpTransport = new StreamableHttpTransport({
         port: port,
         host: host,
         endpoint: '/mcp',
-        enableSessions: false, // Disable sessions for dual mode
+        enableSessions: transportType === 'http', // Enable sessions for http mode, disable for dual
         enableCors: process.env.ENABLE_CORS !== 'false',
       });
 
@@ -1084,10 +1084,6 @@ export class NitroStackServer {
         description: this.config.description,
       });
 
-      this.attachLegacySdkSseIfNeeded(httpTransport as HttpTransport);
-
-      await httpTransport.start();
-
       // Store HTTP transport reference BEFORE modules start
       // This allows OAuthModule to register discovery endpoints
       this._httpTransport = httpTransport as HttpTransport;
@@ -1100,6 +1096,13 @@ export class NitroStackServer {
       if (moduleInstance.start) {
         await moduleInstance.start();
       }
+    }
+
+    // Attach legacy SDK SSE routes and start the HTTP server AFTER modules have started.
+    // This ensures that any OAuth/auth middleware is registered before the actual route handlers.
+    if ((transportType === 'dual' || transportType === 'http') && this._httpTransport) {
+      this.attachLegacySdkSseIfNeeded(this._httpTransport);
+      await this._httpTransport.start();
     }
 
     // Now complete the transport setup using the determined transportType

--- a/typescript/packages/core/src/core/transports/streamable-http.ts
+++ b/typescript/packages/core/src/core/transports/streamable-http.ts
@@ -98,6 +98,7 @@ export class StreamableHttpTransport implements Transport {
   private getToolsCallback?: () => Promise<McpTool[]>;
   private serverConfig?: { name: string; version: string; description?: string };
   private logoBase64?: string;
+  private _routesRegistered = false;
 
   constructor(options: StreamableHttpTransportOptions = {}) {
     this.options = {
@@ -122,7 +123,9 @@ export class StreamableHttpTransport implements Transport {
     this.loadLogo();
 
     this.setupMiddleware();
-    this.setupRoutes();
+    // Routes are NOT registered here — they are registered in start() so that
+    // auth middleware (e.g. OAuthModule) can be added via app.use() BEFORE
+    // route handlers are registered, ensuring correct Express middleware order.
     this.startSessionCleanup();
   }
 
@@ -782,8 +785,20 @@ export class StreamableHttpTransport implements Transport {
    * Start the HTTP server
    */
   async start(): Promise<void> {
+    // Idempotent: if already listening (e.g. MCP SDK calls start() again via
+    // Server.connect()), skip — the server is already up with routes and
+    // middleware in the correct order.
     if (this.server) {
-      await this.close();
+      return;
+    }
+
+    // Register route handlers here (after any external middleware like OAuthModule
+    // has been added via app.use()) to ensure correct Express execution order.
+    // Guard against double registration when MCP SDK calls transport.start() again
+    // via Server.connect().
+    if (!this._routesRegistered) {
+      this.setupRoutes();
+      this._routesRegistered = true;
     }
 
     return new Promise((resolve, reject) => {
@@ -853,6 +868,7 @@ export class StreamableHttpTransport implements Transport {
 
     // Close HTTP server
     if (this.server) {
+      this._routesRegistered = false; // Allow re-registration on next start()
       return new Promise((resolve) => {
         const server = this.server!;
         this.server = null;


### PR DESCRIPTION
## Description

This PR fixes a critical security vulnerability where OAuth 2.1 authentication middleware
was being registered **after** Express route handlers, allowing clients to completely bypass
token validation on HTTP and Dual transport modes.

It also extends the HTTP transport initialization to correctly cover `http` mode (not just
`dual` mode), preventing `OAuthModule` from spinning up a redundant fallback Discovery
server on a separate port.

Finally, it fixes a root-cause issue in `StreamableHttpTransport` where route handlers were
registered in the constructor rather than in `start()`, meaning any middleware added via
`app.use()` after construction (e.g. by `OAuthModule.start()`) would be inserted **after**
the route handlers in Express's middleware stack and therefore silently skipped. The
`start()` method is now also made idempotent to prevent a double-start triggered by the MCP
SDK calling `transport.start()` internally via `Server.connect()`.

## Type of Change

- feat: New feature
- fix: Bug fix

## Related Issues

## Changes Made

**`src/core/oauth-module.ts`**

- Imports `createAuthMiddleware` from the auth layer
- In `http` and `dual` transport modes, retrieves the Express app from the HTTP transport
  and registers the auth middleware on `/mcp`, `/mcp/*`, and `/sse` routes during
  `OAuthModule.start()`, before the HTTP server begins accepting connections

**`src/core/server.ts`**

- Extended the early HTTP transport initialization block from `dual`-only to cover
  `http` mode as well, so `OAuthModule.start()` always has access to `_httpTransport`
- Moved `attachLegacySdkSseIfNeeded()` and `httpTransport.start()` to run **after**
  all `module.start()` calls complete, ensuring auth middleware is registered in
  Express before any route handlers are attached
- Correctly sets `enableSessions: transportType === 'http'` so session tracking is
  only active in pure HTTP mode

**`src/core/transports/streamable-http.ts`**

- Moved `this.setupRoutes()` out of the constructor and into `start()`, so Express route
  handlers are only registered after external middleware (e.g. `OAuthModule`) has had a
  chance to call `app.use()` — fixing the actual root cause of the middleware bypass
- Added a `_routesRegistered` boolean guard to prevent duplicate route registration if
  `start()` is called more than once (e.g. via `Server.connect()` in the MCP SDK)
- Made `start()` idempotent: if the HTTP server is already listening, the method returns
  early instead of closing and restarting, eliminating the double-start that was logged
  on every boot
- Resets `_routesRegistered` in `close()` so a cleanly stopped transport can be
  restarted correctly

## Testing

- `npm run lint`
- `npm test`
- Manual testing performed (if applicable)

Tested end-to-end with a third-party-issued JWT access token against the `/mcp` and `/sse`
endpoints in `http` and `dual` transport modes:

- Requests without a Bearer token receive `401 Unauthorized` with a `WWW-Authenticate` header
- Requests with an invalid JWT receive `401 Unauthorized` with `invalid_token` error
- Requests with a valid JWKS-verified token proceed normally to tool execution
- `OAuthModule` no longer starts a secondary Discovery server when running in `http` mode
- HTTP transport starts exactly once per boot (no duplicate "listening" log lines)

## Screenshots / Recordings

N/A

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [x] I have added/updated tests where appropriate
- [x] I have updated docs where appropriate
- [x] I have kept this PR focused and scoped
- [x] I have used conventional commits