### PR TITLE
Restore branch state to 8137eca

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 .DS_Store
 pizza-1
 inspector
-nitrostack-skills
-content-wireframes

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nitrostack/core",
-  "version": "1.0.10",
+  "version": "1.0.8",
   "description": "NitroStack Core - Build powerful MCP servers with TypeScript",
   "type": "module",
   "main": "dist/core/index.js",

--- a/typescript/packages/core/src/core/app-decorator.ts
+++ b/typescript/packages/core/src/core/app-decorator.ts
@@ -269,11 +269,6 @@ export class McpApplicationFactory {
     // Register the server itself in DI so dynamic modules can inject it
     // Use string token since NitroStackServer has specific constructor signature
     container.registerValue('NitroStackServer', server);
-    // ALSO register under the class constructor token so design:paramtypes resolution works.
-    // OAuthModule injects NitroStackServer via design:paramtypes (no @Inject decorator),
-    // so the DI container looks it up by class reference, not the string token.
-    container.registerValue(NitroStackServer, server);
-
 
     // Now register and add dynamic modules (from forRoot() calls) to server
     for (const dynamicModule of dynamicModulesToAdd) {
@@ -394,9 +389,7 @@ export class McpApplicationFactory {
     }
 
     // Auto-detect transport type based on configuration
-    // Default is undefined — when no explicit transport or OAuth is configured, we leave
-    // _transportType unset so server.ts can apply its own default (dual mode).
-    let transportType: 'stdio' | 'http' | 'dual' | undefined = undefined;
+    let transportType: 'stdio' | 'http' | 'dual' = 'stdio';
     let transportOptions: TransportOptions | undefined = undefined;
     
     // Check explicit transport configuration
@@ -451,15 +444,11 @@ export class McpApplicationFactory {
     }
     
     // Store transport configuration on server for later use
-    // Only write _transportType when it was explicitly/derivatively set (OAuth or user config).
-    // If undefined, server.ts will fall back to its own default (dual mode).
     const serverInternal = server as unknown as { 
-      _transportType: 'stdio' | 'http' | 'dual' | undefined;
+      _transportType: 'stdio' | 'http' | 'dual';
       _transportOptions: TransportOptions | undefined;
     };
-    if (transportType !== undefined) {
-      serverInternal._transportType = transportType;
-    }
+    serverInternal._transportType = transportType;
     serverInternal._transportOptions = transportOptions;
 
     return server;

--- a/typescript/packages/core/src/core/oauth-module.ts
+++ b/typescript/packages/core/src/core/oauth-module.ts
@@ -71,12 +71,6 @@ export interface OAuthModuleConfig {
   issuer?: string;
 
   /**
-   * JWKS URI for cryptographic signature verification
-   * Required for offline verification of JWT access tokens
-   */
-  jwksUri?: string;
-
-  /**
    * Custom token validation
    * Additional validation logic beyond spec requirements
    */
@@ -326,19 +320,9 @@ export class OAuthModule {
       throw new Error('OAuthModule: at least one authorizationServer is required');
     }
 
-    // Set default jwksUri from environment if not explicitly provided
-    if (!config.jwksUri && process.env.JWKS_URI) {
-      config.jwksUri = process.env.JWKS_URI;
-    }
-
-    // Set default audience from environment or fallback to resourceUri
+    // Set default audience to resourceUri if not provided
     if (!config.audience) {
-      config.audience = process.env.TOKEN_AUDIENCE || config.resourceUri;
-    }
-
-    // Set default issuer from environment if not explicitly provided
-    if (!config.issuer && process.env.TOKEN_ISSUER) {
-      config.issuer = process.env.TOKEN_ISSUER;
+      config.audience = config.resourceUri;
     }
 
     this.config = config;
@@ -396,31 +380,6 @@ export class OAuthModule {
       // If introspection endpoint is configured, use it
       if (this.config.tokenIntrospectionEndpoint) {
         return await this.introspectToken(token);
-      }
-
-      // If JWKS URI is configured, validate signature cryptographically
-      if (this.config.jwksUri) {
-        try {
-          const { jwtVerify, createRemoteJWKSet } = await import('jose');
-          const jwks = createRemoteJWKSet(new URL(this.config.jwksUri));
-          const { payload } = await jwtVerify(token, jwks, {
-            issuer: this.config.issuer,
-            audience: this.config.audience || this.config.resourceUri,
-            clockTolerance: 30,
-          });
-
-          // Custom validation
-          if (this.config.customValidation) {
-            const customValid = await this.config.customValidation(payload);
-            if (!customValid) {
-              return { valid: false, error: 'Custom validation failed' };
-            }
-          }
-
-          return { valid: true, payload: payload as Record<string, unknown> };
-        } catch (jwksError: any) {
-          return { valid: false, error: `JWT signature verification failed: ${jwksError.message}` };
-        }
       }
 
       // For JWT tokens without introspection, decode and validate
@@ -562,3 +521,5 @@ export class OAuthModule {
     }
   }
 }
+
+

--- a/typescript/packages/core/src/core/prompt.ts
+++ b/typescript/packages/core/src/core/prompt.ts
@@ -59,8 +59,7 @@ export class Prompt {
     context.logger.info(`Executing prompt: ${this.name}`, { args: args as unknown as JsonObject });
 
     try {
-      const messagesResult = await this.definition.handler(args, context);
-      const messages = Array.isArray(messagesResult) ? messagesResult : [messagesResult];
+      const messages = await this.definition.handler(args, context);
       
       context.logger.info(`Prompt executed successfully: ${this.name}`, {
         messageCount: messages.length,

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -1042,8 +1042,8 @@ export class NitroStackServer {
     const nodeEnv = process.env.NODE_ENV?.toLowerCase();
     const isDevelopment = nodeEnv === 'development' || nodeEnv === 'dev' || !nodeEnv;
 
-    // Use explicit transport if set, respect decorator setting, otherwise default to dual mode
-    const transportType = explicitTransport || this._transportType || 'dual';
+    // Use explicit transport if set, otherwise infer from NODE_ENV
+    const transportType = explicitTransport || (isDevelopment ? 'stdio' : 'dual');
     this._transportType = transportType;
     this.logger.debug(`NitroStackServer.start(): NODE_ENV=${process.env.NODE_ENV}, MCP_TRANSPORT_TYPE=${explicitTransport}, transportType=${transportType}`);
 


### PR DESCRIPTION
## Description

Restores the branch state back to commit `8137eca` by reverting changes related to transport configuration, Prompt message return types, DI container registration of `NitroStackServer`, and remote JWKS validation in the `OAuthModule`.

## Type of Change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [x] refactor: Internal code change
- [ ] test: Test-only changes
- [x] chore: Build, CI, or tooling changes

## Related Issues

<!-- Use closing keywords when appropriate, e.g. Closes #123 -->

## Changes Made

- Reverted `@nitrostack/core` package version from `1.0.10` to `1.0.8`.
- Removed `NitroStackServer` class constructor registration from DI container in `app-decorator.ts`.
- Restored default transport type to `stdio` in `app-decorator.ts` and inferred transport type based on `NODE_ENV` in `server.ts`.
- Removed JWKS signature verification support (`jwksUri`, token audience, issuer environment variables config, and remote JWK set verification using `jose`) from `OAuthModule`.
- Reverted Prompt handler logic to expect an array of messages directly instead of wrapping single objects.
- Updated `.gitignore` to remove temporary directories (`pizza-1`, `nitrostack-skills`, and `content-wireframes`).

## Testing

- [ ] `npm run lint`
- [x] `npm test`
- [ ] Manual testing performed (if applicable)

## Screenshots / Recordings

<!-- Add screenshots or GIFs for UI/UX changes -->

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [ ] I have added/updated tests where appropriate
- [ ] I have updated docs where appropriate
- [x] I have kept this PR focused and scoped
- [x] I have used conventional commits
