### PR TITLE
chore(cli): refresh stale header comment in branding.ts

### DIFF
--- a/typescript/packages/cli/src/ui/branding.ts
+++ b/typescript/packages/cli/src/ui/branding.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import ora, { Ora } from 'ora';
 
 // ═══════════════════════════════════════════════════════════════════════════
-// OFFICIAL MCP BRANDING (Wekan Enterprise Solutions)
+// OFFICIAL MCP BRANDING (NitroStack CLI)
 // ═══════════════════════════════════════════════════════════════════════════
 
 // Core Colors


### PR DESCRIPTION
## Summary
- Header comment in `typescript/packages/cli/src/ui/branding.ts` referenced an unrelated org name ("Wekan Enterprise Solutions") instead of NitroStack

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `grep -rn "Wekan" typescript/packages/cli/` returns nothing

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)