### PR TITLE
fix: correct hardcoded docs URL in legacy HTTP transport info endpoint

### DIFF
--- a/typescript/packages/core/src/core/transports/http-server.ts
+++ b/typescript/packages/core/src/core/transports/http-server.ts
@@ -124,7 +124,7 @@ export class HttpServerTransport implements Transport {
           message: `${basePath}/message`,
           health: `${basePath}/health`,
         },
-        docs: 'https://github.com/nitrostack/nitrostack',
+        docs: 'https://docs.nitrostack.ai',
       });
     });
 


### PR DESCRIPTION
The root info endpoint of HttpServerTransport pointed docs at github.com/nitrostack/nitrostack, which is not the canonical repo (nitrocloudofficial/nitrostack). Use https://docs.nitrostack.ai as the single source of truth, matching the docs URL already used by the CLI branding.
