### PR TITLE
fix(cli): align generate types UX with other generate flows

### DIFF
--- a/typescript/packages/cli/src/commands/generate-types.ts
+++ b/typescript/packages/cli/src/commands/generate-types.ts
@@ -5,8 +5,10 @@ import {
   createHeader,
   createSuccessBox,
   NitroSpinner,
-  spacer
+  spacer,
+  showFooter
 } from '../ui/branding.js';
+import { trackEvent, shutdownAnalytics } from '../analytics/posthog.js';
 
 /**
  * Generates TypeScript types from tool definitions
@@ -24,6 +26,8 @@ export async function generateTypes(options: { output?: string; } = {}) {
 
   if (toolFiles.length === 0) {
     spinner.fail('No tool files found');
+    trackEvent('cli_generate_failed', { component_type: 'types', error: 'No tool files found' });
+    await shutdownAnalytics();
     return;
   }
 
@@ -47,6 +51,11 @@ export async function generateTypes(options: { output?: string; } = {}) {
     `Location: ${path.relative(projectRoot, outputPath)}`,
     `Count:    ${toolFiles.length} tools processed`
   ]));
+
+  showFooter();
+
+  trackEvent('cli_generate_completed', { component_type: 'types', files_processed: toolFiles.length });
+  await shutdownAnalytics();
 }
 
 async function findToolFiles(dir: string): Promise<string[]> {


### PR DESCRIPTION
## Summary
- `generate types` skipped `showFooter()` and analytics tracking (`trackEvent`/`shutdownAnalytics`) that every other `generate` path already does on success/failure
- Banner was already shared correctly via `generate()` dispatch — gap was purely the footer/tracking at the end of `generate-types.ts`

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] Ran `generate types` with no `*.tools.ts` files — fails gracefully, no footer (matches other failure paths)
- [x] Ran `generate types` with a sample `*.tools.ts` file — success path now ends with the footer block matching other generate commands

Fixes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)