### PR TITLE
refactor(cli): update OAuth template display name in init selection list

### DIFF
--- a/typescript/packages/cli/src/commands/init.ts
+++ b/typescript/packages/cli/src/commands/init.ts
@@ -129,7 +129,7 @@ export async function initCommand(projectName: string | undefined, options: Init
             value: 'typescript-pizzaz',
           },
           {
-            name: `${brand.signal('OAuth')}       ${chalk.dim('Flight booking with OAuth 2.1 auth')}`,
+            name: `${brand.signal('Flight booking')}  ${chalk.dim('Flight booking with OAuth 2.1 auth')}`,
             value: 'typescript-oauth',
           },
         ],


### PR DESCRIPTION
## Description

This PR updates the display name of the OAuth template option in the CLI's `init` command selection list. It changes the label from `OAuth` to `Flight booking` to better match the template's actual function and naming convention, while retaining the detail that it uses OAuth 2.1 authentication.

## Type of Change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [x] refactor: Internal code change
- [ ] test: Test-only changes
- [ ] chore: Build, CI, or tooling changes

## Related Issues

<!-- Use closing keywords when appropriate, e.g. Closes #123 -->

## Changes Made

- Modified template selection prompt in [init.ts](typescript/packages/cli/src/commands/init.ts#L129-L135) to display `Flight booking` instead of `OAuth`.
- Aligned display spacing to maintain formatting in the list.

## Testing

- [ ] `npm run lint`
- [ ] `npm test`
- [x] Manual testing performed (if applicable)

## Screenshots / Recordings

<!-- Add screenshots or GIFs for UI/UX changes -->

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [ ] I have added/updated tests where appropriate
- [ ] I have updated docs where appropriate
- [x] I have kept this PR focused and scoped
- [x] I have used conventional commits
