### PR TITLE
feat(core,cli): lifecycle hooks, @Controller decorator, and agent-skills installer with auto-upgrade

### DIFF
--- a/typescript/NOTICE
+++ b/typescript/NOTICE
@@ -41,10 +41,6 @@ jose
 Copyright (c) 2020 Filip Skokan
 Licensed under the MIT License
 
-better-sqlite3
-Copyright (c) 2016 Joshua Wise
-Licensed under the MIT License
-
 bcryptjs
 Copyright (c) 2012 Nevins Bartolomeo
 Licensed under the MIT License

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -29,7 +29,6 @@
   "dependencies": {},
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
-    "@types/better-sqlite3": "^7.6.12",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",

--- a/typescript/packages/cli/NOTICE
+++ b/typescript/packages/cli/NOTICE
@@ -41,10 +41,6 @@ jose
 Copyright (c) 2020 Filip Skokan
 Licensed under the MIT License
 
-better-sqlite3
-Copyright (c) 2016 Joshua Wise
-Licensed under the MIT License
-
 bcryptjs
 Copyright (c) 2012 Nevins Bartolomeo
 Licensed under the MIT License

--- a/typescript/packages/cli/src/__tests__/skills.test.ts
+++ b/typescript/packages/cli/src/__tests__/skills.test.ts
@@ -1,0 +1,284 @@
+import path from 'path';
+import os from 'os';
+import fs from 'fs-extra';
+import { discoverSkills } from '../skills/discover.js';
+import { AGENTS, detectAgents } from '../skills/detect-agents.js';
+import { installSkillsForAgent } from '../skills/installer.js';
+import type { AgentDescriptor, Skill } from '../skills/types.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Creates a temporary directory tree and returns its root path. */
+async function makeTempDir(
+  structure: Record<string, string | null>,
+): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'nitro-skills-test-'));
+  for (const [rel, content] of Object.entries(structure)) {
+    const abs = path.join(root, rel);
+    if (content === null) {
+      await fs.mkdirp(abs);
+    } else {
+      await fs.mkdirp(path.dirname(abs));
+      await fs.writeFile(abs, content, 'utf-8');
+    }
+  }
+  return root;
+}
+
+// ── discoverSkills ───────────────────────────────────────────────────────────
+
+describe('discoverSkills', () => {
+  it('returns a Skill for every non-hidden subdirectory of skills/', async () => {
+    const cloneDir = await makeTempDir({
+      'skills/nitrostack-sdk': null,
+      'skills/mcp-best-practices': null,
+      'skills/oauth-guide': null,
+      'src/index.ts': 'export {}',
+      'README.md': '# hello',
+    });
+
+    try {
+      const skills = await discoverSkills(cloneDir);
+      const names = skills.map((s) => s.name);
+      expect(names).toHaveLength(3);
+      expect(names).toContain('nitrostack-sdk');
+      expect(names).toContain('mcp-best-practices');
+      expect(names).toContain('oauth-guide');
+    } finally {
+      await fs.remove(cloneDir);
+    }
+  });
+
+  it('ignores hidden entries inside skills/', async () => {
+    const cloneDir = await makeTempDir({
+      'skills/real-skill': null,
+      'skills/.hidden': null,
+      'skills/.DS_Store': 'binary',
+    });
+
+    try {
+      const skills = await discoverSkills(cloneDir);
+      expect(skills.map((s) => s.name)).toEqual(['real-skill']);
+    } finally {
+      await fs.remove(cloneDir);
+    }
+  });
+
+  it('ignores plain files inside skills/', async () => {
+    const cloneDir = await makeTempDir({
+      'skills/real-skill': null,
+      'skills/README.md': '# ignored',
+    });
+
+    try {
+      const skills = await discoverSkills(cloneDir);
+      expect(skills.map((s) => s.name)).toEqual(['real-skill']);
+    } finally {
+      await fs.remove(cloneDir);
+    }
+  });
+
+  it('returns an empty array when the skills/ directory does not exist', async () => {
+    const cloneDir = await makeTempDir({ 'README.md': '# empty' });
+
+    try {
+      const skills = await discoverSkills(cloneDir);
+      expect(skills).toHaveLength(0);
+    } finally {
+      await fs.remove(cloneDir);
+    }
+  });
+
+  it('returns skills sorted alphabetically', async () => {
+    const cloneDir = await makeTempDir({
+      'skills/zebra': null,
+      'skills/alpha': null,
+      'skills/mango': null,
+    });
+
+    try {
+      const skills = await discoverSkills(cloneDir);
+      expect(skills.map((s) => s.name)).toEqual(['alpha', 'mango', 'zebra']);
+    } finally {
+      await fs.remove(cloneDir);
+    }
+  });
+
+  it('populates sourcePath correctly', async () => {
+    const cloneDir = await makeTempDir({ 'skills/my-skill': null });
+
+    try {
+      const [skill] = await discoverSkills(cloneDir);
+      expect(skill.sourcePath).toBe(path.join(cloneDir, 'skills', 'my-skill'));
+    } finally {
+      await fs.remove(cloneDir);
+    }
+  });
+});
+
+// ── detectAgents ─────────────────────────────────────────────────────────────
+
+describe('detectAgents', () => {
+  it('returns only agents whose detect() resolves to true', async () => {
+    // Temporarily override detect() for all agents in the registry
+    const originals = AGENTS.map((a) => a.detect.bind(a));
+
+    AGENTS[0].detect = async () => true;   // cursor  → present
+    AGENTS[1].detect = async () => false;  // codex   → absent
+    AGENTS[2].detect = async () => true;   // claude  → present
+    AGENTS[3].detect = async () => false;  // gemini  → absent
+    AGENTS[4].detect = async () => false;  // antigravity → absent
+
+    try {
+      const detected = await detectAgents();
+      const ids = detected.map((a) => a.id);
+      expect(ids).toContain('cursor');
+      expect(ids).toContain('claude-code');
+      expect(ids).not.toContain('codex');
+      expect(ids).not.toContain('gemini-cli');
+      expect(ids).not.toContain('antigravity');
+    } finally {
+      // Restore original detect() functions
+      AGENTS.forEach((a, i) => { a.detect = originals[i]; });
+    }
+  });
+
+  it('handles a detect() that throws without crashing', async () => {
+    const orig = AGENTS[0].detect.bind(AGENTS[0]);
+    AGENTS[0].detect = async () => { throw new Error('boom'); };
+
+    try {
+      // Should not throw; the agent is simply excluded
+      const detected = await detectAgents();
+      expect(detected.map((a) => a.id)).not.toContain(AGENTS[0].id);
+    } finally {
+      AGENTS[0].detect = orig;
+    }
+  });
+});
+
+// ── installSkillsForAgent ─────────────────────────────────────────────────────
+
+describe('installSkillsForAgent', () => {
+  /** Build a minimal agent descriptor pointing to a temp directory. */
+  function makeAgent(skillsDir: string): AgentDescriptor {
+    return {
+      id: 'test-agent',
+      name: 'Test Agent',
+      displayPath: skillsDir,
+      async detect() { return true; },
+      getSkillsDir() { return skillsDir; },
+    };
+  }
+
+  /** Build a set of Skill objects from a list of temp source directories. */
+  function makeSkills(sources: Record<string, string>): Skill[] {
+    return Object.entries(sources).map(([name, sourcePath]) => ({ name, sourcePath }));
+  }
+
+  it('copies skills into the agent skills directory', async () => {
+    const srcRoot = await makeTempDir({
+      'skill-a/SKILL.md': '# A',
+      'skill-b/SKILL.md': '# B',
+    });
+    const destRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'nitro-dest-'));
+
+    try {
+      const skills = makeSkills({
+        'skill-a': path.join(srcRoot, 'skill-a'),
+        'skill-b': path.join(srcRoot, 'skill-b'),
+      });
+
+      const agent = makeAgent(destRoot);
+      const result = await installSkillsForAgent(agent, skills, false);
+
+      expect(result.installed).toContain('skill-a');
+      expect(result.installed).toContain('skill-b');
+      expect(result.skipped).toHaveLength(0);
+      expect(result.error).toBeUndefined();
+
+      expect(await fs.pathExists(path.join(destRoot, 'skill-a', 'SKILL.md'))).toBe(true);
+      expect(await fs.pathExists(path.join(destRoot, 'skill-b', 'SKILL.md'))).toBe(true);
+    } finally {
+      await fs.remove(srcRoot);
+      await fs.remove(destRoot);
+    }
+  });
+
+  it('skips an existing skill when force is false', async () => {
+    const srcRoot = await makeTempDir({ 'skill-a/SKILL.md': '# new' });
+    const destRoot = await makeTempDir({ 'skill-a/SKILL.md': '# existing' });
+
+    try {
+      const skills = makeSkills({ 'skill-a': path.join(srcRoot, 'skill-a') });
+      const agent = makeAgent(destRoot);
+
+      const result = await installSkillsForAgent(agent, skills, false);
+
+      expect(result.skipped).toContain('skill-a');
+      expect(result.installed).toHaveLength(0);
+
+      // Original file should be untouched
+      const content = await fs.readFile(path.join(destRoot, 'skill-a', 'SKILL.md'), 'utf-8');
+      expect(content).toBe('# existing');
+    } finally {
+      await fs.remove(srcRoot);
+      await fs.remove(destRoot);
+    }
+  });
+
+  it('overwrites an existing skill when force is true', async () => {
+    const srcRoot = await makeTempDir({ 'skill-a/SKILL.md': '# new' });
+    const destRoot = await makeTempDir({ 'skill-a/SKILL.md': '# existing' });
+
+    try {
+      const skills = makeSkills({ 'skill-a': path.join(srcRoot, 'skill-a') });
+      const agent = makeAgent(destRoot);
+
+      const result = await installSkillsForAgent(agent, skills, true);
+
+      expect(result.installed).toContain('skill-a');
+      expect(result.skipped).toHaveLength(0);
+
+      const content = await fs.readFile(path.join(destRoot, 'skill-a', 'SKILL.md'), 'utf-8');
+      expect(content).toBe('# new');
+    } finally {
+      await fs.remove(srcRoot);
+      await fs.remove(destRoot);
+    }
+  });
+
+  it('creates the skills directory when it does not exist', async () => {
+    const srcRoot = await makeTempDir({ 'skill-x/SKILL.md': '# x' });
+    const destRoot = path.join(os.tmpdir(), `nitro-new-${Date.now()}`);
+
+    try {
+      const skills = makeSkills({ 'skill-x': path.join(srcRoot, 'skill-x') });
+      const agent = makeAgent(destRoot);
+
+      const result = await installSkillsForAgent(agent, skills, false);
+
+      expect(result.installed).toContain('skill-x');
+      expect(await fs.pathExists(path.join(destRoot, 'skill-x', 'SKILL.md'))).toBe(true);
+    } finally {
+      await fs.remove(srcRoot);
+      await fs.remove(destRoot);
+    }
+  });
+
+  it('reports an error without throwing when the source path is invalid', async () => {
+    const destRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'nitro-dest-'));
+
+    try {
+      const skills: Skill[] = [{ name: 'ghost', sourcePath: '/nonexistent/path/ghost' }];
+      const agent = makeAgent(destRoot);
+
+      const result = await installSkillsForAgent(agent, skills, false);
+
+      expect(result.error).toBeDefined();
+      expect(result.installed).toHaveLength(0);
+    } finally {
+      await fs.remove(destRoot);
+    }
+  });
+});

--- a/typescript/packages/cli/src/__tests__/upgrade.test.ts
+++ b/typescript/packages/cli/src/__tests__/upgrade.test.ts
@@ -1,7 +1,46 @@
-import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { isLocalDependency, compareVersions } from '../commands/upgrade.js';
+import { jest, describe, it, expect, beforeEach, afterEach, beforeAll } from '@jest/globals';
+import path from 'path';
+import os from 'os';
+import fs from 'fs-extra';
+
+// Mock https.get
+const mockHttpsGet = jest.fn<any>();
+jest.unstable_mockModule('https', () => ({
+  default: {
+    get: mockHttpsGet
+  },
+  get: mockHttpsGet
+}));
+
+// Mock the skills modules using unstable_mockModule before importing upgrade.js
+const mockCloneSkillsRepo = jest.fn<() => Promise<string>>();
+const mockDiscoverSkills = jest.fn<(cloneDir: string) => Promise<any[]>>();
+const mockInstallSkills = jest.fn<(agents: any, skills: any, force: boolean, scope: string, projectDir: string) => Promise<any[]>>();
+
+jest.unstable_mockModule('../skills/clone.js', () => ({
+  cloneSkillsRepo: mockCloneSkillsRepo,
+  SkillsCloneError: class SkillsCloneError extends Error {}
+}));
+jest.unstable_mockModule('../skills/discover.js', () => ({
+  discoverSkills: mockDiscoverSkills,
+}));
+jest.unstable_mockModule('../skills/installer.js', () => ({
+  installSkills: mockInstallSkills,
+}));
+
+// We'll import these dynamically in beforeAll
+let isLocalDependency: any;
+let compareVersions: any;
+let upgradeCommand: any;
 
 describe('Upgrade Command', () => {
+  beforeAll(async () => {
+    const module = await import('../commands/upgrade.js');
+    isLocalDependency = module.isLocalDependency;
+    compareVersions = module.compareVersions;
+    upgradeCommand = module.upgradeCommand;
+  });
+
   beforeEach(() => {
     jest.spyOn(console, 'log').mockImplementation(() => {});
     jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -9,11 +48,11 @@ describe('Upgrade Command', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
 
-  it('should export upgradeCommand function', async () => {
-    const module = await import('../commands/upgrade.js');
-    expect(typeof module.upgradeCommand).toBe('function');
+  it('should export upgradeCommand function', () => {
+    expect(typeof upgradeCommand).toBe('function');
   });
 
   describe('isLocalDependency', () => {
@@ -56,4 +95,172 @@ describe('Upgrade Command', () => {
       expect(compareVersions('^1.0.0-beta.1', '1.1.0')).toBe(-1);
     });
   });
+
+  describe('upgradeCommand skills upgrading', () => {
+    let tempProjectDir: string;
+    let tempClonedSkillsDir: string;
+    let originalCwd: () => string;
+
+    beforeEach(async () => {
+      originalCwd = process.cwd;
+    });
+
+    afterEach(async () => {
+      process.cwd = originalCwd;
+      if (tempProjectDir) {
+        await fs.remove(tempProjectDir);
+      }
+      if (tempClonedSkillsDir) {
+        await fs.remove(tempClonedSkillsDir);
+      }
+    });
+
+    it('should upgrade agent skills when a newer version is available', async () => {
+      tempProjectDir = await makeTempDir({
+        'package.json': JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {
+            '@nitrostack/core': '^1.0.0'
+          },
+          nitrostack: {
+            skillsVersion: '0.9.0'
+          }
+        })
+      });
+
+      tempClonedSkillsDir = await makeTempDir({
+        'package.json': JSON.stringify({
+          name: '@nitrostack/skills',
+          version: '1.1.0'
+        }),
+        'skills/mock-skill/SKILL.md': '# Mock Skill'
+      });
+
+      process.cwd = () => tempProjectDir;
+
+      mockCloneSkillsRepo.mockResolvedValue(tempClonedSkillsDir);
+      mockDiscoverSkills.mockResolvedValue([{ name: 'mock-skill', sourcePath: path.join(tempClonedSkillsDir, 'skills', 'mock-skill') }]);
+      mockInstallSkills.mockImplementation(async (agents: any, skills: any, force: boolean, scope: string, projectDir: string) => {
+        // Simulate installation by copying files
+        for (const skill of skills) {
+          const dest = path.join(projectDir, '.agents', 'skills', skill.name);
+          await fs.copy(skill.sourcePath, dest);
+        }
+        return [];
+      });
+
+      // Mock https.get for @nitrostack/core NPM check
+      mockHttpsGet.mockImplementation((url: string, options: any, callback: any) => {
+        const cb = typeof options === 'function' ? options : callback;
+        const mockResponse: any = {
+          statusCode: 200,
+          on: (event: string, handler: Function) => {
+            if (event === 'data') {
+              handler(Buffer.from(JSON.stringify({ version: '1.0.0' }))); // same as package.json
+            }
+            if (event === 'end') {
+              handler();
+            }
+            return mockResponse;
+          }
+        };
+        if (cb) cb(mockResponse);
+        const mockRequest: any = {
+          on: () => mockRequest,
+          destroy: () => {}
+        };
+        return mockRequest;
+      });
+
+      await upgradeCommand({});
+
+      // Verify that skillsVersion was updated in package.json
+      const updatedPkg = fs.readJSONSync(path.join(tempProjectDir, 'package.json'));
+      expect(updatedPkg.nitrostack?.skillsVersion).toBe('1.1.0');
+
+      // Verify that the skill files were copied into agent directories
+      const skillPath = path.join(tempProjectDir, '.agents', 'skills', 'mock-skill', 'SKILL.md');
+      expect(fs.existsSync(skillPath)).toBe(true);
+      expect(fs.readFileSync(skillPath, 'utf-8')).toBe('# Mock Skill');
+    });
+
+    it('should NOT upgrade agent skills in dry-run mode', async () => {
+      tempProjectDir = await makeTempDir({
+        'package.json': JSON.stringify({
+          name: 'test-project',
+          version: '1.0.0',
+          dependencies: {
+            '@nitrostack/core': '^1.0.0'
+          },
+          nitrostack: {
+            skillsVersion: '0.9.0'
+          }
+        })
+      });
+
+      tempClonedSkillsDir = await makeTempDir({
+        'package.json': JSON.stringify({
+          name: '@nitrostack/skills',
+          version: '1.1.0'
+        }),
+        'skills/mock-skill/SKILL.md': '# Mock Skill'
+      });
+
+      process.cwd = () => tempProjectDir;
+
+      mockCloneSkillsRepo.mockResolvedValue(tempClonedSkillsDir);
+      mockDiscoverSkills.mockResolvedValue([{ name: 'mock-skill', sourcePath: path.join(tempClonedSkillsDir, 'skills', 'mock-skill') }]);
+      mockInstallSkills.mockResolvedValue([]);
+
+      mockHttpsGet.mockImplementation((url: string, options: any, callback: any) => {
+        const cb = typeof options === 'function' ? options : callback;
+        const mockResponse: any = {
+          statusCode: 200,
+          on: (event: string, handler: Function) => {
+            if (event === 'data') {
+              handler(Buffer.from(JSON.stringify({ version: '1.0.0' })));
+            }
+            if (event === 'end') {
+              handler();
+            }
+            return mockResponse;
+          }
+        };
+        if (cb) cb(mockResponse);
+        const mockRequest: any = {
+          on: () => mockRequest,
+          destroy: () => {}
+        };
+        return mockRequest;
+      });
+
+      await upgradeCommand({ dryRun: true });
+
+      // Verify that package.json version is still old
+      const updatedPkg = fs.readJSONSync(path.join(tempProjectDir, 'package.json'));
+      expect(updatedPkg.nitrostack?.skillsVersion).toBe('0.9.0');
+
+      // Verify that skill files were NOT copied
+      const skillPath = path.join(tempProjectDir, '.agents', 'skills', 'mock-skill', 'SKILL.md');
+      expect(fs.existsSync(skillPath)).toBe(false);
+    });
+  });
 });
+
+/** Creates a temporary directory tree and returns its root path. */
+async function makeTempDir(
+  structure: Record<string, string | null>,
+): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'nitro-upgrade-test-'));
+  for (const [rel, content] of Object.entries(structure)) {
+    const abs = path.join(root, rel);
+    if (content === null) {
+      await fs.mkdirp(abs);
+    } else {
+      await fs.mkdirp(path.dirname(abs));
+      await fs.writeFile(abs, content, 'utf-8');
+    }
+  }
+  return root;
+}

--- a/typescript/packages/cli/src/commands/init.ts
+++ b/typescript/packages/cli/src/commands/init.ts
@@ -273,12 +273,12 @@ export async function initCommand(projectName: string | undefined, options: Init
 
     spinner.succeed('Project created');
 
-    // Agent skills prompt asked before installing dependencies (horizontal selection)
-    const addAgentSkills = await promptYesNoHorizontal('Add agent skills?', true);
-
-    if (addAgentSkills) {
-      await runSkillsFlow(options.force ?? false, targetDir);
-    }
+    // Agent skills prompt bypassed - installing project-level skills by default
+    // const addAgentSkills = await promptYesNoHorizontal('Add agent skills?', true);
+    // if (addAgentSkills) {
+    //   await runSkillsFlow(options.force ?? false, targetDir);
+    // }
+    await runSkillsFlow(options.force ?? false, targetDir);
 
 
     // Install dependencies

--- a/typescript/packages/cli/src/commands/init.ts
+++ b/typescript/packages/cli/src/commands/init.ts
@@ -213,7 +213,7 @@ export async function initCommand(projectName: string | undefined, options: Init
             value: 'typescript-pizzaz',
           },
           {
-            name: `${brand.signal('OAuth')}       ${chalk.dim('Flight booking with OAuth 2.1 auth')}`,
+            name: `${brand.signal('Flight booking')}  ${chalk.dim('Flight booking with OAuth 2.1 auth')}`,
             value: 'typescript-oauth',
           },
         ],

--- a/typescript/packages/cli/src/commands/init.ts
+++ b/typescript/packages/cli/src/commands/init.ts
@@ -18,6 +18,7 @@ import {
   showFooter
 } from '../ui/branding.js';
 import { trackEvent, shutdownAnalytics } from '../analytics/posthog.js';
+import { runSkillsFlow } from '../skills/index.js';
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -56,6 +57,7 @@ interface InitOptions {
   description?: string;
   author?: string;
   skipInstall?: boolean;
+  force?: boolean;
 }
 
 export async function initCommand(projectName: string | undefined, options: InitOptions) {
@@ -271,6 +273,20 @@ export async function initCommand(projectName: string | undefined, options: Init
       console.log(chalk.dim('  OAuth Setup: See OAUTH_SETUP.md for provider guides\n'));
     } else if (finalTemplate === 'typescript-pizzaz') {
       console.log(chalk.dim('  Mapbox (optional): Get free key from mapbox.com\n'));
+    }
+
+    // Agent skills
+    const { addAgentSkills } = await inquirer.prompt([
+      {
+        type: 'confirm',
+        name: 'addAgentSkills',
+        message: chalk.white('Add agent skills?'),
+        default: false,
+      },
+    ]);
+
+    if (addAgentSkills) {
+      await runSkillsFlow(options.force ?? false);
     }
 
     console.log(chalk.dim('  Happy coding! 🎉\n'));

--- a/typescript/packages/cli/src/commands/init.ts
+++ b/typescript/packages/cli/src/commands/init.ts
@@ -19,6 +19,92 @@ import {
 } from '../ui/branding.js';
 import { trackEvent, shutdownAnalytics } from '../analytics/posthog.js';
 import { runSkillsFlow } from '../skills/index.js';
+import readline from 'readline';
+
+/**
+ * Prompts the user with a horizontal YES/NO choice using left/right arrow keys.
+ */
+async function promptYesNoHorizontal(message: string, defaultValue: boolean = false): Promise<boolean> {
+  return new Promise((resolve) => {
+    let value = defaultValue;
+    const stdin = process.stdin;
+    const stdout = process.stdout;
+
+    // Save TTY and raw mode state
+    const isRaw = stdin.isRaw;
+    if (stdin.isTTY) {
+      stdin.setRawMode(true);
+    }
+    readline.emitKeypressEvents(stdin);
+    stdin.resume();
+
+    // Hide cursor
+    stdout.write('\u001B[?25l');
+
+    const render = () => {
+      readline.clearLine(stdout, 0);
+      readline.cursorTo(stdout, 0);
+
+      const qMark = chalk.cyan('?');
+      const msg = chalk.bold(message);
+      const pointer = chalk.dim('›');
+      const separator = chalk.dim(' / ');
+      
+      const noPart = !value 
+        ? chalk.cyan.underline('No') 
+        : chalk.dim('No');
+
+      const yesPart = value 
+        ? chalk.cyan.underline('Yes') 
+        : chalk.dim('Yes');
+
+      stdout.write(`${qMark} ${msg} ${pointer} ${noPart}${separator}${yesPart}`);
+    };
+
+    render();
+
+    const onKeypress = (str: string, key: any) => {
+      if (!key) return;
+
+      if (key.name === 'left' || key.name === 'right') {
+        value = !value;
+        render();
+      } else if (key.name === 'return' || key.name === 'enter') {
+        cleanup();
+        // Clear prompt line and print final answer
+        readline.clearLine(stdout, 0);
+        readline.cursorTo(stdout, 0);
+        const checkMark = chalk.green('✔');
+        const finalAns = value ? chalk.cyan('Yes') : chalk.cyan('No');
+        stdout.write(`${checkMark} ${chalk.white(message)} ${finalAns}\n`);
+        
+        // Resolve after a small delay to prevent keypress bleeding into the next prompt
+        setTimeout(() => {
+          resolve(value);
+        }, 100);
+      } else if (key.ctrl && key.name === 'c') {
+        cleanup();
+        process.exit(130); // SIGINT exit code
+      }
+    };
+
+    const cleanup = () => {
+      // Show cursor
+      stdout.write('\u001B[?25h');
+      stdin.removeListener('keypress', onKeypress);
+      
+      // Consume any data currently sitting in the stream buffer
+      stdin.read();
+
+      if (stdin.isTTY) {
+        stdin.setRawMode(isRaw);
+      }
+      stdin.pause();
+    };
+
+    stdin.on('keypress', onKeypress);
+  });
+}
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -98,14 +184,10 @@ export async function initCommand(projectName: string | undefined, options: Init
 
     // Check if directory exists
     if (fs.existsSync(targetDir)) {
-      const { overwrite } = await inquirer.prompt([
-        {
-          type: 'confirm',
-          name: 'overwrite',
-          message: chalk.yellow(`Directory ${finalProjectName} already exists. Overwrite?`),
-          default: false,
-        },
-      ]);
+      const overwrite = await promptYesNoHorizontal(
+        chalk.yellow(`Directory ${finalProjectName} already exists. Overwrite?`),
+        false
+      );
 
       if (!overwrite) {
         log('Cancelled', 'warning');
@@ -191,6 +273,22 @@ export async function initCommand(projectName: string | undefined, options: Init
 
     spinner.succeed('Project created');
 
+    // Agent skills prompt asked before installing dependencies (horizontal selection)
+    const addAgentSkills = await promptYesNoHorizontal('Add agent skills?', true);
+
+    if (addAgentSkills) {
+      await runSkillsFlow(options.force ?? false, targetDir);
+    }
+
+    // Dependency installation prompt (horizontal selection)
+    let shouldInstallDeps = !options.skipInstall;
+    if (!options.skipInstall) {
+      shouldInstallDeps = await promptYesNoHorizontal('Install dependencies?', true);
+      if (!shouldInstallDeps) {
+        options.skipInstall = true;
+      }
+    }
+
     // Install dependencies
     if (!options.skipInstall) {
       spinner = new NitroSpinner('Installing dependencies...').start();
@@ -273,20 +371,6 @@ export async function initCommand(projectName: string | undefined, options: Init
       console.log(chalk.dim('  OAuth Setup: See OAUTH_SETUP.md for provider guides\n'));
     } else if (finalTemplate === 'typescript-pizzaz') {
       console.log(chalk.dim('  Mapbox (optional): Get free key from mapbox.com\n'));
-    }
-
-    // Agent skills
-    const { addAgentSkills } = await inquirer.prompt([
-      {
-        type: 'confirm',
-        name: 'addAgentSkills',
-        message: chalk.white('Add agent skills?'),
-        default: false,
-      },
-    ]);
-
-    if (addAgentSkills) {
-      await runSkillsFlow(options.force ?? false);
     }
 
     console.log(chalk.dim('  Happy coding! 🎉\n'));

--- a/typescript/packages/cli/src/commands/init.ts
+++ b/typescript/packages/cli/src/commands/init.ts
@@ -280,14 +280,6 @@ export async function initCommand(projectName: string | undefined, options: Init
       await runSkillsFlow(options.force ?? false, targetDir);
     }
 
-    // Dependency installation prompt (horizontal selection)
-    let shouldInstallDeps = !options.skipInstall;
-    if (!options.skipInstall) {
-      shouldInstallDeps = await promptYesNoHorizontal('Install dependencies?', true);
-      if (!shouldInstallDeps) {
-        options.skipInstall = true;
-      }
-    }
 
     // Install dependencies
     if (!options.skipInstall) {

--- a/typescript/packages/cli/src/commands/upgrade.ts
+++ b/typescript/packages/cli/src/commands/upgrade.ts
@@ -18,11 +18,19 @@ import {
 } from '../ui/branding.js';
 import { trackEvent, shutdownAnalytics } from '../analytics/posthog.js';
 
+import { cloneSkillsRepo } from '../skills/clone.js';
+import { discoverSkills } from '../skills/discover.js';
+import { installSkills } from '../skills/installer.js';
+import { AGENTS } from '../skills/detect-agents.js';
+
 interface PackageJson {
   name?: string;
   version?: string;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  nitrostack?: {
+    skillsVersion?: string;
+  };
 }
 
 interface UpgradeOptions {
@@ -295,6 +303,67 @@ export async function upgradeCommand(options: UpgradeOptions): Promise<void> {
     } catch (error) {
       widgetsSpinner.fail('Failed to upgrade widgets');
       console.error(error);
+    }
+  }
+
+  // Upgrade skills
+  const rootPackageJson: PackageJson = fs.readJSONSync(rootPackageJsonPath);
+  const localSkillsVersion = rootPackageJson.nitrostack?.skillsVersion || '0.0.0';
+  let tempSkillsDir: string | null = null;
+  const skillsSpinner = new NitroSpinner('Checking agent skills...').start();
+  try {
+    tempSkillsDir = await cloneSkillsRepo();
+    const skillsPkgJsonPath = path.join(tempSkillsDir, 'package.json');
+    let remoteSkillsVersion = '1.0.0';
+    if (fs.existsSync(skillsPkgJsonPath)) {
+      const skillsPkgJson = fs.readJSONSync(skillsPkgJsonPath);
+      remoteSkillsVersion = skillsPkgJson.version || '1.0.0';
+    }
+
+    if (compareVersions(localSkillsVersion, remoteSkillsVersion) < 0) {
+      if (dryRun) {
+        allResults.push({
+          location: 'skills',
+          packageName: '@nitrostack/skills',
+          previousVersion: localSkillsVersion,
+          newVersion: remoteSkillsVersion,
+          upgraded: false,
+        });
+        skillsSpinner.info(`Skills: Updates available (${localSkillsVersion} → ${remoteSkillsVersion})`);
+      } else {
+        const skills = await discoverSkills(tempSkillsDir);
+        await installSkills(AGENTS, skills, true, 'project', projectRoot);
+        
+        // Write new version to package.json
+        const updatedPackageJson: PackageJson = fs.readJSONSync(rootPackageJsonPath);
+        if (!updatedPackageJson.nitrostack) {
+          updatedPackageJson.nitrostack = {};
+        }
+        updatedPackageJson.nitrostack.skillsVersion = remoteSkillsVersion;
+        fs.writeJSONSync(rootPackageJsonPath, updatedPackageJson, { spaces: 2 });
+        
+        allResults.push({
+          location: 'skills',
+          packageName: '@nitrostack/skills',
+          previousVersion: localSkillsVersion,
+          newVersion: remoteSkillsVersion,
+          upgraded: true,
+        });
+        skillsSpinner.succeed(`Skills: Upgraded from ${localSkillsVersion} to ${remoteSkillsVersion}`);
+      }
+    } else {
+      skillsSpinner.info('Skills: All agent skills are up to date');
+    }
+  } catch (error) {
+    skillsSpinner.fail('Failed to upgrade agent skills');
+    console.error(error);
+  } finally {
+    if (tempSkillsDir) {
+      try {
+        fs.removeSync(tempSkillsDir);
+      } catch {
+        // best effort
+      }
     }
   }
 

--- a/typescript/packages/cli/src/index.ts
+++ b/typescript/packages/cli/src/index.ts
@@ -29,6 +29,7 @@ export function createProgram() {
     .option('--description <description>', 'Description of the project')
     .option('--author <author>', 'Author of the project')
     .option('--skip-install', 'Skip installing dependencies')
+    .option('--force', 'Overwrite existing skill files when adding agent skills')
     .action(initCommand);
 
   program

--- a/typescript/packages/cli/src/skills/clone.ts
+++ b/typescript/packages/cli/src/skills/clone.ts
@@ -1,0 +1,70 @@
+import os from 'os';
+import path from 'path';
+import crypto from 'crypto';
+import { execSync } from 'child_process';
+import fs from 'fs-extra';
+
+export const SKILLS_REPO_URL = 'https://github.com/nitrocloudofficial/skills.git';
+
+/**
+ * Thrown when the skills repository cannot be cloned (git missing, network
+ * error, repository not found, etc.).  The caller should catch this and
+ * display a user-friendly warning rather than crashing the entire init flow.
+ */
+export class SkillsCloneError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'SkillsCloneError';
+  }
+}
+
+/**
+ * Clones the NitroStack skills repository into a unique temporary directory
+ * and returns the absolute path to that directory.
+ *
+ * The caller is responsible for cleaning up the directory when done:
+ * ```ts
+ * const tempDir = await cloneSkillsRepo();
+ * try {
+ *   // use tempDir …
+ * } finally {
+ *   await fs.remove(tempDir);
+ * }
+ * ```
+ *
+ * @throws {SkillsCloneError} when git is unavailable or the clone fails.
+ */
+export async function cloneSkillsRepo(): Promise<string> {
+  const uniqueId = crypto.randomBytes(6).toString('hex');
+  const tempDir = path.join(os.tmpdir(), `nitrostack-skills-${uniqueId}`);
+
+  try {
+    execSync(`git clone --depth 1 "${SKILLS_REPO_URL}" "${tempDir}"`, {
+      stdio: 'pipe',
+      timeout: 60_000,
+    });
+  } catch (err: unknown) {
+    // Clean up any partial clone before throwing
+    try {
+      await fs.remove(tempDir);
+    } catch {
+      // best-effort cleanup
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+
+    if (message.includes('git: command not found') || message.includes("'git' is not recognized")) {
+      throw new SkillsCloneError(
+        'Git is not installed or not in PATH. Install Git from https://git-scm.com and try again.',
+        err,
+      );
+    }
+
+    throw new SkillsCloneError(
+      `Failed to clone skills repository: ${message.split('\n')[0]}`,
+      err,
+    );
+  }
+
+  return tempDir;
+}

--- a/typescript/packages/cli/src/skills/detect-agents.ts
+++ b/typescript/packages/cli/src/skills/detect-agents.ts
@@ -56,8 +56,9 @@ export const AGENTS: AgentDescriptor[] = [
     async detect() {
       return dirExists(path.join(HOME, '.cursor'));
     },
-    getSkillsDir() {
-      return path.join(HOME, '.cursor', 'skills');
+    getSkillsDir(scope: 'project' | 'global' = 'global', projectDir: string = process.cwd()) {
+      const base = scope === 'project' ? projectDir : HOME;
+      return path.join(base, '.cursor', 'skills');
     },
   },
   {
@@ -67,8 +68,9 @@ export const AGENTS: AgentDescriptor[] = [
     async detect() {
       return commandExists('codex') || dirExists(path.join(HOME, '.codex'));
     },
-    getSkillsDir() {
-      return path.join(HOME, '.codex', 'skills');
+    getSkillsDir(scope: 'project' | 'global' = 'global', projectDir: string = process.cwd()) {
+      const base = scope === 'project' ? projectDir : HOME;
+      return path.join(base, '.codex', 'skills');
     },
   },
   {
@@ -78,8 +80,9 @@ export const AGENTS: AgentDescriptor[] = [
     async detect() {
       return commandExists('claude') || dirExists(path.join(HOME, '.claude'));
     },
-    getSkillsDir() {
-      return path.join(HOME, '.claude', 'skills');
+    getSkillsDir(scope: 'project' | 'global' = 'global', projectDir: string = process.cwd()) {
+      const base = scope === 'project' ? projectDir : HOME;
+      return path.join(base, '.claude', 'skills');
     },
   },
   {
@@ -89,8 +92,9 @@ export const AGENTS: AgentDescriptor[] = [
     async detect() {
       return commandExists('gemini') || dirExists(path.join(HOME, '.gemini'));
     },
-    getSkillsDir() {
-      return path.join(HOME, '.gemini', 'skills');
+    getSkillsDir(scope: 'project' | 'global' = 'global', projectDir: string = process.cwd()) {
+      const base = scope === 'project' ? projectDir : HOME;
+      return path.join(base, '.gemini', 'skills');
     },
   },
   {
@@ -100,8 +104,9 @@ export const AGENTS: AgentDescriptor[] = [
     async detect() {
       return commandExists('antigravity') || dirExists(path.join(HOME, '.antigravity'));
     },
-    getSkillsDir() {
-      return path.join(HOME, '.antigravity', 'skills');
+    getSkillsDir(scope: 'project' | 'global' = 'global', projectDir: string = process.cwd()) {
+      const base = scope === 'project' ? projectDir : HOME;
+      return path.join(base, '.antigravity', 'skills');
     },
   },
 

--- a/typescript/packages/cli/src/skills/detect-agents.ts
+++ b/typescript/packages/cli/src/skills/detect-agents.ts
@@ -73,7 +73,7 @@ export const AGENTS: AgentDescriptor[] = [
   // ── Original 5 agents (must keep indices 0-4 for tests) ───────────────────
   createAgentDescriptor({
     id: 'cursor',
-    name: 'Cursor',
+    name: 'Cursor Agent',
     folderName: '.cursor',
   }),
   createAgentDescriptor({
@@ -96,60 +96,34 @@ export const AGENTS: AgentDescriptor[] = [
   }),
   createAgentDescriptor({
     id: 'antigravity',
-    name: 'Antigravity',
+    name: 'Google Antigravity',
     folderName: '.antigravity',
-    cmd: 'antigravity',
+    cmd: 'agy',
   }),
 
-  // ── Additional coding agents ──────────────────────────────────────────────
-  createAgentDescriptor({
-    id: 'windsurf',
-    name: 'Windsurf',
-    folderName: '.windsurf',
-    cmd: 'windsurf',
-  }),
-  createAgentDescriptor({
-    id: 'continue',
-    name: 'Continue.dev',
-    folderName: '.continue',
-  }),
-  createAgentDescriptor({
-    id: 'vscode',
-    name: 'VS Code Agent Mode',
-    folderName: '.vscode',
-    // Detect only by command presence — ~/.vscode exists on nearly every dev
-    // machine regardless of whether Agent Mode is in use, causing false positives.
-    customDetect: async () => commandExists('code'),
-  }),
-  createAgentDescriptor({
-    id: 'zed',
-    name: 'Zed',
-    folderName: '.zed',
-    cmd: 'zed',
-  }),
+  // ── Additional coding agents (limited to GitHub Copilot and OpenCode) ──────
   createAgentDescriptor({
     id: 'github-copilot',
-    name: 'GitHub Copilot',
-    // Copilot stores its config at ~/.config/github-copilot, not ~/.copilot
-    folderName: '.config/github-copilot',
+    name: 'GitHub Copilot Agent',
+    folderName: '.copilot',
   }),
   createAgentDescriptor({
-    id: 'goose',
-    name: 'Goose',
-    folderName: '.goose',
-    cmd: 'goose',
+    id: 'opencode',
+    name: 'OpenCode Agent',
+    // OpenCode stores its config at ~/.config/opencode
+    folderName: '.config/opencode',
+    cmd: 'opencode',
+    getSkillsDir(scope: 'project' | 'global' = 'global', projectDir: string = process.cwd()) {
+      if (scope === 'project') {
+        return path.join(projectDir, '.opencode', 'skills');
+      }
+      return path.join(HOME, '.config', 'opencode', 'skills');
+    },
   }),
   createAgentDescriptor({
-    id: 'aider',
-    name: 'Aider',
-    folderName: '.aider',
-    cmd: 'aider',
-  }),
-  createAgentDescriptor({
-    id: 'openhands',
-    name: 'OpenHands',
-    folderName: '.openhands',
-    cmd: 'openhands',
+    id: 'agents',
+    name: 'Workspace Agents',
+    folderName: '.agents',
   }),
 ];
 

--- a/typescript/packages/cli/src/skills/detect-agents.ts
+++ b/typescript/packages/cli/src/skills/detect-agents.ts
@@ -1,17 +1,20 @@
 import os from 'os';
 import path from 'path';
-import { execSync } from 'child_process';
+import { exec } from 'child_process';
+import { promisify } from 'util';
 import fs from 'fs-extra';
 import type { AgentDescriptor } from './types.js';
+
+const execAsync = promisify(exec);
 
 /**
  * Returns true when the given CLI command is available in the system PATH.
  * Works cross-platform: uses `where` on Windows, `which` elsewhere.
  */
-function commandExists(cmd: string): boolean {
+async function commandExists(cmd: string): Promise<boolean> {
   try {
     const whichCmd = process.platform === 'win32' ? `where ${cmd}` : `which ${cmd}`;
-    execSync(whichCmd, { stdio: 'pipe' });
+    await execAsync(whichCmd);
     return true;
   } catch {
     return false;
@@ -31,111 +34,123 @@ function dirExists(dirPath: string): boolean {
 
 const HOME = os.homedir();
 
+interface AgentSpec {
+  id: string;
+  name: string;
+  folderName: string;
+  cmd?: string;
+  customDetect?: () => Promise<boolean>;
+  getSkillsDir?: (scope?: 'project' | 'global', projectDir?: string) => string;
+}
+
 /**
- * Registry of all supported AI coding agents.
- *
- * To add a new agent, append a plain object that satisfies AgentDescriptor:
- *
- * ```ts
- * {
- *   id: 'my-agent',
- *   name: 'My Agent',
- *   displayPath: '~/.my-agent/skills',
- *   async detect() { return commandExists('my-agent'); },
- *   getSkillsDir() { return path.join(HOME, '.my-agent', 'skills'); },
- * }
- * ```
- *
- * No other file needs to change.
+ * Helper to build an AgentDescriptor from a simpler specification,
+ * reducing duplicate boilerplate for detect() and getSkillsDir().
  */
+function createAgentDescriptor(spec: AgentSpec): AgentDescriptor {
+  return {
+    id: spec.id,
+    name: spec.name,
+    displayPath: `~/${spec.folderName}/skills`,
+    async detect() {
+      if (spec.customDetect) {
+        return spec.customDetect();
+      }
+      const hasCmd = spec.cmd ? await commandExists(spec.cmd) : false;
+      return hasCmd || dirExists(path.join(HOME, spec.folderName));
+    },
+    getSkillsDir(scope: 'project' | 'global' = 'global', projectDir: string = process.cwd()) {
+      if (spec.getSkillsDir) {
+        return spec.getSkillsDir(scope, projectDir);
+      }
+      const base = scope === 'project' ? projectDir : HOME;
+      return path.join(base, spec.folderName, 'skills');
+    },
+  };
+}
+
 export const AGENTS: AgentDescriptor[] = [
-  {
+  // ── Original 5 agents (must keep indices 0-4 for tests) ───────────────────
+  createAgentDescriptor({
     id: 'cursor',
     name: 'Cursor',
-    displayPath: '.cursor/skills',
-    async detect() {
-      return dirExists(path.join(HOME, '.cursor'));
-    },
-    getSkillsDir(scope: 'project' | 'global' = 'global', projectDir: string = process.cwd()) {
-      const base = scope === 'project' ? projectDir : HOME;
-      return path.join(base, '.cursor', 'skills');
-    },
-  },
-  {
+    folderName: '.cursor',
+  }),
+  createAgentDescriptor({
     id: 'codex',
     name: 'Codex',
-    displayPath: '~/.codex/skills',
-    async detect() {
-      return commandExists('codex') || dirExists(path.join(HOME, '.codex'));
-    },
-    getSkillsDir(scope: 'project' | 'global' = 'global', projectDir: string = process.cwd()) {
-      const base = scope === 'project' ? projectDir : HOME;
-      return path.join(base, '.codex', 'skills');
-    },
-  },
-  {
+    folderName: '.codex',
+    cmd: 'codex',
+  }),
+  createAgentDescriptor({
     id: 'claude-code',
     name: 'Claude Code',
-    displayPath: '~/.claude/skills',
-    async detect() {
-      return commandExists('claude') || dirExists(path.join(HOME, '.claude'));
-    },
-    getSkillsDir(scope: 'project' | 'global' = 'global', projectDir: string = process.cwd()) {
-      const base = scope === 'project' ? projectDir : HOME;
-      return path.join(base, '.claude', 'skills');
-    },
-  },
-  {
+    folderName: '.claude',
+    cmd: 'claude',
+  }),
+  createAgentDescriptor({
     id: 'gemini-cli',
     name: 'Gemini CLI',
-    displayPath: '~/.gemini/skills',
-    async detect() {
-      return commandExists('gemini') || dirExists(path.join(HOME, '.gemini'));
-    },
-    getSkillsDir(scope: 'project' | 'global' = 'global', projectDir: string = process.cwd()) {
-      const base = scope === 'project' ? projectDir : HOME;
-      return path.join(base, '.gemini', 'skills');
-    },
-  },
-  {
+    folderName: '.gemini',
+    cmd: 'gemini',
+  }),
+  createAgentDescriptor({
     id: 'antigravity',
     name: 'Antigravity',
-    displayPath: '~/.antigravity/skills',
-    async detect() {
-      return commandExists('antigravity') || dirExists(path.join(HOME, '.antigravity'));
-    },
-    getSkillsDir(scope: 'project' | 'global' = 'global', projectDir: string = process.cwd()) {
-      const base = scope === 'project' ? projectDir : HOME;
-      return path.join(base, '.antigravity', 'skills');
-    },
-  },
+    folderName: '.antigravity',
+    cmd: 'antigravity',
+  }),
 
-  // ── Future agents ─────────────────────────────────────────────────────────
-  // Uncomment and adjust as support is added:
-  //
-  // { id: 'vscode', name: 'VS Code Agent Mode', displayPath: '~/.vscode/skills',
-  //   async detect() { return commandExists('code') || dirExists(path.join(HOME, '.vscode')); },
-  //   getSkillsDir() { return path.join(HOME, '.vscode', 'skills'); } },
-  //
-  // { id: 'continue', name: 'Continue.dev', displayPath: '~/.continue/skills',
-  //   async detect() { return dirExists(path.join(HOME, '.continue')); },
-  //   getSkillsDir() { return path.join(HOME, '.continue', 'skills'); } },
-  //
-  // { id: 'windsurf', name: 'Windsurf', displayPath: '~/.windsurf/skills',
-  //   async detect() { return commandExists('windsurf') || dirExists(path.join(HOME, '.windsurf')); },
-  //   getSkillsDir() { return path.join(HOME, '.windsurf', 'skills'); } },
-  //
-  // { id: 'cline', name: 'Cline', displayPath: '~/.cline/skills',
-  //   async detect() { return dirExists(path.join(HOME, '.cline')); },
-  //   getSkillsDir() { return path.join(HOME, '.cline', 'skills'); } },
-  //
-  // { id: 'roo-code', name: 'Roo Code', displayPath: '~/.roo/skills',
-  //   async detect() { return dirExists(path.join(HOME, '.roo')); },
-  //   getSkillsDir() { return path.join(HOME, '.roo', 'skills'); } },
-  //
-  // { id: 'openhands', name: 'OpenHands', displayPath: '~/.openhands/skills',
-  //   async detect() { return commandExists('openhands') || dirExists(path.join(HOME, '.openhands')); },
-  //   getSkillsDir() { return path.join(HOME, '.openhands', 'skills'); } },
+  // ── Additional coding agents ──────────────────────────────────────────────
+  createAgentDescriptor({
+    id: 'windsurf',
+    name: 'Windsurf',
+    folderName: '.windsurf',
+    cmd: 'windsurf',
+  }),
+  createAgentDescriptor({
+    id: 'continue',
+    name: 'Continue.dev',
+    folderName: '.continue',
+  }),
+  createAgentDescriptor({
+    id: 'vscode',
+    name: 'VS Code Agent Mode',
+    folderName: '.vscode',
+    // Detect only by command presence — ~/.vscode exists on nearly every dev
+    // machine regardless of whether Agent Mode is in use, causing false positives.
+    customDetect: async () => commandExists('code'),
+  }),
+  createAgentDescriptor({
+    id: 'zed',
+    name: 'Zed',
+    folderName: '.zed',
+    cmd: 'zed',
+  }),
+  createAgentDescriptor({
+    id: 'github-copilot',
+    name: 'GitHub Copilot',
+    // Copilot stores its config at ~/.config/github-copilot, not ~/.copilot
+    folderName: '.config/github-copilot',
+  }),
+  createAgentDescriptor({
+    id: 'goose',
+    name: 'Goose',
+    folderName: '.goose',
+    cmd: 'goose',
+  }),
+  createAgentDescriptor({
+    id: 'aider',
+    name: 'Aider',
+    folderName: '.aider',
+    cmd: 'aider',
+  }),
+  createAgentDescriptor({
+    id: 'openhands',
+    name: 'OpenHands',
+    folderName: '.openhands',
+    cmd: 'openhands',
+  }),
 ];
 
 /**

--- a/typescript/packages/cli/src/skills/detect-agents.ts
+++ b/typescript/packages/cli/src/skills/detect-agents.ts
@@ -1,0 +1,153 @@
+import os from 'os';
+import path from 'path';
+import { execSync } from 'child_process';
+import fs from 'fs-extra';
+import type { AgentDescriptor } from './types.js';
+
+/**
+ * Returns true when the given CLI command is available in the system PATH.
+ * Works cross-platform: uses `where` on Windows, `which` elsewhere.
+ */
+function commandExists(cmd: string): boolean {
+  try {
+    const whichCmd = process.platform === 'win32' ? `where ${cmd}` : `which ${cmd}`;
+    execSync(whichCmd, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true when a directory exists at `dirPath`.
+ */
+function dirExists(dirPath: string): boolean {
+  try {
+    return fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+const HOME = os.homedir();
+
+/**
+ * Registry of all supported AI coding agents.
+ *
+ * To add a new agent, append a plain object that satisfies AgentDescriptor:
+ *
+ * ```ts
+ * {
+ *   id: 'my-agent',
+ *   name: 'My Agent',
+ *   displayPath: '~/.my-agent/skills',
+ *   async detect() { return commandExists('my-agent'); },
+ *   getSkillsDir() { return path.join(HOME, '.my-agent', 'skills'); },
+ * }
+ * ```
+ *
+ * No other file needs to change.
+ */
+export const AGENTS: AgentDescriptor[] = [
+  {
+    id: 'cursor',
+    name: 'Cursor',
+    displayPath: '.cursor/skills',
+    async detect() {
+      return dirExists(path.join(HOME, '.cursor'));
+    },
+    getSkillsDir() {
+      return path.join(HOME, '.cursor', 'skills');
+    },
+  },
+  {
+    id: 'codex',
+    name: 'Codex',
+    displayPath: '~/.codex/skills',
+    async detect() {
+      return commandExists('codex') || dirExists(path.join(HOME, '.codex'));
+    },
+    getSkillsDir() {
+      return path.join(HOME, '.codex', 'skills');
+    },
+  },
+  {
+    id: 'claude-code',
+    name: 'Claude Code',
+    displayPath: '~/.claude/skills',
+    async detect() {
+      return commandExists('claude') || dirExists(path.join(HOME, '.claude'));
+    },
+    getSkillsDir() {
+      return path.join(HOME, '.claude', 'skills');
+    },
+  },
+  {
+    id: 'gemini-cli',
+    name: 'Gemini CLI',
+    displayPath: '~/.gemini/skills',
+    async detect() {
+      return commandExists('gemini') || dirExists(path.join(HOME, '.gemini'));
+    },
+    getSkillsDir() {
+      return path.join(HOME, '.gemini', 'skills');
+    },
+  },
+  {
+    id: 'antigravity',
+    name: 'Antigravity',
+    displayPath: '~/.antigravity/skills',
+    async detect() {
+      return commandExists('antigravity') || dirExists(path.join(HOME, '.antigravity'));
+    },
+    getSkillsDir() {
+      return path.join(HOME, '.antigravity', 'skills');
+    },
+  },
+
+  // ── Future agents ─────────────────────────────────────────────────────────
+  // Uncomment and adjust as support is added:
+  //
+  // { id: 'vscode', name: 'VS Code Agent Mode', displayPath: '~/.vscode/skills',
+  //   async detect() { return commandExists('code') || dirExists(path.join(HOME, '.vscode')); },
+  //   getSkillsDir() { return path.join(HOME, '.vscode', 'skills'); } },
+  //
+  // { id: 'continue', name: 'Continue.dev', displayPath: '~/.continue/skills',
+  //   async detect() { return dirExists(path.join(HOME, '.continue')); },
+  //   getSkillsDir() { return path.join(HOME, '.continue', 'skills'); } },
+  //
+  // { id: 'windsurf', name: 'Windsurf', displayPath: '~/.windsurf/skills',
+  //   async detect() { return commandExists('windsurf') || dirExists(path.join(HOME, '.windsurf')); },
+  //   getSkillsDir() { return path.join(HOME, '.windsurf', 'skills'); } },
+  //
+  // { id: 'cline', name: 'Cline', displayPath: '~/.cline/skills',
+  //   async detect() { return dirExists(path.join(HOME, '.cline')); },
+  //   getSkillsDir() { return path.join(HOME, '.cline', 'skills'); } },
+  //
+  // { id: 'roo-code', name: 'Roo Code', displayPath: '~/.roo/skills',
+  //   async detect() { return dirExists(path.join(HOME, '.roo')); },
+  //   getSkillsDir() { return path.join(HOME, '.roo', 'skills'); } },
+  //
+  // { id: 'openhands', name: 'OpenHands', displayPath: '~/.openhands/skills',
+  //   async detect() { return commandExists('openhands') || dirExists(path.join(HOME, '.openhands')); },
+  //   getSkillsDir() { return path.join(HOME, '.openhands', 'skills'); } },
+];
+
+/**
+ * Runs all agent detectors in parallel and returns only the agents that are
+ * detected on the current machine.
+ */
+export async function detectAgents(): Promise<AgentDescriptor[]> {
+  const results = await Promise.all(
+    AGENTS.map(async (agent) => {
+      try {
+        const found = await agent.detect();
+        return found ? agent : null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return results.filter((a): a is AgentDescriptor => a !== null);
+}

--- a/typescript/packages/cli/src/skills/discover.ts
+++ b/typescript/packages/cli/src/skills/discover.ts
@@ -1,0 +1,52 @@
+import path from 'path';
+import fs from 'fs-extra';
+import type { Skill } from './types.js';
+
+/**
+ * The subdirectory inside the cloned repository that contains individual skill
+ * folders.  Repository layout:
+ *
+ *   <clone>/
+ *     skills/
+ *       remotion/        ← one skill per subdirectory
+ *       mcp-best-practices/
+ *       …
+ *     src/
+ *     README.md
+ */
+const SKILLS_SUBDIR = 'skills';
+
+/**
+ * Discovers all skills inside the cloned repository.
+ *
+ * A "skill" is any immediate subdirectory of `<cloneDir>/skills/` whose name
+ * does not start with a dot.  Regular files and hidden directories are ignored.
+ *
+ * @param cloneDir - Absolute path to the root of the cloned repository.
+ * @returns Array of discovered skills, sorted alphabetically by name.
+ */
+export async function discoverSkills(cloneDir: string): Promise<Skill[]> {
+  const skillsRoot = path.join(cloneDir, SKILLS_SUBDIR);
+
+  if (!(await fs.pathExists(skillsRoot))) {
+    return [];
+  }
+
+  const entries = await fs.readdir(skillsRoot, { withFileTypes: true });
+
+  const skills: Skill[] = [];
+
+  for (const entry of entries) {
+    // Skip hidden entries (e.g. .DS_Store, .git)
+    if (entry.name.startsWith('.')) continue;
+    // Only directories are treated as skills
+    if (!entry.isDirectory()) continue;
+
+    skills.push({
+      name: entry.name,
+      sourcePath: path.join(skillsRoot, entry.name),
+    });
+  }
+
+  return skills.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/typescript/packages/cli/src/skills/index.ts
+++ b/typescript/packages/cli/src/skills/index.ts
@@ -1,0 +1,116 @@
+import fs from 'fs-extra';
+import inquirer from 'inquirer';
+import chalk from 'chalk';
+import { cloneSkillsRepo, SkillsCloneError } from './clone.js';
+import { discoverSkills } from './discover.js';
+import { detectAgents } from './detect-agents.js';
+import { installSkills } from './installer.js';
+import {
+  printSkillsHeader,
+  printCloned,
+  printSkillList,
+  printDetectedAgents,
+  printNoAgentsWarning,
+  printInstalling,
+  printSuccess,
+  printCloneError,
+} from './ui.js';
+import type { AgentDescriptor } from './types.js';
+
+/**
+ * Runs the full agent-skills installation flow.
+ *
+ * Steps:
+ *  1. Clone the skills repository into a temporary directory.
+ *  2. Discover all skills in the `skills/` subdirectory.
+ *  3. Detect supported AI agents installed on the machine.
+ *  4. Prompt the user to select which agents to install skills into.
+ *  5. Install the skills and report results.
+ *  6. Clean up the temporary clone.
+ *
+ * Graceful fallbacks:
+ *  - Git unavailable or clone fails → print warning and return.
+ *  - No agents detected → print warning and return.
+ *  - User selects no agents → return silently.
+ *  - Individual skill copy fails → reported per-agent, does not abort the run.
+ *
+ * @param force - When true, overwrite existing skill files.
+ */
+export async function runSkillsFlow(force: boolean = false): Promise<void> {
+  printSkillsHeader();
+
+  // ── Step 1: Clone ──────────────────────────────────────────────────────────
+  let tempDir: string;
+
+  try {
+    tempDir = await cloneSkillsRepo();
+  } catch (err: unknown) {
+    const message =
+      err instanceof SkillsCloneError
+        ? err.message
+        : err instanceof Error
+        ? err.message
+        : String(err);
+    printCloneError(message);
+    return;
+  }
+
+  try {
+    printCloned();
+
+    // ── Step 2: Discover skills ──────────────────────────────────────────────
+    const skills = await discoverSkills(tempDir);
+
+    if (skills.length === 0) {
+      console.log(chalk.dim('  No skills found in the repository.\n'));
+      return;
+    }
+
+    printSkillList(skills);
+
+    // ── Step 3: Detect agents ────────────────────────────────────────────────
+    const detected = await detectAgents();
+    printDetectedAgents(detected.length);
+
+    if (detected.length === 0) {
+      printNoAgentsWarning();
+      return;
+    }
+
+    // ── Step 4: Agent selection ──────────────────────────────────────────────
+    const { selectedIds } = await inquirer.prompt<{ selectedIds: string[] }>([
+      {
+        type: 'checkbox',
+        name: 'selectedIds',
+        message: chalk.white('Select agents to install skills to'),
+        suffix: chalk.dim('\n  (space to toggle, enter to confirm)\n'),
+        choices: detected.map((agent: AgentDescriptor) => ({
+          name: `${chalk.white(agent.name)}  ${chalk.dim(agent.displayPath)}`,
+          value: agent.id,
+          checked: false,
+        })),
+        pageSize: 10,
+      },
+    ]);
+
+    if (selectedIds.length === 0) {
+      console.log(chalk.dim('\n  No agents selected — skipping skill installation.\n'));
+      return;
+    }
+
+    const selectedAgents = detected.filter((a) => selectedIds.includes(a.id));
+
+    // ── Step 5: Install ──────────────────────────────────────────────────────
+    const results = await installSkills(selectedAgents, skills, force);
+    printInstalling(results);
+    printSuccess();
+
+  } finally {
+    // ── Cleanup: always remove the temp clone ────────────────────────────────
+    try {
+      await fs.remove(tempDir);
+    } catch {
+      // best-effort; temp files will be cleaned by the OS
+    }
+  }
+}

--- a/typescript/packages/cli/src/skills/index.ts
+++ b/typescript/packages/cli/src/skills/index.ts
@@ -109,7 +109,7 @@ export async function runSkillsFlow(force: boolean = false, projectDir: string =
         choices: detected.map((agent: AgentDescriptor) => ({
           name: `${chalk.white(agent.name)}  ${chalk.dim(agent.displayPath)}`,
           value: agent.id,
-          checked: true,
+          checked: false,
         })),
         pageSize: 10,
       },

--- a/typescript/packages/cli/src/skills/index.ts
+++ b/typescript/packages/cli/src/skills/index.ts
@@ -1,7 +1,28 @@
 import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
+import readline from 'readline';
 import { cloneSkillsRepo, SkillsCloneError } from './clone.js';
+
+// Monkeypatch Inquirer's CheckboxPrompt to remove the '<i> to invert selection' instruction
+const checkboxConstructor = (inquirer.prompt as any).prompts?.checkbox;
+if (checkboxConstructor) {
+  const originalCheckboxRender = checkboxConstructor.prototype.render;
+  if (originalCheckboxRender) {
+    checkboxConstructor.prototype.render = function(error?: any) {
+      const originalScreenRender = this.screen.render;
+      this.screen.render = (msg: string, bottom: string) => {
+        const cleanedMsg = msg.replace(/, .*?i.*? to invert selection, and /i, ', and ');
+        return originalScreenRender.call(this.screen, cleanedMsg, bottom);
+      };
+      try {
+        return originalCheckboxRender.call(this, error);
+      } finally {
+        this.screen.render = originalScreenRender;
+      }
+    };
+  }
+}
 import { discoverSkills } from './discover.js';
 import { detectAgents } from './detect-agents.js';
 import { installSkills } from './installer.js';
@@ -36,7 +57,7 @@ import type { AgentDescriptor } from './types.js';
  *
  * @param force - When true, overwrite existing skill files.
  */
-export async function runSkillsFlow(force: boolean = false): Promise<void> {
+export async function runSkillsFlow(force: boolean = false, projectDir: string = process.cwd()): Promise<void> {
   printSkillsHeader();
 
   // ── Step 1: Clone ──────────────────────────────────────────────────────────
@@ -78,16 +99,17 @@ export async function runSkillsFlow(force: boolean = false): Promise<void> {
     }
 
     // ── Step 4: Agent selection ──────────────────────────────────────────────
+    console.log(chalk.dim('  Use space to toggle, enter to confirm.\n'));
+
     const { selectedIds } = await inquirer.prompt<{ selectedIds: string[] }>([
       {
         type: 'checkbox',
         name: 'selectedIds',
         message: chalk.white('Select agents to install skills to'),
-        suffix: chalk.dim('\n  (space to toggle, enter to confirm)\n'),
         choices: detected.map((agent: AgentDescriptor) => ({
           name: `${chalk.white(agent.name)}  ${chalk.dim(agent.displayPath)}`,
           value: agent.id,
-          checked: false,
+          checked: true,
         })),
         pageSize: 10,
       },
@@ -100,8 +122,11 @@ export async function runSkillsFlow(force: boolean = false): Promise<void> {
 
     const selectedAgents = detected.filter((a) => selectedIds.includes(a.id));
 
+    // ── Step 4.5: Scope selection ───────────────────────────────────────────
+    const scope = await promptScopeVertical();
+
     // ── Step 5: Install ──────────────────────────────────────────────────────
-    const results = await installSkills(selectedAgents, skills, force);
+    const results = await installSkills(selectedAgents, skills, force, scope, projectDir);
     printInstalling(results);
     printSuccess();
 
@@ -113,4 +138,92 @@ export async function runSkillsFlow(force: boolean = false): Promise<void> {
       // best-effort; temp files will be cleaned by the OS
     }
   }
+}
+
+/**
+ * Custom vertical scope selection prompt that dynamically displays option
+ * descriptions/subtext only when that option is currently selected.
+ */
+async function promptScopeVertical(): Promise<'project' | 'global'> {
+  return new Promise((resolve) => {
+    let activeIndex = 0; // 0 = project, 1 = global
+    const stdin = process.stdin;
+    const stdout = process.stdout;
+
+    const isRaw = stdin.isRaw;
+    if (stdin.isTTY) {
+      stdin.setRawMode(true);
+    }
+    readline.emitKeypressEvents(stdin);
+    stdin.resume();
+
+    // Hide cursor
+    stdout.write('\u001B[?25l');
+
+    const render = () => {
+      readline.cursorTo(stdout, 0);
+      readline.clearScreenDown(stdout);
+
+      const qIcon = chalk.cyan('◆');
+      const msg = chalk.bold('Installation scope');
+
+      const projectDesc = activeIndex === 0
+        ? ` ${chalk.dim('(Install in current directory (committed with your project))')}`
+        : '';
+      const projectLine = activeIndex === 0
+        ? `${chalk.cyan('●')} ${chalk.cyan.bold('Project')}${projectDesc}`
+        : `${chalk.dim('○ Project')}`;
+
+      const globalDesc = activeIndex === 1
+        ? ` ${chalk.dim('(Install in home directory (available across all projects))')}`
+        : '';
+      const globalLine = activeIndex === 1
+        ? `${chalk.cyan('●')} ${chalk.cyan.bold('Global')}${globalDesc}`
+        : `${chalk.dim('○ Global')}`;
+
+      stdout.write(`${qIcon} ${msg}\n  ${projectLine}\n  ${globalLine}`);
+
+      // Move cursor back up 2 lines to align on next render
+      readline.moveCursor(stdout, 0, -2);
+    };
+
+    render();
+
+    const onKeypress = (str: string, key: any) => {
+      if (!key) return;
+
+      if (key.name === 'up' || key.name === 'down') {
+        activeIndex = activeIndex === 0 ? 1 : 0;
+        render();
+      } else if (key.name === 'return' || key.name === 'enter') {
+        cleanup();
+
+        readline.cursorTo(stdout, 0);
+        readline.clearScreenDown(stdout);
+
+        const checkMark = chalk.green('✔');
+        const finalAns = activeIndex === 0 ? 'Project' : 'Global';
+        stdout.write(`${checkMark} ${chalk.bold('Installation scope')} ${chalk.cyan(finalAns)}\n`);
+
+        // Resolve after a small delay to prevent keypress bleeding
+        setTimeout(() => {
+          resolve(activeIndex === 0 ? 'project' : 'global');
+        }, 100);
+      } else if (key.ctrl && key.name === 'c') {
+        cleanup();
+        process.exit(130);
+      }
+    };
+
+    const cleanup = () => {
+      stdout.write('\u001B[?25h');
+      stdin.removeListener('keypress', onKeypress);
+      stdin.read();
+      if (stdin.isTTY) {
+        stdin.setRawMode(isRaw);
+      }
+    };
+
+    stdin.on('keypress', onKeypress);
+  });
 }

--- a/typescript/packages/cli/src/skills/index.ts
+++ b/typescript/packages/cli/src/skills/index.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import fs from 'fs-extra';
 import chalk from 'chalk';
 import { cloneSkillsRepo, SkillsCloneError } from './clone.js';
@@ -69,6 +70,36 @@ export async function runSkillsFlow(force: boolean = false, projectDir: string =
     // Installs the skills for all 6 agents by default at project scope
     const results = await installSkills(AGENTS, skills, force, 'project', projectDir);
     printInstalling(results);
+
+    // Read the skills version from the cloned repository's package.json
+    let skillsVersion = '1.0.0';
+    const skillsPackageJsonPath = path.join(tempDir, 'package.json');
+    if (await fs.pathExists(skillsPackageJsonPath)) {
+      try {
+        const pkgJson = await fs.readJSON(skillsPackageJsonPath);
+        if (pkgJson.version) {
+          skillsVersion = pkgJson.version;
+        }
+      } catch {
+        // Ignore read errors
+      }
+    }
+
+    // Write skills version to the project's package.json
+    const projectPackageJsonPath = path.join(projectDir, 'package.json');
+    if (await fs.pathExists(projectPackageJsonPath)) {
+      try {
+        const projectPkgJson = await fs.readJSON(projectPackageJsonPath);
+        if (!projectPkgJson.nitrostack) {
+          projectPkgJson.nitrostack = {};
+        }
+        projectPkgJson.nitrostack.skillsVersion = skillsVersion;
+        await fs.writeJSON(projectPackageJsonPath, projectPkgJson, { spaces: 2 });
+      } catch {
+        // Ignore write errors
+      }
+    }
+
     printSuccess();
 
   } finally {

--- a/typescript/packages/cli/src/skills/index.ts
+++ b/typescript/packages/cli/src/skills/index.ts
@@ -1,37 +1,13 @@
 import fs from 'fs-extra';
-import inquirer from 'inquirer';
 import chalk from 'chalk';
-import readline from 'readline';
 import { cloneSkillsRepo, SkillsCloneError } from './clone.js';
-
-// Monkeypatch Inquirer's CheckboxPrompt to remove the '<i> to invert selection' instruction
-const checkboxConstructor = (inquirer.prompt as any).prompts?.checkbox;
-if (checkboxConstructor) {
-  const originalCheckboxRender = checkboxConstructor.prototype.render;
-  if (originalCheckboxRender) {
-    checkboxConstructor.prototype.render = function(error?: any) {
-      const originalScreenRender = this.screen.render;
-      this.screen.render = (msg: string, bottom: string) => {
-        const cleanedMsg = msg.replace(/, .*?i.*? to invert selection, and /i, ', and ');
-        return originalScreenRender.call(this.screen, cleanedMsg, bottom);
-      };
-      try {
-        return originalCheckboxRender.call(this, error);
-      } finally {
-        this.screen.render = originalScreenRender;
-      }
-    };
-  }
-}
 import { discoverSkills } from './discover.js';
-import { detectAgents } from './detect-agents.js';
+import { AGENTS } from './detect-agents.js';
 import { installSkills } from './installer.js';
 import {
   printSkillsHeader,
   printCloned,
   printSkillList,
-  printDetectedAgents,
-  printNoAgentsWarning,
   printInstalling,
   printSuccess,
   printCloneError,
@@ -89,44 +65,9 @@ export async function runSkillsFlow(force: boolean = false, projectDir: string =
 
     printSkillList(skills);
 
-    // ── Step 3: Detect agents ────────────────────────────────────────────────
-    const detected = await detectAgents();
-    printDetectedAgents(detected.length);
-
-    if (detected.length === 0) {
-      printNoAgentsWarning();
-      return;
-    }
-
-    // ── Step 4: Agent selection ──────────────────────────────────────────────
-    console.log(chalk.dim('  Use space to toggle, enter to confirm.\n'));
-
-    const { selectedIds } = await inquirer.prompt<{ selectedIds: string[] }>([
-      {
-        type: 'checkbox',
-        name: 'selectedIds',
-        message: chalk.white('Select agents to install skills to'),
-        choices: detected.map((agent: AgentDescriptor) => ({
-          name: `${chalk.white(agent.name)}  ${chalk.dim(agent.displayPath)}`,
-          value: agent.id,
-          checked: false,
-        })),
-        pageSize: 10,
-      },
-    ]);
-
-    if (selectedIds.length === 0) {
-      console.log(chalk.dim('\n  No agents selected — skipping skill installation.\n'));
-      return;
-    }
-
-    const selectedAgents = detected.filter((a) => selectedIds.includes(a.id));
-
-    // ── Step 4.5: Scope selection ───────────────────────────────────────────
-    const scope = await promptScopeVertical();
-
-    // ── Step 5: Install ──────────────────────────────────────────────────────
-    const results = await installSkills(selectedAgents, skills, force, scope, projectDir);
+    // ── Step 3: Install Project-Level Skills ─────────────────────────────────
+    // Installs the skills for all 6 agents by default at project scope
+    const results = await installSkills(AGENTS, skills, force, 'project', projectDir);
     printInstalling(results);
     printSuccess();
 
@@ -140,90 +81,4 @@ export async function runSkillsFlow(force: boolean = false, projectDir: string =
   }
 }
 
-/**
- * Custom vertical scope selection prompt that dynamically displays option
- * descriptions/subtext only when that option is currently selected.
- */
-async function promptScopeVertical(): Promise<'project' | 'global'> {
-  return new Promise((resolve) => {
-    let activeIndex = 0; // 0 = project, 1 = global
-    const stdin = process.stdin;
-    const stdout = process.stdout;
 
-    const isRaw = stdin.isRaw;
-    if (stdin.isTTY) {
-      stdin.setRawMode(true);
-    }
-    readline.emitKeypressEvents(stdin);
-    stdin.resume();
-
-    // Hide cursor
-    stdout.write('\u001B[?25l');
-
-    const render = () => {
-      readline.cursorTo(stdout, 0);
-      readline.clearScreenDown(stdout);
-
-      const qIcon = chalk.cyan('◆');
-      const msg = chalk.bold('Installation scope');
-
-      const projectDesc = activeIndex === 0
-        ? ` ${chalk.dim('(Install in current directory (committed with your project))')}`
-        : '';
-      const projectLine = activeIndex === 0
-        ? `${chalk.cyan('●')} ${chalk.cyan.bold('Project')}${projectDesc}`
-        : `${chalk.dim('○ Project')}`;
-
-      const globalDesc = activeIndex === 1
-        ? ` ${chalk.dim('(Install in home directory (available across all projects))')}`
-        : '';
-      const globalLine = activeIndex === 1
-        ? `${chalk.cyan('●')} ${chalk.cyan.bold('Global')}${globalDesc}`
-        : `${chalk.dim('○ Global')}`;
-
-      stdout.write(`${qIcon} ${msg}\n  ${projectLine}\n  ${globalLine}`);
-
-      // Move cursor back up 2 lines to align on next render
-      readline.moveCursor(stdout, 0, -2);
-    };
-
-    render();
-
-    const onKeypress = (str: string, key: any) => {
-      if (!key) return;
-
-      if (key.name === 'up' || key.name === 'down') {
-        activeIndex = activeIndex === 0 ? 1 : 0;
-        render();
-      } else if (key.name === 'return' || key.name === 'enter') {
-        cleanup();
-
-        readline.cursorTo(stdout, 0);
-        readline.clearScreenDown(stdout);
-
-        const checkMark = chalk.green('✔');
-        const finalAns = activeIndex === 0 ? 'Project' : 'Global';
-        stdout.write(`${checkMark} ${chalk.bold('Installation scope')} ${chalk.cyan(finalAns)}\n`);
-
-        // Resolve after a small delay to prevent keypress bleeding
-        setTimeout(() => {
-          resolve(activeIndex === 0 ? 'project' : 'global');
-        }, 100);
-      } else if (key.ctrl && key.name === 'c') {
-        cleanup();
-        process.exit(130);
-      }
-    };
-
-    const cleanup = () => {
-      stdout.write('\u001B[?25h');
-      stdin.removeListener('keypress', onKeypress);
-      stdin.read();
-      if (stdin.isTTY) {
-        stdin.setRawMode(isRaw);
-      }
-    };
-
-    stdin.on('keypress', onKeypress);
-  });
-}

--- a/typescript/packages/cli/src/skills/installer.ts
+++ b/typescript/packages/cli/src/skills/installer.ts
@@ -19,11 +19,13 @@ export async function installSkillsForAgent(
   agent: AgentDescriptor,
   skills: Skill[],
   force: boolean,
+  scope: 'project' | 'global',
+  projectDir: string = process.cwd(),
 ): Promise<InstallResult> {
   const result: InstallResult = { agent, installed: [], skipped: [] };
 
   try {
-    const skillsDir = agent.getSkillsDir();
+    const skillsDir = agent.getSkillsDir(scope, projectDir);
     await fs.mkdirp(skillsDir);
 
     for (const skill of skills) {
@@ -53,11 +55,13 @@ export async function installSkills(
   agents: AgentDescriptor[],
   skills: Skill[],
   force: boolean,
+  scope: 'project' | 'global',
+  projectDir: string = process.cwd(),
 ): Promise<InstallResult[]> {
   const results: InstallResult[] = [];
 
   for (const agent of agents) {
-    const result = await installSkillsForAgent(agent, skills, force);
+    const result = await installSkillsForAgent(agent, skills, force, scope, projectDir);
     results.push(result);
   }
 

--- a/typescript/packages/cli/src/skills/installer.ts
+++ b/typescript/packages/cli/src/skills/installer.ts
@@ -1,0 +1,65 @@
+import path from 'path';
+import fs from 'fs-extra';
+import type { AgentDescriptor, InstallResult, Skill } from './types.js';
+
+/**
+ * Installs all discovered skills into the skills directory of a single agent.
+ *
+ * - Creates the target directory if it does not exist.
+ * - Skips individual skills whose destination directory already exists,
+ *   unless `force` is true.
+ * - Preserves the full folder structure of each skill.
+ *
+ * @param agent  - The agent to install into.
+ * @param skills - All skills discovered from the repository.
+ * @param force  - When true, overwrite existing skill directories.
+ * @returns      InstallResult describing what was installed vs skipped.
+ */
+export async function installSkillsForAgent(
+  agent: AgentDescriptor,
+  skills: Skill[],
+  force: boolean,
+): Promise<InstallResult> {
+  const result: InstallResult = { agent, installed: [], skipped: [] };
+
+  try {
+    const skillsDir = agent.getSkillsDir();
+    await fs.mkdirp(skillsDir);
+
+    for (const skill of skills) {
+      const dest = path.join(skillsDir, skill.name);
+
+      const alreadyExists = await fs.pathExists(dest);
+      if (alreadyExists && !force) {
+        result.skipped.push(skill.name);
+        continue;
+      }
+
+      await fs.copy(skill.sourcePath, dest, { overwrite: force });
+      result.installed.push(skill.name);
+    }
+  } catch (err: unknown) {
+    result.error = err instanceof Error ? err.message : String(err);
+  }
+
+  return result;
+}
+
+/**
+ * Installs skills into every selected agent sequentially.
+ * Sequential (rather than parallel) installation gives cleaner CLI progress output.
+ */
+export async function installSkills(
+  agents: AgentDescriptor[],
+  skills: Skill[],
+  force: boolean,
+): Promise<InstallResult[]> {
+  const results: InstallResult[] = [];
+
+  for (const agent of agents) {
+    const result = await installSkillsForAgent(agent, skills, force);
+    results.push(result);
+  }
+
+  return results;
+}

--- a/typescript/packages/cli/src/skills/installer.ts
+++ b/typescript/packages/cli/src/skills/installer.ts
@@ -19,7 +19,7 @@ export async function installSkillsForAgent(
   agent: AgentDescriptor,
   skills: Skill[],
   force: boolean,
-  scope: 'project' | 'global',
+  scope: 'project' | 'global' = 'global',
   projectDir: string = process.cwd(),
 ): Promise<InstallResult> {
   const result: InstallResult = { agent, installed: [], skipped: [] };
@@ -55,7 +55,7 @@ export async function installSkills(
   agents: AgentDescriptor[],
   skills: Skill[],
   force: boolean,
-  scope: 'project' | 'global',
+  scope: 'project' | 'global' = 'global',
   projectDir: string = process.cwd(),
 ): Promise<InstallResult[]> {
   const results: InstallResult[] = [];

--- a/typescript/packages/cli/src/skills/types.ts
+++ b/typescript/packages/cli/src/skills/types.ts
@@ -23,7 +23,7 @@ export interface AgentDescriptor {
   /** Returns true when the agent appears to be installed on this machine */
   detect(): Promise<boolean>;
   /** Returns the absolute path of the directory where skills should be installed */
-  getSkillsDir(): string;
+  getSkillsDir(scope?: 'project' | 'global', projectDir?: string): string;
 }
 
 /**

--- a/typescript/packages/cli/src/skills/types.ts
+++ b/typescript/packages/cli/src/skills/types.ts
@@ -1,0 +1,40 @@
+/**
+ * A single skill discovered from the skills repository.
+ * Each skill maps to one subdirectory under `skills/` in the cloned repo.
+ */
+export interface Skill {
+  /** Directory name — used as the skill identifier and display name */
+  name: string;
+  /** Absolute path to the skill directory inside the temporary clone */
+  sourcePath: string;
+}
+
+/**
+ * Describes a supported AI coding agent.
+ * Add new agents by appending entries to the AGENTS registry in detect-agents.ts.
+ */
+export interface AgentDescriptor {
+  /** Machine-readable identifier (kebab-case) */
+  id: string;
+  /** Human-readable display name shown in the CLI */
+  name: string;
+  /** Short path hint shown next to the agent name in the selection list */
+  displayPath: string;
+  /** Returns true when the agent appears to be installed on this machine */
+  detect(): Promise<boolean>;
+  /** Returns the absolute path of the directory where skills should be installed */
+  getSkillsDir(): string;
+}
+
+/**
+ * Result of installing skills for one agent.
+ */
+export interface InstallResult {
+  agent: AgentDescriptor;
+  /** Skill names that were successfully copied */
+  installed: string[];
+  /** Skill names that were skipped because the destination already existed */
+  skipped: string[];
+  /** Non-fatal error message, if any */
+  error?: string;
+}

--- a/typescript/packages/cli/src/skills/ui.ts
+++ b/typescript/packages/cli/src/skills/ui.ts
@@ -1,0 +1,125 @@
+import chalk from 'chalk';
+import { brand } from '../ui/branding.js';
+import { SKILLS_REPO_URL } from './clone.js';
+import type { InstallResult, Skill } from './types.js';
+
+// ── Private helpers ──────────────────────────────────────────────────────────
+
+/** Diamond prefix used for info lines — matches Remotion create-video style */
+const diamond = () => chalk.dim('◇');
+
+/** Bullet used for list items */
+const bullet = () => brand.sky('•');
+
+// ── Public output functions ──────────────────────────────────────────────────
+
+/**
+ * Prints the skills section header:
+ *
+ *   skills
+ *
+ *   ◇ Source: https://github.com/nitrocloudofficial/skills.git
+ *   ◇ Repository cloned
+ */
+export function printSkillsHeader(): void {
+  console.log('\n' + chalk.white.bold('  skills') + '\n');
+  console.log(`  ${diamond()} ${chalk.dim('Source:')} ${brand.sky(SKILLS_REPO_URL)}`);
+}
+
+/**
+ * Prints the "Repository cloned" confirmation line.
+ * Called after cloneSkillsRepo() succeeds.
+ */
+export function printCloned(): void {
+  console.log(`  ${diamond()} ${chalk.dim('Repository cloned')}\n`);
+}
+
+/**
+ * Prints the discovered skill list:
+ *
+ *   ◇ Found 4 skills
+ *
+ *   • nitrostack-sdk
+ *   • mcp-best-practices
+ *   …
+ */
+export function printSkillList(skills: Skill[]): void {
+  console.log(`  ${diamond()} ${chalk.white(`Found ${skills.length} skill${skills.length === 1 ? '' : 's'}`)}\n`);
+
+  for (const skill of skills) {
+    console.log(`    ${bullet()} ${chalk.white(skill.name)}`);
+  }
+
+  console.log('');
+}
+
+/**
+ * Prints the detected-agent count line:
+ *
+ *   ◇ Detected 3 agents
+ */
+export function printDetectedAgents(count: number): void {
+  console.log(`  ${diamond()} ${chalk.white(`Detected ${count} agent${count === 1 ? '' : 's'}`)}\n`);
+}
+
+/**
+ * Prints a warning when no agents are detected so the user knows why the
+ * flow is being skipped rather than seeing a silent no-op.
+ */
+export function printNoAgentsWarning(): void {
+  console.log(
+    `  ${chalk.hex('#F59E0B')('⚠')} ${chalk.dim('No supported AI agents detected on this machine.')}\n` +
+    `    ${chalk.dim('Install Cursor, Claude Code, Gemini CLI, or Codex and re-run to add skills.')}\n`,
+  );
+}
+
+/**
+ * Prints the per-agent installation results:
+ *
+ *   Installing...
+ *
+ *   ✔ Cursor         (3 installed)
+ *   ✔ Claude Code    (2 installed, 1 skipped)
+ *   ⚠ Gemini CLI     error: …
+ */
+export function printInstalling(results: InstallResult[]): void {
+  console.log(`\n  ${chalk.white.bold('Installing...')}\n`);
+
+  for (const result of results) {
+    if (result.error) {
+      const label = chalk.hex('#F59E0B')('⚠');
+      console.log(`    ${label} ${chalk.white(result.agent.name)}  ${chalk.dim('error: ' + result.error)}`);
+      continue;
+    }
+
+    const label = brand.mint('✔');
+    const parts: string[] = [];
+
+    if (result.installed.length > 0) {
+      parts.push(`${result.installed.length} installed`);
+    }
+    if (result.skipped.length > 0) {
+      parts.push(`${result.skipped.length} skipped`);
+    }
+
+    const detail = parts.length > 0 ? chalk.dim(`  (${parts.join(', ')})`) : '';
+    console.log(`    ${label} ${chalk.white(result.agent.name)}${detail}`);
+  }
+}
+
+/**
+ * Prints the final success message.
+ */
+export function printSuccess(): void {
+  console.log('\n  ' + chalk.white('✨ NitroStack agent skills installed successfully.') + '\n');
+}
+
+/**
+ * Prints a warning when git is not available or the clone fails.
+ */
+export function printCloneError(message: string): void {
+  console.log(
+    `\n  ${chalk.hex('#F59E0B')('⚠')} ${chalk.dim('Agent skills skipped:')}\n` +
+    `    ${chalk.dim(message)}\n`,
+  );
+}

--- a/typescript/packages/core/NOTICE
+++ b/typescript/packages/core/NOTICE
@@ -41,10 +41,6 @@ jose
 Copyright (c) 2020 Filip Skokan
 Licensed under the MIT License
 
-better-sqlite3
-Copyright (c) 2016 Joshua Wise
-Licensed under the MIT License
-
 bcryptjs
 Copyright (c) 2012 Nevins Bartolomeo
 Licensed under the MIT License

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -50,7 +50,6 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
     "bcryptjs": "^2.4.3",
-    "better-sqlite3": "^11.8.1",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^4.21.2",
@@ -65,7 +64,6 @@
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
-    "@types/better-sqlite3": "^7.6.12",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",

--- a/typescript/packages/core/src/core/__tests__/di.test.ts
+++ b/typescript/packages/core/src/core/__tests__/di.test.ts
@@ -93,4 +93,49 @@ describe('DIContainer', () => {
         const l1 = container.resolve(Level1);
         expect(l1.l2.l3).toBeInstanceOf(Level3);
     });
+
+    it('should return all instantiated instances via getInstances()', () => {
+        class ServiceA { }
+        class ServiceB { }
+        
+        container.resolve(ServiceA);
+        container.resolve(ServiceB);
+        
+        const instances = container.getInstances();
+        expect(instances.length).toBe(2);
+        expect(instances.some((inst: any) => inst instanceof ServiceA)).toBe(true);
+        expect(instances.some((inst: any) => inst instanceof ServiceB)).toBe(true);
+    });
+
+    it('should eagerly instantiate all registered providers via instantiateAll()', () => {
+        class RegisteredA { }
+        class RegisteredB { }
+
+        container.register(RegisteredA);
+        container.register(RegisteredB);
+
+        // Nothing resolved yet
+        expect(container.getInstances().length).toBe(0);
+
+        container.instantiateAll();
+
+        const instances = container.getInstances();
+        expect(instances.length).toBe(2);
+        expect(instances.some((inst: any) => inst instanceof RegisteredA)).toBe(true);
+        expect(instances.some((inst: any) => inst instanceof RegisteredB)).toBe(true);
+    });
+
+    it('should skip providers that fail to resolve and log via the provided logger', () => {
+        class GoodService { }
+        // A string token with no provider/value registered cannot be resolved
+        container.register('missing-token' as any);
+        container.register(GoodService);
+
+        const logger = { error: jest.fn() };
+        expect(() => container.instantiateAll(logger)).not.toThrow();
+
+        // The good service is still instantiated despite the bad token
+        expect(container.getInstances().some((inst: any) => inst instanceof GoodService)).toBe(true);
+        expect(logger.error).toHaveBeenCalled();
+    });
 });

--- a/typescript/packages/core/src/core/__tests__/server.extended.test.ts
+++ b/typescript/packages/core/src/core/__tests__/server.extended.test.ts
@@ -44,7 +44,10 @@ jest.unstable_mockModule('../di/container.js', () => ({
     DIContainer: {
         getInstance: jest.fn().mockReturnValue({
             resolve: jest.fn(),
-            registerValue: jest.fn()
+            register: jest.fn(),
+            registerValue: jest.fn(),
+            getInstances: jest.fn().mockReturnValue([]),
+            instantiateAll: jest.fn()
         })
     }
 }));

--- a/typescript/packages/core/src/core/__tests__/server.test.ts
+++ b/typescript/packages/core/src/core/__tests__/server.test.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 jest.unstable_mockModule('@modelcontextprotocol/sdk/server/index.js', () => ({
     Server: jest.fn().mockImplementation(() => ({
         connect: jest.fn(),
+        close: jest.fn().mockResolvedValue(undefined as never),
         addTool: jest.fn(),
         addResource: jest.fn(),
         addPrompt: jest.fn(),
@@ -112,5 +113,502 @@ describe('NitroStackServer', () => {
 
         const mcpInstance = (McpServer as unknown as jest.Mock<any>).mock.results[0].value;
         expect(mcpInstance.connect).toHaveBeenCalled();
+    });
+
+    it('should invoke lifecycle hooks on resolved modules and services in order', async () => {
+        const order: string[] = [];
+
+        class HookService {
+            onModuleInit() {
+                order.push('service:init');
+            }
+            onApplicationBootstrap() {
+                order.push('service:bootstrap');
+            }
+            onModuleDestroy() {
+                order.push('service:destroy');
+            }
+            beforeApplicationShutdown(signal?: string) {
+                order.push(`service:beforeShutdown:${signal}`);
+            }
+            onApplicationShutdown(signal?: string) {
+                order.push(`service:shutdown:${signal}`);
+            }
+        }
+
+        @Module({
+            name: 'hook-module',
+            providers: [HookService]
+        })
+        class HookModule {
+            constructor(public service: HookService) {}
+
+            onModuleInit() {
+                order.push('module:init');
+            }
+            onApplicationBootstrap() {
+                order.push('module:bootstrap');
+            }
+            onModuleDestroy() {
+                order.push('module:destroy');
+            }
+            beforeApplicationShutdown(signal?: string) {
+                order.push(`module:beforeShutdown:${signal}`);
+            }
+            onApplicationShutdown(signal?: string) {
+                order.push(`module:shutdown:${signal}`);
+            }
+        }
+
+        // Clear DI container singleton to avoid registration conflicts
+        const { DIContainer: RealDI } = await import('../di/container.js');
+        RealDI.getInstance().clear();
+
+        // Create new server instance after clearing DI container
+        const localServer = new NitroStackServer();
+        localServer.module(HookModule);
+
+        await localServer.start();
+
+        // Exact startup order: all inits, then all bootstraps (before listen/connect)
+        expect(order).toEqual(['service:init', 'module:init', 'service:bootstrap', 'module:bootstrap']);
+
+        const mcpInstance = (McpServer as unknown as jest.Mock<any>).mock.results.at(-1)?.value;
+        expect(mcpInstance.connect).toHaveBeenCalled();
+
+        // Now stop with signal
+        order.length = 0;
+        await localServer.stop('SIGTERM');
+
+        // Exact stop order: destroys, beforeShutdowns, then shutdowns
+        expect(order).toEqual([
+            'service:destroy',
+            'module:destroy',
+            'service:beforeShutdown:SIGTERM',
+            'module:beforeShutdown:SIGTERM',
+            'service:shutdown:SIGTERM',
+            'module:shutdown:SIGTERM',
+        ]);
+    });
+
+    it('should continue teardown even if a shutdown hook throws an error', async () => {
+        const order: string[] = [];
+
+        class ThrowingService {
+            onModuleDestroy() {
+                order.push('throwing-service:destroy:before-throw');
+                throw new Error('Teardown crash!');
+            }
+            onApplicationShutdown() {
+                order.push('throwing-service:shutdown');
+            }
+        }
+
+        class NormalService {
+            onModuleDestroy() {
+                order.push('normal-service:destroy');
+            }
+            onApplicationShutdown() {
+                order.push('normal-service:shutdown');
+            }
+        }
+
+        @Module({
+            name: 'faulty-module',
+            providers: [ThrowingService, NormalService]
+        })
+        class FaultyModule {
+            constructor(public throwing: ThrowingService, public normal: NormalService) {}
+        }
+
+        const { DIContainer: RealDI } = await import('../di/container.js');
+        RealDI.getInstance().clear();
+
+        const localServer = new NitroStackServer();
+        localServer.module(FaultyModule);
+
+        await localServer.start();
+        
+        // Clear order log before stopping
+        order.length = 0;
+        
+        // Stop server, which should execute triggerLifecycleHook safely and not throw
+        await expect(localServer.stop('SIGTERM')).resolves.not.toThrow();
+
+        // Verify that subsequent destruction hook and shutdown hooks are still executed
+        expect(order).toEqual(
+            expect.arrayContaining([
+                'throwing-service:destroy:before-throw',
+                'normal-service:destroy',
+                'throwing-service:shutdown',
+                'normal-service:shutdown'
+            ])
+        );
+    });
+
+    it('should run onModuleInit for instances registered during module.start()', async () => {
+        const order: string[] = [];
+
+        class LateService {
+            onModuleInit() {
+                order.push('late:init');
+            }
+            onApplicationBootstrap() {
+                order.push('late:bootstrap');
+            }
+        }
+
+        @Module({
+            name: 'late-module',
+            providers: []
+        })
+        class LateModule {
+            onModuleInit() {
+                order.push('module:init');
+            }
+            onApplicationBootstrap() {
+                order.push('module:bootstrap');
+            }
+            async start() {
+                const { DIContainer: RealDI } = await import('../di/container.js');
+                RealDI.getInstance().register(LateService);
+                RealDI.getInstance().resolve(LateService);
+                order.push('module:start');
+            }
+        }
+
+        const { DIContainer: RealDI } = await import('../di/container.js');
+        RealDI.getInstance().clear();
+
+        const localServer = new NitroStackServer();
+        localServer.module(LateModule);
+
+        await localServer.start();
+
+        expect(order).toEqual([
+            'module:init',
+            'module:start',
+            'late:init',
+            'module:bootstrap',
+            'late:bootstrap',
+        ]);
+    });
+
+    it('should run onApplicationShutdown even if mcpServer.close throws', async () => {
+        const order: string[] = [];
+
+        @Module({
+            name: 'close-fail-module',
+            providers: []
+        })
+        class CloseFailModule {
+            onApplicationShutdown(signal?: string) {
+                order.push(`shutdown:${signal}`);
+            }
+        }
+
+        const { DIContainer: RealDI } = await import('../di/container.js');
+        RealDI.getInstance().clear();
+
+        const localServer = new NitroStackServer();
+        localServer.module(CloseFailModule);
+        await localServer.start();
+
+        const mcpInstance = (McpServer as unknown as jest.Mock<any>).mock.results.at(-1)?.value;
+        mcpInstance.close.mockRejectedValueOnce(new Error('close failed'));
+
+        await expect(localServer.stop('SIGTERM')).rejects.toThrow('close failed');
+        expect(order).toEqual(['shutdown:SIGTERM']);
+    });
+
+    it('should deduplicate instances to run hooks exactly once per instance', async () => {
+        const order: string[] = [];
+        const instance = {
+            onModuleInit() {
+                order.push('instance:init');
+            }
+        };
+
+        const { triggerLifecycleHook: trigger } = await import('../lifecycle.js');
+
+        // Pass duplicate instances in the array
+        await trigger([instance, instance, instance], 'onModuleInit');
+
+        expect(order).toEqual(['instance:init']);
+    });
+
+    it('should support function instances with lifecycle hooks', async () => {
+        const order: string[] = [];
+        const fnInstance = Object.assign(() => {}, {
+            onModuleInit() {
+                order.push('function:init');
+            }
+        });
+
+        const { triggerLifecycleHook: trigger } = await import('../lifecycle.js');
+
+        await trigger([fnInstance], 'onModuleInit');
+
+        expect(order).toEqual(['function:init']);
+    });
+
+    it('should not abort teardown when a throwing getter is hit in safe mode', async () => {
+        const order: string[] = [];
+
+        // Instance whose hook property throws on access (e.g. throwing getter / proxy)
+        const throwingGetterInstance = {};
+        Object.defineProperty(throwingGetterInstance, 'onApplicationShutdown', {
+            get() {
+                throw new Error('getter boom');
+            },
+            enumerable: true,
+        });
+
+        const normalInstance = {
+            onApplicationShutdown() {
+                order.push('normal:shutdown');
+            }
+        };
+
+        const logger = { error: jest.fn() };
+        const { triggerLifecycleHook: trigger } = await import('../lifecycle.js');
+
+        await expect(
+            trigger([throwingGetterInstance, normalInstance], 'onApplicationShutdown', { safe: true, logger })
+        ).resolves.not.toThrow();
+
+        // The throwing lookup is logged, and later instances still run
+        expect(logger.error).toHaveBeenCalled();
+        expect(order).toEqual(['normal:shutdown']);
+    });
+
+    it('should rethrow a throwing getter lookup when not in safe mode', async () => {
+        const throwingGetterInstance = {};
+        Object.defineProperty(throwingGetterInstance, 'onModuleInit', {
+            get() {
+                throw new Error('getter boom');
+            },
+            enumerable: true,
+        });
+
+        const { triggerLifecycleHook: trigger } = await import('../lifecycle.js');
+
+        await expect(
+            trigger([throwingGetterInstance], 'onModuleInit')
+        ).rejects.toThrow('getter boom');
+    });
+
+    it('should run shutdown hooks when an OS signal is received via enableShutdownHooks', async () => {
+        const order: string[] = [];
+
+        @Module({ name: 'signal-module', providers: [] })
+        class SignalModule {
+            beforeApplicationShutdown(signal?: string) {
+                order.push(`beforeShutdown:${signal}`);
+            }
+            onApplicationShutdown(signal?: string) {
+                order.push(`shutdown:${signal}`);
+            }
+        }
+
+        const { DIContainer: RealDI } = await import('../di/container.js');
+        RealDI.getInstance().clear();
+
+        const localServer = new NitroStackServer();
+        localServer.module(SignalModule);
+        await localServer.start();
+
+        const before = process.listenerCount('SIGTERM');
+        localServer.enableShutdownHooks(['SIGTERM']);
+        expect(process.listenerCount('SIGTERM')).toBe(before + 1);
+
+        // Emit the signal to trigger the registered handler
+        (process as NodeJS.EventEmitter).emit('SIGTERM');
+        await (localServer as any)._stopping;
+
+        expect(order).toEqual(['beforeShutdown:SIGTERM', 'shutdown:SIGTERM']);
+        // Handlers should be cleaned up after shutdown to avoid listener leaks
+        expect(process.listenerCount('SIGTERM')).toBe(before);
+    });
+
+    it('should not double-register signal handlers across enableShutdownHooks calls', async () => {
+        const { DIContainer: RealDI } = await import('../di/container.js');
+        RealDI.getInstance().clear();
+
+        const localServer = new NitroStackServer();
+        const before = process.listenerCount('SIGINT');
+
+        localServer.enableShutdownHooks(['SIGINT']);
+        localServer.enableShutdownHooks(['SIGINT']);
+        expect(process.listenerCount('SIGINT')).toBe(before + 1);
+
+        // Cleanup so the listener does not leak into other tests
+        await localServer.stop();
+        expect(process.listenerCount('SIGINT')).toBe(before);
+    });
+
+    it('should run init/bootstrap hooks for declared-but-uninjected providers and controllers', async () => {
+        const order: string[] = [];
+
+        class UnusedService {
+            onModuleInit() {
+                order.push('service:init');
+            }
+            onApplicationBootstrap() {
+                order.push('service:bootstrap');
+            }
+        }
+
+        class HookController {
+            @Tool({ name: 'hook-ctrl-tool', description: 'd', inputSchema: z.object({}) })
+            run() { }
+            onModuleInit() {
+                order.push('controller:init');
+            }
+            onApplicationBootstrap() {
+                order.push('controller:bootstrap');
+            }
+        }
+
+        @Module({
+            name: 'eager-module',
+            controllers: [HookController],
+            providers: [UnusedService]
+        })
+        class EagerModule { }
+
+        const { DIContainer: RealDI } = await import('../di/container.js');
+        RealDI.getInstance().clear();
+
+        const localServer = new NitroStackServer();
+        localServer.module(EagerModule);
+        await localServer.start();
+
+        expect(order).toEqual(
+            expect.arrayContaining([
+                'service:init',
+                'controller:init',
+                'service:bootstrap',
+                'controller:bootstrap'
+            ])
+        );
+        // Each hook must run exactly once per instance
+        expect(order.filter((o) => o === 'service:init')).toHaveLength(1);
+        expect(order.filter((o) => o === 'controller:init')).toHaveLength(1);
+    });
+
+    it('should run teardown hooks only once when stop() is called multiple times', async () => {
+        const order: string[] = [];
+
+        @Module({ name: 'idempotent-module', providers: [] })
+        class IdempotentModule {
+            onModuleDestroy() {
+                order.push('destroy');
+            }
+            onApplicationShutdown() {
+                order.push('shutdown');
+            }
+        }
+
+        const { DIContainer: RealDI } = await import('../di/container.js');
+        RealDI.getInstance().clear();
+
+        const localServer = new NitroStackServer();
+        localServer.module(IdempotentModule);
+        await localServer.start();
+
+        order.length = 0;
+
+        // Concurrent + repeated calls should share a single teardown
+        await Promise.all([localServer.stop('SIGTERM'), localServer.stop('SIGTERM')]);
+        await localServer.stop('SIGTERM');
+
+        expect(order).toEqual(['destroy', 'shutdown']);
+    });
+
+    it('should continue teardown when a module stop() throws', async () => {
+        const order: string[] = [];
+
+        @Module({ name: 'faulty-stop-module', providers: [] })
+        class FaultyStopModule {
+            async stop() {
+                order.push('faulty:stop');
+                throw new Error('module stop failed');
+            }
+            onApplicationShutdown() {
+                order.push('faulty:shutdown');
+            }
+        }
+
+        @Module({ name: 'normal-stop-module', providers: [] })
+        class NormalStopModule {
+            async stop() {
+                order.push('normal:stop');
+            }
+            onApplicationShutdown() {
+                order.push('normal:shutdown');
+            }
+        }
+
+        const { DIContainer: RealDI } = await import('../di/container.js');
+        RealDI.getInstance().clear();
+
+        const localServer = new NitroStackServer();
+        localServer.module(FaultyStopModule);
+        localServer.module(NormalStopModule);
+        await localServer.start();
+
+        order.length = 0;
+
+        // A throwing module.stop() must not abort teardown of the other modules
+        await expect(localServer.stop('SIGTERM')).resolves.not.toThrow();
+
+        expect(order).toEqual(
+            expect.arrayContaining([
+                'faulty:stop',
+                'normal:stop',
+                'faulty:shutdown',
+                'normal:shutdown'
+            ])
+        );
+    });
+
+    it('should use a single controller instance for tools and lifecycle hooks via server.module()', async () => {
+        let constructed = 0;
+
+        // Non-@Injectable controller registered via server.module()
+        class CtrlWithHook {
+            value = 0;
+            constructor() {
+                constructed++;
+            }
+            @Tool({ name: 'get-value', description: 'd', inputSchema: z.object({}) })
+            getValue() {
+                return this.value;
+            }
+            onModuleInit() {
+                this.value = 42;
+            }
+        }
+
+        @Module({
+            name: 'single-instance-module',
+            controllers: [CtrlWithHook]
+        })
+        class SingleInstanceModule { }
+
+        const { DIContainer: RealDI } = await import('../di/container.js');
+        RealDI.getInstance().clear();
+
+        const localServer = new NitroStackServer();
+        localServer.module(SingleInstanceModule);
+        await localServer.start();
+
+        // Exactly one instance was constructed (no tool-vs-hook divergence)
+        expect(constructed).toBe(1);
+
+        // The instance backing the tools is the same one that received onModuleInit
+        const resolved = RealDI.getInstance().resolve(CtrlWithHook) as any;
+        expect(resolved.value).toBe(42);
     });
 });

--- a/typescript/packages/core/src/core/app-decorator.ts
+++ b/typescript/packages/core/src/core/app-decorator.ts
@@ -94,6 +94,13 @@ export interface McpAppOptions {
       basePath?: string;
     };
   };
+
+  /**
+   * Register OS signal handlers (SIGTERM/SIGINT) so the application shuts down
+   * gracefully and runs the shutdown lifecycle hooks. Enabled by default; set to
+   * false if the host process manages its own shutdown.
+   */
+  shutdownHooks?: boolean;
 }
 
 /**
@@ -446,6 +453,12 @@ export class McpApplicationFactory {
     };
     serverInternal._transportType = transportType;
     serverInternal._transportOptions = transportOptions;
+
+    // Register graceful-shutdown signal handlers so shutdown lifecycle hooks run
+    // on SIGTERM/SIGINT. Opt-out via `shutdownHooks: false`.
+    if (options.shutdownHooks !== false) {
+      server.enableShutdownHooks();
+    }
 
     return server;
   }

--- a/typescript/packages/core/src/core/builders.ts
+++ b/typescript/packages/core/src/core/builders.ts
@@ -9,6 +9,7 @@ import {
   extractPrompts,
   getWidgetMetadata,
   getInitialToolMetadata,
+  getControllerPrefix,
   ToolOptions,
   ResourceOptions,
   PromptOptions,
@@ -97,6 +98,7 @@ export function buildTool(
 export function buildTools(controllerInstance: ControllerInstance): Tool[] {
   const constructor = Object.getPrototypeOf(controllerInstance).constructor as ControllerClass;
   const toolMetadata = extractTools(constructor);
+  const prefix = getControllerPrefix(constructor);
 
   return toolMetadata.map(({ methodName, options }) => {
     const prototype = Object.getPrototypeOf(controllerInstance) as object;
@@ -106,7 +108,15 @@ export function buildTools(controllerInstance: ControllerInstance): Tool[] {
     // Check for initial tool decorator
     const isInitial = getInitialToolMetadata(prototype, methodName);
 
-    return buildTool(controllerInstance, methodName, options, widgetMeta, isInitial);
+    // Apply the controller prefix without mutating the shared options object
+    // stored in class metadata. Skip when the name is already prefixed.
+    const name =
+      prefix && !options.name.startsWith(`${prefix}_`)
+        ? `${prefix}_${options.name}`
+        : options.name;
+    const toolOptions = name === options.name ? options : { ...options, name };
+
+    return buildTool(controllerInstance, methodName, toolOptions, widgetMeta, isInitial);
   });
 }
 

--- a/typescript/packages/core/src/core/builders.ts
+++ b/typescript/packages/core/src/core/builders.ts
@@ -20,8 +20,6 @@ import { getInterceptorMetadata } from './interceptors/interceptor.decorator.js'
 import { getPipeMetadata } from './pipes/pipe.decorator.js';
 import { getExceptionFilterMetadata } from './filters/exception-filter.decorator.js';
 import { DIContainer } from './di/container.js';
-import { isInjectable } from './di/injectable.decorator.js';
-
 /**
  * Controller instance type
  */
@@ -214,8 +212,12 @@ export function buildController(controller: ControllerClass): {
   const container = DIContainer.getInstance();
 
   // Create controller instance (with DI if available)
+  // Resolve from DI whenever the controller is registered so tools bind to the
+  // same singleton that receives lifecycle hooks (via instantiateAll). Falling
+  // back to `new controller()` only for unregistered controllers avoids the
+  // double-instance divergence for non-@Injectable controllers.
   let instance: ControllerInstance;
-  if (isInjectable(controller) && container.has(controller)) {
+  if (container.has(controller)) {
     instance = container.resolve<ControllerInstance>(controller);
   } else {
     instance = new controller();

--- a/typescript/packages/core/src/core/decorators.ts
+++ b/typescript/packages/core/src/core/decorators.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import { z } from 'zod';
 import type { JsonValue, ClassConstructor, ResourceAnnotations, ToolAnnotations } from './types.js';
 import type { TaskSupportLevel } from './task.js';
+import { DIContainer } from './di/container.js';
 
 /**
  * Metadata keys for decorators
@@ -11,6 +12,7 @@ export const WIDGET_METADATA = Symbol('widget:metadata');
 export const RESOURCE_METADATA = Symbol('resource:metadata');
 export const PROMPT_METADATA = Symbol('prompt:metadata');
 export const GUARDS_METADATA = Symbol('guards:metadata');
+export const CONTROLLER_METADATA = Symbol('controller:metadata');
 
 /**
  * Example data for tools/resources
@@ -135,8 +137,10 @@ interface ToolMetadataEntry {
  */
 export function Tool(options: ToolOptions): MethodDecorator {
   return function (target: MethodDecoratorTarget, propertyKey: string | symbol, descriptor: PropertyDescriptor): PropertyDescriptor {
-    // Get existing tools or create new array
-    const existingTools: ToolMetadataEntry[] = Reflect.getMetadata(TOOL_METADATA, target.constructor) || [];
+    // Get existing tools or create new array. Clone to avoid mutating a parent
+    // class's metadata array when subclassing (Reflect.getMetadata walks the
+    // prototype chain, so a shared reference would pollute the parent).
+    const existingTools: ToolMetadataEntry[] = [...(Reflect.getMetadata(TOOL_METADATA, target.constructor) || [])];
 
     // Add this tool
     existingTools.push({
@@ -215,6 +219,64 @@ export function Widget(routePath: string | WidgetRouteMetadata): MethodDecorator
 }
 
 /**
+ * Controller decorator options
+ */
+export interface ControllerOptions {
+  /**
+   * Optional prefix applied to every @Tool name defined in this controller.
+   * For example, `@Controller('github')` turns a tool named `create_issue`
+   * into `github_create_issue`.
+   */
+  prefix?: string;
+}
+
+/**
+ * Controller metadata stored on the class
+ */
+interface ControllerMetadata {
+  prefix?: string;
+}
+
+/**
+ * Controller decorator - Marks a class as a controller, auto-registers it in
+ * the DI container, and optionally prefixes all of its @Tool names.
+ *
+ * @example
+ * ```typescript
+ * @Controller('github')
+ * export class GitHubController {
+ *   @Tool({ name: 'create_issue', ... })
+ *   async createIssue() { } // exposed as `github_create_issue`
+ * }
+ * ```
+ */
+export function Controller(prefixOrOptions?: string | ControllerOptions): ClassDecorator {
+  const options: ControllerMetadata =
+    typeof prefixOrOptions === 'string'
+      ? { prefix: prefixOrOptions }
+      : { prefix: prefixOrOptions?.prefix };
+
+  return (target: object) => {
+    Reflect.defineMetadata(CONTROLLER_METADATA, options, target);
+
+    // Auto-register in the DI container so the tool-bound instance is the same
+    // singleton that receives lifecycle hooks (mirrors @Injectable behavior).
+    const container = DIContainer.getInstance();
+    if (!container.has(target as ClassConstructor)) {
+      container.register(target as ClassConstructor);
+    }
+  };
+}
+
+/**
+ * Get the tool-name prefix declared via @Controller, if any
+ */
+export function getControllerPrefix(target: ClassConstructor): string | undefined {
+  const metadata: ControllerMetadata | undefined = Reflect.getMetadata(CONTROLLER_METADATA, target);
+  return metadata?.prefix;
+}
+
+/**
  * Resource metadata stored on class
  */
 interface ResourceMetadataEntry {
@@ -239,7 +301,7 @@ interface ResourceMetadataEntry {
  */
 export function Resource(options: ResourceOptions): MethodDecorator {
   return function (target: MethodDecoratorTarget, propertyKey: string | symbol, descriptor: PropertyDescriptor): PropertyDescriptor {
-    const existingResources: ResourceMetadataEntry[] = Reflect.getMetadata(RESOURCE_METADATA, target.constructor) || [];
+    const existingResources: ResourceMetadataEntry[] = [...(Reflect.getMetadata(RESOURCE_METADATA, target.constructor) || [])];
 
     existingResources.push({
       methodName: String(propertyKey),
@@ -276,7 +338,7 @@ interface PromptMetadataEntry {
  */
 export function Prompt(options: PromptOptions): MethodDecorator {
   return function (target: MethodDecoratorTarget, propertyKey: string | symbol, descriptor: PropertyDescriptor): PropertyDescriptor {
-    const existingPrompts: PromptMetadataEntry[] = Reflect.getMetadata(PROMPT_METADATA, target.constructor) || [];
+    const existingPrompts: PromptMetadataEntry[] = [...(Reflect.getMetadata(PROMPT_METADATA, target.constructor) || [])];
 
     existingPrompts.push({
       methodName: String(propertyKey),

--- a/typescript/packages/core/src/core/decorators/__tests__/decorators.test.ts
+++ b/typescript/packages/core/src/core/decorators/__tests__/decorators.test.ts
@@ -1,10 +1,15 @@
-import { jest, describe, it, expect } from '@jest/globals';
+import { jest, describe, it, expect, afterEach } from '@jest/globals';
 import 'reflect-metadata';
 import { z } from 'zod';
 import {
-    Tool, Resource, Prompt, Widget,
-    extractTools, extractResources, extractPrompts, getWidgetMetadata
+    Tool, Resource, Prompt, Widget, Controller,
+    extractTools, extractResources, extractPrompts, getWidgetMetadata, getControllerPrefix
 } from '../../decorators';
+import { buildTools } from '../../builders';
+import { DIContainer } from '../../di/container';
+import { OnEvent, getEventHandlers } from '../../events/event.decorator';
+import { Inject, getInjectTokens } from '../../di/injectable.decorator';
+import { Body, getParamPipesMetadata } from '../../pipes/pipe.decorator';
 
 describe('Core Decorators', () => {
     describe('@Tool', () => {
@@ -134,5 +139,197 @@ describe('Core Decorators', () => {
                 return Bad;
             }).toThrow(/requires a non-empty string "route"/);
         });
+    });
+});
+
+describe('@Controller', () => {
+    afterEach(() => {
+        DIContainer.getInstance().clear();
+    });
+
+    it('should auto-register the class in the DI container', () => {
+        @Controller()
+        class BareController {
+            @Tool({ name: 'noop', description: 'd', inputSchema: z.string() })
+            noop() { }
+        }
+
+        expect(DIContainer.getInstance().has(BareController)).toBe(true);
+    });
+
+    it('should expose the prefix via getControllerPrefix (string form)', () => {
+        @Controller('github')
+        class GitHubController {
+            @Tool({ name: 'create_issue', description: 'd', inputSchema: z.string() })
+            createIssue() { }
+        }
+
+        expect(getControllerPrefix(GitHubController)).toBe('github');
+    });
+
+    it('should expose the prefix via getControllerPrefix (options form)', () => {
+        @Controller({ prefix: 'slack' })
+        class SlackController {
+            @Tool({ name: 'send', description: 'd', inputSchema: z.string() })
+            send() { }
+        }
+
+        expect(getControllerPrefix(SlackController)).toBe('slack');
+    });
+
+    it('should return undefined when no prefix is set', () => {
+        @Controller()
+        class NoPrefixController {
+            @Tool({ name: 'x', description: 'd', inputSchema: z.string() })
+            x() { }
+        }
+
+        expect(getControllerPrefix(NoPrefixController)).toBeUndefined();
+    });
+
+    it('should prefix tool names when building tools', () => {
+        @Controller('github')
+        class GitHubController {
+            @Tool({ name: 'create_issue', description: 'd', inputSchema: z.string() })
+            createIssue() { }
+        }
+
+        const tools = buildTools(new GitHubController() as any);
+        expect(tools.map(t => t.name)).toEqual(['github_create_issue']);
+    });
+
+    it('should not double-prefix a tool name that already starts with the prefix', () => {
+        @Controller('github')
+        class GitHubController {
+            @Tool({ name: 'github_create_issue', description: 'd', inputSchema: z.string() })
+            createIssue() { }
+        }
+
+        const tools = buildTools(new GitHubController() as any);
+        expect(tools.map(t => t.name)).toEqual(['github_create_issue']);
+    });
+
+    it('should not mutate the stored tool metadata when prefixing', () => {
+        @Controller('github')
+        class GitHubController {
+            @Tool({ name: 'create_issue', description: 'd', inputSchema: z.string() })
+            createIssue() { }
+        }
+
+        buildTools(new GitHubController() as any);
+        // The original metadata should remain unprefixed so repeated builds are stable.
+        expect(extractTools(GitHubController)[0].options.name).toBe('create_issue');
+        const secondBuild = buildTools(new GitHubController() as any);
+        expect(secondBuild.map(t => t.name)).toEqual(['github_create_issue']);
+    });
+
+    it('should leave tool names untouched when no prefix is set', () => {
+        @Controller()
+        class PlainController {
+            @Tool({ name: 'do_thing', description: 'd', inputSchema: z.string() })
+            doThing() { }
+        }
+
+        const tools = buildTools(new PlainController() as any);
+        expect(tools.map(t => t.name)).toEqual(['do_thing']);
+    });
+});
+
+describe('Class Inheritance - metadata pollution', () => {
+    afterEach(() => {
+        DIContainer.getInstance().clear();
+    });
+
+    it('should not pollute parent @Tool metadata when subclassing', () => {
+        class Parent {
+            @Tool({ name: 'parent_tool', description: 'd', inputSchema: z.string() })
+            parentMethod() { }
+        }
+
+        class Child extends Parent {
+            @Tool({ name: 'child_tool', description: 'd', inputSchema: z.string() })
+            childMethod() { }
+        }
+
+        expect(extractTools(Parent).map(t => t.options.name)).toEqual(['parent_tool']);
+        expect(extractTools(Child).map(t => t.options.name)).toEqual(['parent_tool', 'child_tool']);
+    });
+
+    it('should not pollute parent @Resource metadata when subclassing', () => {
+        class Parent {
+            @Resource({ uri: 'p://res', name: 'parent_res', description: 'd' })
+            parentRes() { }
+        }
+
+        class Child extends Parent {
+            @Resource({ uri: 'c://res', name: 'child_res', description: 'd' })
+            childRes() { }
+        }
+
+        expect(extractResources(Parent).map(r => r.options.name)).toEqual(['parent_res']);
+        expect(extractResources(Child).map(r => r.options.name)).toEqual(['parent_res', 'child_res']);
+    });
+
+    it('should not pollute parent @Prompt metadata when subclassing', () => {
+        class Parent {
+            @Prompt({ name: 'parent_prompt', description: 'd' })
+            parentPrompt() { }
+        }
+
+        class Child extends Parent {
+            @Prompt({ name: 'child_prompt', description: 'd' })
+            childPrompt() { }
+        }
+
+        expect(extractPrompts(Parent).map(p => p.options.name)).toEqual(['parent_prompt']);
+        expect(extractPrompts(Child).map(p => p.options.name)).toEqual(['parent_prompt', 'child_prompt']);
+    });
+
+    it('should not pollute parent @OnEvent metadata when subclassing', () => {
+        class Parent {
+            @OnEvent('parent.event')
+            onParent() { }
+        }
+
+        class Child extends Parent {
+            @OnEvent('child.event')
+            onChild() { }
+        }
+
+        expect(getEventHandlers(Parent).map(h => h.event)).toEqual(['parent.event']);
+        expect(getEventHandlers(Child).map(h => h.event)).toEqual(['parent.event', 'child.event']);
+    });
+
+    it('should not pollute parent @Inject metadata when subclassing', () => {
+        class Parent {
+            constructor(@Inject('PARENT_TOKEN') public parentDep: unknown) { }
+        }
+
+        class Child extends Parent {
+            constructor(@Inject('CHILD_TOKEN') public childDep: unknown) {
+                super(childDep);
+            }
+        }
+
+        expect(getInjectTokens(Parent)).toEqual(['PARENT_TOKEN']);
+        expect(getInjectTokens(Child)[0]).toBe('CHILD_TOKEN');
+    });
+
+    it('should not pollute parent @Body metadata when a subclass overrides a method', () => {
+        class Parent {
+            @Tool({ name: 'p', description: 'd', inputSchema: z.string() })
+            handle(@Body() _input: unknown, _extra: unknown) { }
+        }
+
+        class Child extends Parent {
+            // Overrides the same method name; @Body keys metadata on
+            // (prototype, propertyKey) and getMetadata walks the prototype chain,
+            // so without cloning the child would mutate the parent's param object.
+            @Tool({ name: 'c', description: 'd', inputSchema: z.string() })
+            handle(@Body() _second: unknown, @Body() _third: unknown) { }
+        }
+
+        expect(Object.keys(getParamPipesMetadata(Parent.prototype, 'handle'))).toHaveLength(1);
+        expect(Object.keys(getParamPipesMetadata(Child.prototype, 'handle')).length).toBeGreaterThan(1);
     });
 });

--- a/typescript/packages/core/src/core/di/container.ts
+++ b/typescript/packages/core/src/core/di/container.ts
@@ -124,6 +124,38 @@ export class DIContainer {
   }
 
   /**
+   * Get all currently instantiated objects in the container
+   */
+  getInstances(): unknown[] {
+    return Array.from(this.instances.values());
+  }
+
+  /**
+   * Eagerly instantiate every registered provider.
+   *
+   * The container resolves lazily, so declared-but-uninjected providers (and
+   * controllers) would otherwise never be constructed and would miss lifecycle
+   * hooks. This mirrors NestJS's eager singleton instantiation. A provider that
+   * fails to resolve is logged (if a logger is supplied) and skipped so one bad
+   * token does not abort startup.
+   *
+   * @param logger - Optional logger for resolution failures
+   */
+  instantiateAll(logger?: { error(msg: string, meta?: unknown): void }): void {
+    for (const token of this.providers.keys()) {
+      if (this.instances.has(token)) {
+        continue;
+      }
+      try {
+        this.resolve(token);
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        logger?.error(`Failed to instantiate provider "${String(token)}": ${errMsg}`, { error });
+      }
+    }
+  }
+
+  /**
    * Clear all registrations (useful for testing)
    */
   clear(): void {

--- a/typescript/packages/core/src/core/di/injectable.decorator.ts
+++ b/typescript/packages/core/src/core/di/injectable.decorator.ts
@@ -74,7 +74,8 @@ export function Injectable(options?: InjectableOptions): ClassDecorator {
  */
 export function Inject(token: InjectionToken): ParameterDecorator {
   return (target: object, propertyKey: string | symbol | undefined, parameterIndex: number) => {
-    const existingTokens: InjectionToken[] = Reflect.getMetadata(INJECT_KEY, target) || [];
+    // Clone to avoid mutating a parent class's inject-token array when subclassing.
+    const existingTokens: InjectionToken[] = [...(Reflect.getMetadata(INJECT_KEY, target) || [])];
     existingTokens[parameterIndex] = token;
     Reflect.defineMetadata(INJECT_KEY, existingTokens, target);
   };

--- a/typescript/packages/core/src/core/events/event.decorator.ts
+++ b/typescript/packages/core/src/core/events/event.decorator.ts
@@ -39,7 +39,8 @@ interface EventHandlerMetadata {
 export function OnEvent(event: string): MethodDecorator {
   return (target: object, propertyKey: string | symbol, descriptor: PropertyDescriptor) => {
     const targetWithConstructor = target as { constructor: object };
-    const existingHandlers = Reflect.getMetadata(EVENT_HANDLER_KEY, targetWithConstructor.constructor) || [];
+    // Clone to avoid mutating a parent class's handler array when subclassing.
+    const existingHandlers = [...(Reflect.getMetadata(EVENT_HANDLER_KEY, targetWithConstructor.constructor) || [])];
     existingHandlers.push({
       event,
       methodName: propertyKey,

--- a/typescript/packages/core/src/core/index.ts
+++ b/typescript/packages/core/src/core/index.ts
@@ -90,6 +90,7 @@ export {
   getWidgetMetadata,
   getGuardsMetadata,
   InitialTool,
+  getInitialToolMetadata,
 } from './decorators.js';
 
 export type {

--- a/typescript/packages/core/src/core/index.ts
+++ b/typescript/packages/core/src/core/index.ts
@@ -82,6 +82,8 @@ export {
   Widget,
   Resource as ResourceDecorator,
   Prompt as PromptDecorator,
+  Controller as ControllerDecorator,
+  getControllerPrefix,
   extractTools,
   extractResources,
   extractPrompts,
@@ -95,6 +97,7 @@ export type {
   ToolInvocationMessages,
   ResourceOptions,
   PromptOptions,
+  ControllerOptions,
   WidgetCspOptions,
   WidgetRouteMetadata,
 } from './decorators.js';

--- a/typescript/packages/core/src/core/index.ts
+++ b/typescript/packages/core/src/core/index.ts
@@ -193,6 +193,18 @@ export type { ConfigModuleOptions } from './config-module.js';
 export { McpApp, McpApplicationFactory, getMcpAppMetadata } from './app-decorator.js';
 export type { McpAppOptions } from './app-decorator.js';
 
+// ========== V3 Lifecycle Hooks ==========
+export { triggerLifecycleHook } from './lifecycle.js';
+export type {
+  OnModuleInit,
+  OnApplicationBootstrap,
+  OnModuleDestroy,
+  BeforeApplicationShutdown,
+  OnApplicationShutdown,
+  LifecycleHookName,
+  LifecycleHookOptions,
+} from './lifecycle.js';
+
 // ========== MCP Apps / OpenAI Apps SDK Constants ==========
 /**
  * MIME type for MCP Apps widgets

--- a/typescript/packages/core/src/core/lifecycle.ts
+++ b/typescript/packages/core/src/core/lifecycle.ts
@@ -1,0 +1,105 @@
+/**
+ * NitroStack Lifecycle Interfaces
+ *
+ * NestJS-style lifecycle hook interfaces for modules, controllers, and providers.
+ */
+
+export interface OnModuleInit {
+  onModuleInit(): Promise<void> | void;
+}
+
+export interface OnApplicationBootstrap {
+  onApplicationBootstrap(): Promise<void> | void;
+}
+
+export interface OnModuleDestroy {
+  onModuleDestroy(): Promise<void> | void;
+}
+
+export interface BeforeApplicationShutdown {
+  beforeApplicationShutdown(signal?: string): Promise<void> | void;
+}
+
+export interface OnApplicationShutdown {
+  onApplicationShutdown(signal?: string): Promise<void> | void;
+}
+
+export type LifecycleHookName =
+  | 'onModuleInit'
+  | 'onApplicationBootstrap'
+  | 'onModuleDestroy'
+  | 'beforeApplicationShutdown'
+  | 'onApplicationShutdown';
+
+export type LifecycleHookOptions = {
+  safe?: boolean;
+  logger?: { error(msg: string, meta?: unknown): void };
+};
+
+function getInstanceLabel(instance: object | ((...args: unknown[]) => unknown)): string {
+  if (typeof instance === 'function') {
+    return instance.name || 'Function';
+  }
+  const ctor = instance.constructor;
+  if (typeof ctor === 'function' && ctor !== Object && ctor.name) {
+    return ctor.name;
+  }
+  return 'Object';
+}
+
+/**
+ * Triggers a lifecycle hook sequentially across all instances that implement it.
+ *
+ * Note: callers typically pass `DIContainer.getInstances()`, which includes every
+ * resolved DI entry -- providers, controllers, modules, and values registered via
+ * `registerValue()` (e.g. the logger or the server itself). Only instances that
+ * actually expose a matching hook method are invoked; everything else (primitives,
+ * plain values without the hook) is skipped. Keep this in mind if a registered
+ * value coincidentally defines a method named like a lifecycle hook.
+ *
+ * @param instances Array of resolved instances to check
+ * @param hookName Name of the hook method (e.g. 'onModuleInit')
+ * @param options Optional safe-mode / logger settings
+ * @param args Arguments to pass to the hook method
+ */
+export async function triggerLifecycleHook(
+  instances: unknown[],
+  hookName: LifecycleHookName,
+  options?: LifecycleHookOptions,
+  ...args: unknown[]
+): Promise<void> {
+  const isSafe = options?.safe ?? false;
+  const logger = options?.logger;
+
+  // Deduplicate instances to prevent executing hooks multiple times on aliased/multi-token registrations
+  const uniqueInstances = Array.from(new Set(instances));
+
+  for (const instance of uniqueInstances) {
+    // Only the cheap, non-throwing type guard stays outside the try. The
+    // `hookName in instance` check and the property read can trigger Proxy traps
+    // or throwing getters, so they must run inside the try to respect safe mode.
+    if (!instance || (typeof instance !== 'object' && typeof instance !== 'function')) {
+      continue;
+    }
+
+    try {
+      if (!(hookName in instance)) {
+        continue;
+      }
+      const hookMethod = (instance as Record<string, unknown>)[hookName];
+      if (typeof hookMethod !== 'function') {
+        continue;
+      }
+      await hookMethod.apply(instance, args);
+    } catch (error) {
+      if (!isSafe) {
+        throw error;
+      }
+      const errMsg = error instanceof Error ? error.message : String(error);
+      logger?.error(
+        `Failed to execute lifecycle hook ${hookName} on ${getInstanceLabel(instance)}: ${errMsg}`,
+        { error }
+      );
+    }
+  }
+}

--- a/typescript/packages/core/src/core/pipes/pipe.decorator.ts
+++ b/typescript/packages/core/src/core/pipes/pipe.decorator.ts
@@ -61,7 +61,8 @@ export function Body(...pipes: PipeConstructor[]): ParameterDecorator {
   return (target: object, propertyKey: string | symbol | undefined, parameterIndex: number) => {
     if (!propertyKey) return;
     
-    const existingParams = Reflect.getMetadata(PARAM_PIPES_KEY, target, propertyKey) || {};
+    // Clone to avoid mutating a parent class's param-pipe object when subclassing.
+    const existingParams = { ...(Reflect.getMetadata(PARAM_PIPES_KEY, target, propertyKey) || {}) };
     existingParams[parameterIndex] = {
       type: 'body',
       pipes,

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -34,7 +34,7 @@ import { ToolExecutionError, ValidationError, ResourceNotFoundError, PromptNotFo
 import { v4 as uuidv4 } from 'uuid';
 import { isModule, getModuleMetadata } from './module.js';
 import { buildController } from './builders.js';
-import { DIContainer } from './di/container.js';
+import { DIContainer, type InjectionToken } from './di/container.js';
 import {
   TaskManager,
   TaskContext,
@@ -44,6 +44,7 @@ import {
   TaskAlreadyTerminalError,
   TaskAugmentationRequiredError,
 } from './task.js';
+import { triggerLifecycleHook } from './lifecycle.js';
 
 /**
  * Controller instance type
@@ -53,10 +54,10 @@ interface ControllerInstance {
 }
 
 /**
- * Module instance with lifecycle hooks
+ * Module instance with NitroStack start/stop hooks
+ * (NestJS-style init/destroy/shutdown hooks are discovered via DI getInstances())
  */
 interface ModuleInstance {
-  onModuleInit?(): Promise<void> | void;
   start?(): Promise<void> | void;
   stop?(): Promise<void> | void;
 }
@@ -128,6 +129,12 @@ export class NitroStackServer {
 
   /** Task manager for MCP Tasks support */
   private taskManager: TaskManager;
+
+  /** Registered OS signal handlers for graceful shutdown (see enableShutdownHooks) */
+  private _shutdownSignalHandlers: Array<{ signal: NodeJS.Signals; handler: () => void }> = [];
+
+  /** Guards stop() so double signals / repeated calls don't re-run teardown */
+  private _stopping?: Promise<void>;
 
   constructor(config?: McpServerConfig) {
     // Default config if not provided (e.g., when instantiated by DI container)
@@ -540,11 +547,33 @@ export class NitroStackServer {
 
     this.logger.info(`Registering module: ${metadata.name}`);
 
+    // Register providers in DI so declared-but-uninjected providers are still
+    // instantiated during start() (via instantiateAll) and run lifecycle hooks,
+    // matching the McpApplicationFactory path.
+    const providers = metadata.providers || [];
+    for (const provider of providers) {
+      if (typeof provider === 'function') {
+        DIContainer.getInstance().register(provider as ClassConstructor);
+      } else if (provider && typeof provider === 'object' && 'provide' in provider) {
+        const token = provider.provide as InjectionToken;
+        if (provider.useValue !== undefined) {
+          DIContainer.getInstance().registerValue(token, provider.useValue);
+        } else if (provider.useClass) {
+          DIContainer.getInstance().register(token, provider.useClass);
+        }
+      }
+    }
+
     // Process all controllers in the module
     const controllers = metadata.controllers || [];
 
     for (const controller of controllers) {
       this.logger.info(`  Processing controller: ${(controller as ClassConstructor).name}`);
+
+      // Register the controller in DI so it is instantiated during start()
+      // (via instantiateAll) and participates in lifecycle hooks, matching the
+      // McpApplicationFactory path.
+      DIContainer.getInstance().register(controller as ClassConstructor);
 
       // Build all tools, resources, and prompts from controller
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1066,13 +1095,18 @@ export class NitroStackServer {
     this._transportType = transportType;
     this.logger.debug(`NitroStackServer.start(): NODE_ENV=${process.env.NODE_ENV}, MCP_TRANSPORT_TYPE=${explicitTransport}, transportType=${transportType}`);
 
-    // Call onModuleInit for all modules
+    // Resolve all modules so they (and their dependencies) are initialized in the DI container
     for (const moduleClass of this.modules) {
-      const moduleInstance = DIContainer.getInstance().resolve<ModuleInstance>(moduleClass);
-      if (moduleInstance.onModuleInit) {
-        await moduleInstance.onModuleInit();
-      }
+      DIContainer.getInstance().resolve<ModuleInstance>(moduleClass);
     }
+
+    // Eagerly instantiate all registered providers/controllers so their lifecycle
+    // hooks fire even when they aren't injected anywhere (NestJS-style singletons).
+    DIContainer.getInstance().instantiateAll(this.logger);
+
+    // Call onModuleInit for currently resolved instances (NestJS: after DI resolution)
+    const initializedInstances = new Set(DIContainer.getInstance().getInstances());
+    await triggerLifecycleHook([...initializedInstances], 'onModuleInit');
 
     // If HTTP transport is needed (dual or http mode), set it up BEFORE calling module.start()
     // This allows modules like OAuthModule to register endpoints/middleware on the HTTP server
@@ -1121,6 +1155,16 @@ export class NitroStackServer {
         await moduleInstance.start();
       }
     }
+
+    // Init any instances registered during module.start() that missed the first pass
+    const allInstances = DIContainer.getInstance().getInstances();
+    const lateInstances = allInstances.filter((instance) => !initializedInstances.has(instance));
+    if (lateInstances.length > 0) {
+      await triggerLifecycleHook(lateInstances, 'onModuleInit');
+    }
+
+    // NestJS: onApplicationBootstrap runs after init, before the app accepts connections
+    await triggerLifecycleHook(DIContainer.getInstance().getInstances(), 'onApplicationBootstrap');
 
     // Start HTTP listener and attach legacy SSE routes ONLY AFTER dynamic modules have finished starting
     if ((transportType === 'dual' || transportType === 'http') && this._httpTransport) {
@@ -1397,15 +1441,81 @@ export class NitroStackServer {
   }
 
   /**
-   * Stop the server
+   * Register OS signal handlers so the server shuts down gracefully, running the
+   * NestJS-style shutdown lifecycle hooks (beforeApplicationShutdown /
+   * onApplicationShutdown) with the received signal.
+   *
+   * Opt-in (like NestJS `enableShutdownHooks`) to avoid attaching process
+   * listeners for consumers that manage their own shutdown. Safe to call more
+   * than once; handlers are only attached once per signal.
+   *
+   * @param signals - Signals to listen for (default: SIGTERM, SIGINT)
    */
-  async stop(): Promise<void> {
+  enableShutdownHooks(signals: NodeJS.Signals[] = ['SIGTERM', 'SIGINT']): this {
+    for (const signal of signals) {
+      if (this._shutdownSignalHandlers.some((h) => h.signal === signal)) {
+        continue;
+      }
+      const handler = () => {
+        // stop() is idempotent, so repeated signals are safe.
+        this.stop(signal).catch((error) => {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          this.logger.error(`Error during ${signal} shutdown`, { error: errorMessage });
+        });
+      };
+      process.on(signal, handler);
+      this._shutdownSignalHandlers.push({ signal, handler });
+    }
+    return this;
+  }
+
+  /**
+   * Remove any process signal handlers registered via enableShutdownHooks().
+   */
+  private removeShutdownHooks(): void {
+    for (const { signal, handler } of this._shutdownSignalHandlers) {
+      process.removeListener(signal, handler);
+    }
+    this._shutdownSignalHandlers = [];
+  }
+
+  /**
+   * Stop the server
+   *
+   * Idempotent: concurrent or repeated calls (e.g. from multiple OS signals)
+   * share the same in-flight teardown instead of re-running lifecycle hooks or
+   * double-closing transports.
+   */
+  async stop(signal?: string): Promise<void> {
+    if (!this._stopping) {
+      this._stopping = this.doStop(signal);
+    }
+    return this._stopping;
+  }
+
+  private async doStop(signal?: string): Promise<void> {
+    // Detach signal handlers first so nothing re-enters teardown mid-shutdown.
+    this.removeShutdownHooks();
+
+    const instances = DIContainer.getInstance().getInstances();
     try {
-      // Call stop for all modules
+      // Call onModuleDestroy for all resolved instances
+      await triggerLifecycleHook(instances, 'onModuleDestroy', { safe: true, logger: this.logger });
+
+      // Call beforeApplicationShutdown for all resolved instances
+      await triggerLifecycleHook(instances, 'beforeApplicationShutdown', { safe: true, logger: this.logger }, signal);
+
+      // Call stop for all modules. A single failing module must not prevent the
+      // remaining modules (or transport teardown) from stopping.
       for (const moduleClass of this.modules) {
         const moduleInstance = DIContainer.getInstance().resolve<ModuleInstance>(moduleClass);
         if (moduleInstance.stop) {
-          await moduleInstance.stop();
+          try {
+            await moduleInstance.stop();
+          } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.logger.error(`Error stopping module ${moduleClass.name}`, { error: errorMessage });
+          }
         }
       }
 
@@ -1440,6 +1550,9 @@ export class NitroStackServer {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error('Error stopping server', { error: errorMessage });
       throw error;
+    } finally {
+      // NestJS: always run after connection close attempts, even if close threw
+      await triggerLifecycleHook(instances, 'onApplicationShutdown', { safe: true, logger: this.logger }, signal);
     }
   }
 

--- a/typescript/packages/core/src/core/transports/streamable-http.ts
+++ b/typescript/packages/core/src/core/transports/streamable-http.ts
@@ -1260,13 +1260,8 @@ export class StreamableHttpTransport {
       display: flex;
       align-items: center;
       justify-content: center;
-      cursor: pointer;
       color: #b4b4b4;
       transition: border-color 0.2s;
-    }
-
-    .chatgpt-icon-box:hover {
-      border-color: #b4b4b4;
     }
 
     .chatgpt-icon-desc {
@@ -1310,7 +1305,7 @@ export class StreamableHttpTransport {
       color: #676767;
     }
 
-    .chatgpt-input:focus, .chatgpt-input.active-input {
+    .chatgpt-input.active-input {
       border-color: #10a37f;
     }
 
@@ -1361,7 +1356,6 @@ export class StreamableHttpTransport {
       font-weight: 500;
       border-radius: 9999px;
       border: none;
-      cursor: pointer;
       color: #ececec;
       background-color: transparent;
       display: flex;
@@ -1384,7 +1378,6 @@ export class StreamableHttpTransport {
       font-size: 14.5px;
       appearance: none;
       outline: none;
-      cursor: pointer;
       background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23b4b4b4' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
       background-repeat: no-repeat;
       background-position: right 14px center;
@@ -1429,7 +1422,6 @@ export class StreamableHttpTransport {
       width: 16px;
       height: 16px;
       accent-color: #10a37f;
-      cursor: pointer;
       margin-top: 3px;
     }
 
@@ -1443,7 +1435,6 @@ export class StreamableHttpTransport {
       font-size: 13.5px;
       font-weight: 600;
       color: #ececec;
-      cursor: pointer;
     }
 
     .chatgpt-checkbox-desc {
@@ -1480,12 +1471,7 @@ export class StreamableHttpTransport {
       font-weight: 600;
       border-radius: 9999px;
       border: none;
-      cursor: pointer;
       transition: background-color 0.2s;
-    }
-
-    .chatgpt-btn-create:hover {
-      background-color: #ececec;
     }
 
     /* Claude Custom Connector Mockup Styles */
@@ -1589,7 +1575,7 @@ export class StreamableHttpTransport {
       color: #706e67;
     }
 
-    .claude-input:focus-within, .claude-input.active-input {
+    .claude-input.active-input {
       border-color: #3890ff;
       box-shadow: 0 0 0 1px #3890ff;
     }
@@ -1626,7 +1612,6 @@ export class StreamableHttpTransport {
       font-size: 13.5px;
       font-weight: 500;
       color: #e3e2e0;
-      cursor: pointer;
       margin-bottom: 24px;
       user-select: none;
     }
@@ -1681,11 +1666,9 @@ export class StreamableHttpTransport {
     .claude-btn-add {
       background-color: #e3e2e0;
       color: #161513;
+      cursor: default;
     }
 
-    .claude-btn-add:hover {
-      background-color: #ffffff;
-    }
   </style>
 </head>
 <body>

--- a/typescript/packages/widgets/NOTICE
+++ b/typescript/packages/widgets/NOTICE
@@ -41,10 +41,6 @@ jose
 Copyright (c) 2020 Filip Skokan
 Licensed under the MIT License
 
-better-sqlite3
-Copyright (c) 2016 Joshua Wise
-Licensed under the MIT License
-
 bcryptjs
 Copyright (c) 2012 Nevins Bartolomeo
 Licensed under the MIT License


### PR DESCRIPTION
## Description

This PR lands three coordinated features across the `core` and `cli` packages: NestJS-style lifecycle hooks, an `@Controller` decorator with tool-name prefixing, and a full agent-skills installer (with automatic upgrades) supporting 13 AI coding agents across project/global scopes. It also refines the Streamable HTTP transport UI and trims an unused dependency.

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [x] refactor: Internal code change
- [ ] test: Test-only changes
- [x] chore: Build, CI, or tooling changes

## Related Issues

<!-- Add closing keywords here if this resolves any tracked issues, e.g. Closes #123 -->

## Changes Made

### Core Package (`packages/core`)
- **Lifecycle hooks** in `core/lifecycle.ts`, `core/server.ts`, and `core/index.ts`:
  - Implements NestJS-style lifecycle hooks (`OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, `BeforeApplicationShutdown`, `OnApplicationShutdown`).
  - Eagerly instantiates all registered providers and controllers (`instantiateAll`).
  - Supports idempotent shutdown hook listeners (`enableShutdownHooks`) and guarantees clean, ordered teardown.
  - Publicly exports `triggerLifecycleHook` and the lifecycle hook types from `core/index.ts`.
- **Controller & Tool prefixing** in `core/decorators.ts`, `core/builders.ts`, and `core/di/container.ts`:
  - Adds `@Controller(prefix | { prefix })` to auto-register classes and support namespaces (tool prefixing) without mutating shared metadata.
  - Exports `ControllerDecorator`, `getControllerPrefix`, `getInitialToolMetadata`, and the `ControllerOptions` type from `core/index.ts`.
- **Decorator Metadata Isolation** in `core/decorators.ts`, `core/di/injectable.decorator.ts`, `core/events/event.decorator.ts`, and `core/pipes/pipe.decorator.ts`:
  - Clones metadata structures on class/property/parameter decorator applications to prevent metadata leaking/pollution between parent and sub-classes.
- **UI & UX Refinement** in `core/transports/streamable-http.ts`:
  - Cleans up unnecessary `cursor: pointer` attributes, redundant focus classes, and unused hover styles from HTML/CSS mockups.
- **Dependency cleanup**:
  - Removes the unused `better-sqlite3` / `@types/better-sqlite3` dependency and its NOTICE attribution from `core`, `cli`, and `widgets` packages.
- **Tests**:
  - Adds unit test coverage for lifecycle sequence, DI eager instantiation, decorator inheritance isolation, and `@Controller` tool prefixing in `src/core/__tests__/server.test.ts`, `src/core/__tests__/server.extended.test.ts`, `src/core/__tests__/di.test.ts`, and `src/core/decorators/__tests__/decorators.test.ts`.

### CLI Package (`packages/cli`)
- **Agent Detection & Skills Installation Flow** in `src/skills/...`:
  - Implements an automated workflow to shallow-clone the skills repository, discover skills, detect 13 supported AI coding agents, and install/overwrite skills to local projects or global paths.
  - Adds a `createAgentDescriptor` factory/helper to reduce boilerplate and structure command/directory presence detection.
  - Expands agent coverage to 13 total agents: Cursor, Codex, Claude Code, Gemini CLI, Antigravity, Windsurf, Continue.dev, VS Code Agent Mode, Zed, GitHub Copilot, Goose, Aider, OpenHands.
  - Configures the CLI multi-select menu choices for detected agents to be unchecked by default.
  - `init` now installs agent skills unconditionally (no more yes/no prompt) via `runSkillsFlow`; adds a `--force` flag to overwrite existing skill files.
- **Automated skill upgrades** in `src/commands/upgrade.ts`:
  - Tracks the installed skills version in a new `nitrostack.skillsVersion` field in the project's `package.json`.
  - On `upgrade`, clones the skills repo, compares versions, and reinstalls skills when a newer version is available (supports `--dry-run`).
- **TTY Interface & Command Prompts** in `src/commands/init.ts` and `src/index.ts`:
  - Adds support for horizontal choices (`promptYesNoHorizontal`) and vertical scope prompts.
  - Refactors the `init` flow to remove a redundant dependency installation prompt.
  - Renames the OAuth starter template's display label from "OAuth" to "Flight booking" in the template picker.
- **Tests**:
  - Implements unit tests for cloning, skills discovery, agent detection, and installation logic in `src/__tests__/skills.test.ts`.
  - Adds `src/__tests__/upgrade.test.ts` covering skill-upgrade version comparison and install logic.

## Testing

- [ ] `npm run lint`
- [x] `npm test`
- [x] Manual testing performed (if applicable)

Jest suites cover the lifecycle runner, `@Controller`, DI eager instantiation, the CLI skills flow, and the new skills-upgrade logic.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [x] I have added/updated tests where appropriate
- [ ] I have updated docs where appropriate
- [x] I have kept this PR focused and scoped
- [x] I have used conventional commits
