### PR TITLE
Add Concord governance agent MCP sample app

### DIFF
--- a/sample-apps/concord-governance-agent/.agents/skills/auth-security/SKILL.md
+++ b/sample-apps/concord-governance-agent/.agents/skills/auth-security/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: nitrostack-auth-security
+description: Best practices for implementing JWT, API Keys, OAuth 2.1, and RBAC in a NitroStack application.
+---
+
+## When to Use
+Use this skill when configuring security modules, implementing user authentication, restricting tool access via guards, or handling sensitive tokens.
+
+---
+
+## 1. JSON Web Tokens (JWT)
+To secure tools with JWT authentication:
+
+### Register `JWTModule`:
+```typescript
+import { JWTModule, Module, McpApp } from '@nitrostack/core';
+
+@McpApp({
+  server: { name: 'my-server', version: '1.0.0' }
+})
+@Module({
+  imports: [
+    JWTModule.forRoot({
+      secret: process.env.JWT_SECRET!,
+      expiresIn: '7d',
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### Write a `JWTGuard`:
+```typescript
+import { Guard, ExecutionContext, Injectable, ConfigService } from '@nitrostack/core';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class JWTGuard implements Guard {
+  constructor(private config: ConfigService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const token = this.extractToken(context);
+    if (!token) return false;
+
+    try {
+      const secret = this.config.get('JWT_SECRET');
+      const payload = jwt.verify(token, secret) as any;
+      context.auth = {
+        subject: payload.sub,
+        role: payload.role,
+        token,
+      };
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private extractToken(context: ExecutionContext): string | null {
+    const auth = context.metadata?.authorization;
+    if (auth?.startsWith('Bearer ')) {
+      return auth.substring(7);
+    }
+    return null;
+  }
+}
+```
+
+---
+
+## 2. API Key Authentication
+Use `ApiKeyModule` for service-to-service validation.
+
+### Register `ApiKeyModule`:
+```typescript
+import { ApiKeyModule, Module } from '@nitrostack/core';
+
+@Module({
+  imports: [
+    ApiKeyModule.forRoot({
+      keysEnvPrefix: 'API_KEY', // Reads API_KEY_1, API_KEY_2, etc.
+      headerName: 'x-api-key',
+      hashed: false,
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### API Key Guard:
+```typescript
+import { Guard, ExecutionContext, ApiKeyModule } from '@nitrostack/core';
+
+export class ApiKeyGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const apiKey = context.metadata?.['x-api-key'] || context.metadata?.apiKey;
+    if (!apiKey) return false;
+
+    const isValid = await ApiKeyModule.validate(apiKey as string);
+    if (isValid) {
+      context.auth = {
+        subject: `apikey_${(apiKey as string).substring(0, 10)}`,
+        scopes: ['*'],
+      };
+      return true;
+    }
+    return false;
+  }
+}
+```
+
+---
+
+## 3. Role-Based Access Control (RBAC)
+Chain guards sequentially to implement user-role authorization.
+
+```typescript
+import { Injectable, Guard, ExecutionContext, UseGuards, Tool, z } from '@nitrostack/core';
+import { JWTGuard } from './jwt.guard.js';
+
+@Injectable()
+export class AdminGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Requires JWTGuard to have populated context.auth first
+    return context.auth?.role === 'admin';
+  }
+}
+
+// Applying chained guards to a tool
+export class SystemTools {
+  @Tool({
+    name: 'reset_database',
+    description: 'Dangerous action: wipes database. Admin only.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(JWTGuard, AdminGuard) // Chain auth first, then role check
+  async resetDatabase() {
+    return { success: true };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.agents/skills/mcp-app-architecture/SKILL.md
+++ b/sample-apps/concord-governance-agent/.agents/skills/mcp-app-architecture/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: nitrostack-mcp-app-architecture
+description: Best practices and guidelines for bootstrapping, defining modules, using dependency injection, managing server lifecycles, and handling events in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill whenever you are bootstrapping a new NitroStack MCP server, creating modules, injecting services, or handling application lifecycle events.
+
+## Bootstrapping a NitroStack App
+A NitroStack application is initialized with the `@McpApp` decorator on a root class, accompanied by a root `@Module`.
+
+```typescript
+import { McpApp, Module } from '@nitrostack/core';
+import { DatabaseModule } from './database/database.module.js';
+import { UsersModule } from './users/users.module.js';
+
+@McpApp({
+  module: AppModule,
+  server: {
+    name: 'user-management-server',
+    version: '1.0.0',
+  },
+})
+@Module({
+  imports: [DatabaseModule, UsersModule],
+})
+export class AppModule {}
+```
+
+## Modules
+Modules organize your application structure. Use the `@Module` decorator to define imports, exports, and providers.
+
+* **`imports`**: Other modules whose exported providers should be available in this module.
+* **`providers`**: Services, tools, resources, or prompts that should be instantiated and managed by the DI container within this module.
+* **`exports`**: Providers defined in this module that should be visible to other modules importing this one.
+
+```typescript
+import { Module } from '@nitrostack/core';
+import { UsersService } from './users.service.js';
+import { UsersTools } from './users.tools.js';
+
+@Module({
+  providers: [UsersService, UsersTools],
+  exports: [UsersService],
+})
+
+## Controllers
+Use the `@ControllerDecorator` (or alias it as `@Controller`) to group tools, resources, and prompts together. Controllers are automatically registered as singletons in the DI container.
+
+### Key Controller Options:
+* **`prefix`**: A string prefix applied to every `@Tool` defined in this controller. For example, `@ControllerDecorator('github')` prefixing a tool named `create_issue` exposes it to MCP clients as `github_create_issue`.
+
+```typescript
+import { ControllerDecorator as Controller, Tool, ExecutionContext } from '@nitrostack/core';
+
+@Controller('github')
+export class GitHubController {
+  @Tool({
+    name: 'create_issue',
+    description: 'Create an issue in a repository',
+    inputSchema: z.object({ /* ... */ })
+  })
+  async createIssue(input: any, ctx: ExecutionContext) {
+    // Exposed to clients as "github_create_issue"
+  }
+}
+```
+
+## Dependency Injection (DI)
+NitroStack uses a robust dependency injection container to manage class instances and lifecycles.
+
+### Injection Lifecycles
+1. **Singleton (Default)**: A single instance is shared across the entire application.
+2. **Transient**: A new instance is created every time it is resolved/injected.
+3. **Scoped**: A new instance is created per incoming request or context.
+
+```typescript
+import { Injectable, Scope } from '@nitrostack/core';
+
+@Injectable({ scope: Scope.SINGLETON })
+export class UsersService {
+  constructor(private readonly db: DatabaseService) {}
+  
+  async getUser(id: string) {
+    return this.db.query('SELECT * FROM users WHERE id = $1', [id]);
+  }
+}
+```
+
+## Lifecycles and Hooks
+Implement NestJS-style lifecycle interfaces on modules, controllers, or providers to hook into application state changes:
+
+* **`OnModuleInit`** (`onModuleInit`): Called after modules have initialized but before the server starts listening.
+* **`OnApplicationBootstrap`** (`onApplicationBootstrap`): Called once the server is fully started and listening.
+* **`OnModuleDestroy`** (`onModuleDestroy`): Called when the module or application is shutting down.
+* **`BeforeApplicationShutdown`** (`beforeApplicationShutdown(signal?: string)`): Called before the application starts shutting down. Receives the OS signal (e.g. `SIGINT`).
+* **`OnApplicationShutdown`** (`onApplicationShutdown(signal?: string)`): Called during shutdown. Receives the OS signal.
+
+```typescript
+import { 
+  Injectable, 
+  OnModuleInit, 
+  OnApplicationBootstrap,
+  OnModuleDestroy, 
+  BeforeApplicationShutdown,
+  OnApplicationShutdown 
+} from '@nitrostack/core';
+
+@Injectable()
+export class DatabaseService 
+  implements OnModuleInit, OnApplicationBootstrap, OnModuleDestroy, BeforeApplicationShutdown, OnApplicationShutdown 
+{
+  async onModuleInit() {
+    await this.connect();
+  }
+
+  async onApplicationBootstrap() {
+    console.log('App ready to handle connections.');
+  }
+
+  async onModuleDestroy() {
+    await this.cleanupPendingQueries();
+  }
+
+  async beforeApplicationShutdown(signal?: string) {
+    console.log(`Shutting down soon (signal: ${signal}).`);
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    await this.disconnect();
+  }
+}
+```
+
+---
+
+## Eventing System (`emitEvent` and `@OnEvent`)
+NitroStack includes an internal eventing system to decouple components. A service or tool can emit an event using `emitEvent`, and any injectable class (like a handler service or controller) can subscribe using the `@OnEvent` decorator.
+
+### 1. Emitting Events
+Call `emitEvent` to dispatch an event payload asynchronously.
+
+```typescript
+import { Injectable, emitEvent } from '@nitrostack/core';
+
+@Injectable()
+export class SpaceShipService {
+  async launchShip(shipId: string) {
+    // Process launch...
+    
+    // Dispatch event
+    emitEvent('ship.launched', {
+      shipId,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+```
+
+### 2. Listening to Events
+Decorate a method inside any `@Injectable()` class with `@OnEvent('event_pattern')` to register it as an event handler.
+
+```typescript
+import { Injectable, OnEvent } from '@nitrostack/core';
+
+@Injectable({ deps: [] })
+export class FlightLogHandler {
+  @OnEvent('ship.launched')
+  async logLaunch(data: { shipId: string; timestamp: string }) {
+    console.error(`🚀 [EVENT] Ship ${data.shipId} was successfully launched at ${data.timestamp}`);
+  }
+}
+```
+
+> [!NOTE]
+> For the `@OnEvent` decorator to register properly, the containing class must be declared as a provider inside an active module.

--- a/sample-apps/concord-governance-agent/.agents/skills/middleware-pipeline/SKILL.md
+++ b/sample-apps/concord-governance-agent/.agents/skills/middleware-pipeline/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: nitrostack-middleware-pipeline
+description: Best practices for implementing and applying Guards, Interceptors, Middleware, Pipes, and Exception Filters in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill when implementing request validation, authorization checks, response mapping, logging, error handling, or performance tracking on NitroStack tool methods.
+
+---
+
+## 1. Guards (`Guard` and `@UseGuards`)
+Guards determine if a request should be processed by a tool handler based on authentication, authorization, or other conditions.
+
+### Interface:
+```typescript
+import { Guard, ExecutionContext } from '@nitrostack/core';
+
+export interface Guard {
+  canActivate(context: ExecutionContext): boolean | Promise<boolean>;
+}
+```
+
+### Example:
+```typescript
+import { Guard, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class RolesGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const userRoles = context.clientMetadata?.roles || [];
+    return userRoles.includes('admin');
+  }
+}
+```
+
+Apply the guard using `@UseGuards(...)`:
+```typescript
+import { Tool, UseGuards, z } from '@nitrostack/core';
+import { RolesGuard } from './roles.guard.js';
+
+export class AdminTools {
+  @Tool({
+    name: 'delete_system_logs',
+    description: 'Delete all system logs from the server.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(RolesGuard)
+  async deleteLogs() {
+    return { success: true };
+  }
+}
+```
+
+---
+
+## 2. Interceptors (`InterceptorInterface` and `@UseInterceptors`)
+Interceptors can transform/intercept input arguments or mapped output from a tool method execution.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface InterceptorInterface {
+  intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { InterceptorInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class TimingInterceptor implements InterceptorInterface {
+  async intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    const start = Date.now();
+    const result = await next();
+    const duration = Date.now() - start;
+    context.logger.info(`Execution took ${duration}ms`);
+    return {
+      ...result,
+      _meta: { durationMs: duration }
+    };
+  }
+}
+```
+
+---
+
+## 3. Exception Filters (`ExceptionFilterInterface` and `@UseFilters`)
+Exception filters catch any errors thrown within guards, interceptors, or the tool handlers themselves, mapping them into user-friendly JSON payloads.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext): unknown | Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { ExceptionFilterInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class CustomExceptionFilter implements ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext) {
+    const message = exception instanceof Error ? exception.message : 'Unknown error';
+    return {
+      error: true,
+      message,
+      timestamp: new Date().toISOString()
+    };
+  }
+}
+```
+
+Apply the filter using `@UseFilters(...)` on a tool method:
+
+```typescript
+import { Tool, UseFilters, z } from '@nitrostack/core';
+import { CustomExceptionFilter } from './custom-exception.filter.js';
+
+export class LoggingTools {
+  @Tool({
+    name: 'generate_report',
+    description: 'Generates system usage reports.',
+    inputSchema: z.object({}),
+  })
+  @UseFilters(CustomExceptionFilter)
+  async generateReport() {
+    throw new Error('Report generation is not implemented yet.');
+  }
+}
+```
+
+---
+
+## 4. Middleware (`MiddlewareInterface`, `@Middleware` and `@UseMiddleware`)
+Middleware executes before the request reaches the tool handler, and can wrap the handler execution by invoking `next()`.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface MiddlewareInterface {
+  use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { Middleware, MiddlewareInterface, ExecutionContext } from '@nitrostack/core';
+
+@Middleware()
+export class LoggingMiddleware implements MiddlewareInterface {
+  async use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    context.logger.info(`Entering tool: ${context.toolName}`);
+    try {
+      const result = await next();
+      context.logger.info(`Exiting tool: ${context.toolName}`);
+      return result;
+    } catch (error) {
+      context.logger.error(`Error in tool: ${error}`);
+      throw error;
+    }
+  }
+}
+```
+
+Apply the middleware using `@UseMiddleware(...)` on a tool method:
+```typescript
+import { Tool, UseMiddleware, z } from '@nitrostack/core';
+import { LoggingMiddleware } from './logging.middleware.js';
+
+export class StationTools {
+  @Tool({
+    name: 'fetch_logs',
+    description: 'Fetch station operations logs.',
+    inputSchema: z.object({}),
+  })
+  @UseMiddleware(LoggingMiddleware)
+  async fetchLogs() {
+    return { status: 'operational' };
+  }
+}
+```
+
+---
+
+## 5. Pipes (`PipeInterface`, `@Pipe` and `@UsePipes`)
+Pipes are used to transform or validate input arguments before they reach the tool handler method.
+
+### Interface:
+```typescript
+import { ArgumentMetadata } from '@nitrostack/core';
+
+export interface PipeInterface<T = unknown, R = unknown> {
+  transform(value: T, metadata: ArgumentMetadata): R | Promise<R>;
+}
+```
+
+### Example:
+```typescript
+import { Pipe, PipeInterface, ArgumentMetadata } from '@nitrostack/core';
+
+@Pipe()
+export class TrimPipe implements PipeInterface<Record<string, unknown>, Record<string, unknown>> {
+  transform(value: Record<string, unknown>, metadata: ArgumentMetadata) {
+    const trimmed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      trimmed[key] = typeof val === 'string' ? val.trim() : val;
+    }
+    return trimmed;
+  }
+}
+```
+
+Apply the pipe using `@UsePipes(...)` on a tool method:
+```typescript
+import { Tool, UsePipes, z } from '@nitrostack/core';
+import { TrimPipe } from './trim.pipe.js';
+
+export class MessagingTools {
+  @Tool({
+    name: 'send_message',
+    description: 'Send a message to other stations.',
+    inputSchema: z.object({ text: z.string() }),
+  })
+  @UsePipes(TrimPipe)
+  async sendMessage(input: { text: string }) {
+    return { sentText: input.text };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.agents/skills/tools-resources-prompts/SKILL.md
+++ b/sample-apps/concord-governance-agent/.agents/skills/tools-resources-prompts/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: nitrostack-tools-resources-prompts
+description: Guidelines and patterns for defining Tools, Resources, and Prompts in a NitroStack application with schema validation via Zod, including caching, rate-limiting, and base64 file uploads.
+---
+
+## When to Use
+Use this skill whenever you are defining, editing, or validating tools, resources, or prompts on a NitroStack MCP server.
+
+## Defining Tools with `@Tool`
+An MCP tool exposes a function that an AI client can invoke. Decorate a service or controller method with `@Tool`.
+
+### Key Tool Options:
+* `name`: Kebab-case or snake_case unique identifier.
+* `description`: Detailed description explaining when and how the client should use it.
+* `inputSchema`: A Zod object schema for strict validation of inputs.
+* `outputSchema` (optional): Zod schema validating the output structure.
+
+```typescript
+import { ToolDecorator as Tool, ControllerDecorator as Controller, InitialTool, z, ExecutionContext } from '@nitrostack/core';
+
+@Controller('weather')
+export class WeatherService {
+  @Tool({
+    name: 'get_current_weather',
+    description: 'Get the current weather forecast for a specific city.',
+    inputSchema: z.object({
+      city: z.string().describe('The name of the city, e.g., San Francisco'),
+      unit: z.enum(['celsius', 'fahrenheit']).default('celsius'),
+    }),
+  })
+  @InitialTool() // Auto-invoked when the AI client initializes/starts
+  async getWeather(
+    input: { city: string; unit: 'celsius' | 'fahrenheit' },
+    ctx: ExecutionContext
+  ) {
+    ctx.logger.info(`Fetching weather for ${input.city}`);
+    // implementation
+    return {
+      city: input.city,
+      temp: 22,
+      condition: 'Sunny',
+    };
+  }
+}
+```
+
+## Defining Resources with `@Resource`
+An MCP resource exposes static or dynamic data files/URIs that the AI client can read.
+
+### Key Resource Options:
+* `uri`: URI pattern (e.g., `git://{owner}/{repo}/file` or static `app://config`).
+* `name`: Unique name of the resource.
+* `description`: Explanation of what data this resource provides.
+* `mimeType`: Mime type of the response (e.g., `text/plain`, `application/json`).
+
+```typescript
+import { Resource, ExecutionContext } from '@nitrostack/core';
+
+export class ConfigResources {
+  @Resource({
+    uri: 'app://settings',
+    name: 'Application Settings',
+    description: 'System-wide configuration settings and parameters.',
+    mimeType: 'application/json',
+  })
+  async getSettings(ctx: ExecutionContext) {
+    return {
+      environment: 'development',
+      debugMode: true,
+    };
+  }
+}
+```
+
+## Defining Prompts with `@Prompt`
+An MCP prompt exposes reusable templates or instruction sets that guide LLMs.
+
+### Key Prompt Options:
+* `name`: Name of the prompt.
+* `description`: Describes what task this prompt helps accomplish.
+* `arguments`: Declares parameters the client can supply to customize the prompt template.
+
+```typescript
+import { Prompt, ExecutionContext } from '@nitrostack/core';
+
+export class PromptTemplates {
+  @Prompt({
+    name: 'code_review',
+    description: 'Provide an intensive code review for a given code snippet.',
+    arguments: [
+      { name: 'language', description: 'The programming language, e.g., TypeScript', required: true },
+      { name: 'code', description: 'The code snippet to review', required: true },
+    ],
+  })
+  async getCodeReviewPrompt(
+    args: { language: string; code: string },
+    ctx: ExecutionContext
+  ) {
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: `You are an expert software engineer. Review this ${args.language} code:\n\n${args.code}`,
+        },
+      ],
+    };
+  }
+}
+```
+
+---
+
+## Tool Policies: Caching (`@Cache`) and Rate Limiting (`@RateLimit`)
+You can control tool execution behaviors (such as performance optimization and throttling) using method decorators.
+
+### 1. Caching with `@Cache`
+Use `@Cache` to cache tool execution outputs for a specified duration (TTL in seconds). This reduces database or API overhead for frequent identical requests.
+
+#### Options:
+* `ttl`: Cache time-to-live in seconds (required).
+* `key` (optional): Custom function `(input: any, context?: any) => string` that returns a unique cache key based on inputs. If not defined, a key is auto-generated from serialized input arguments.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, Cache, z } from '@nitrostack/core';
+
+export class StationTools {
+  @Tool({
+    name: 'get_system_status',
+    description: 'Fetch real-time station metrics. Response is cached.',
+    inputSchema: z.object({}),
+  })
+  @Cache({ ttl: 60 }) // Caches status for 60 seconds
+  async getSystemStatus() {
+    return { temperature: 21.5, oxygen: 0.98 };
+  }
+
+  @Tool({
+    name: 'get_crew_status',
+    description: 'Fetch status of a crew member. Cached by crew ID.',
+    inputSchema: z.object({ id: z.string() }),
+  })
+  @Cache({
+    ttl: 300,
+    key: (input) => `crew:status:${input.id}`
+  })
+  async getCrewStatus(input: { id: string }) {
+    // ...
+  }
+}
+```
+
+### 2. Rate Limiting with `@RateLimit`
+Use `@RateLimit` to restrict the number of tool invocations within a specified time window to prevent client abuse.
+
+#### Options:
+* `requests`: Number of allowed requests in the window (required).
+* `window`: Throttling duration window (required). Supports formats like `'1s'`, `'1m'`, `'1h'`.
+* `key` (optional): Custom function `(context: ExecutionContext) => string` to group rate limits. Useful for rate-limiting per user role or API key.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, RateLimit, z, ExecutionContext } from '@nitrostack/core';
+
+export class DiagnosticTools {
+  @Tool({
+    name: 'run_deep_diagnostic',
+    description: 'Run intensive diagnostics. Rate limited.',
+    inputSchema: z.object({}),
+  })
+  @RateLimit({ requests: 3, window: '1m' }) // Max 3 requests per minute globally
+  async runDeepDiagnostic() {
+    return { diagnosticReport: 'All systems operational.' };
+  }
+
+  @Tool({
+    name: 'request_supply_drop',
+    description: 'Request inventory supplies. Rate limited per user.',
+    inputSchema: z.object({ item: z.string() }),
+  })
+  @RateLimit({
+    requests: 5,
+    window: '1h',
+    key: (ctx: ExecutionContext) => ctx.auth?.subject || 'anonymous'
+  })
+  async requestSupply(input: { item: string }, ctx: ExecutionContext) {
+    // ...
+  }
+}
+```
+
+---
+
+## Handling File Uploads in Tools
+NitroStack supports file uploads from MCP clients (like NitroStudio) by passing the file as a base64-encoded string inside a tool's input parameters.
+
+### 1. Declaring Input Schema for File Uploads
+To accept an uploaded file, define three Zod fields in your tool's `inputSchema`:
+* `file_name`: The name of the file (e.g. `report.csv`).
+* `file_type`: The MIME type (e.g. `text/csv`).
+* `file_content`: The base64-encoded string containing the file data.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+
+export class FileTools {
+  @Tool({
+    name: 'upload_document',
+    description: 'Upload a text document or image.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async uploadDocument(input: any, ctx: ExecutionContext) {
+    // Processing logic
+  }
+}
+```
+
+### 2. Decoding Base64 Payloads
+File uploads can arrive in two formats depending on the client:
+1. **Data URL format**: `data:image/png;base64,iVBORw0KGgo...`
+2. **Raw Base64 format**: `iVBORw0KGgo...`
+
+Use the following universal decoder pattern to parse either format into a Node `Buffer`:
+
+```typescript
+import * as fs from 'fs';
+import * as path from 'path';
+
+function decodeBase64File(content: string): Buffer {
+  const matches = content.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/);
+  
+  if (matches && matches.length === 3) {
+    // Data URL format - decode matches[2]
+    return Buffer.from(matches[2], 'base64');
+  } else {
+    // Raw base64 format - decode input directly
+    return Buffer.from(content, 'base64');
+  }
+}
+```
+
+### 3. Secure File Saving Example
+Always validate the directory paths to prevent directory traversal attacks when saving files to disk.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads');
+
+export class SecureUploadTools {
+  @Tool({
+    name: 'save_uploaded_file',
+    description: 'Decodes and saves an uploaded file securely.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async saveFile(input: any, ctx: ExecutionContext) {
+    // Ensure uploads directory exists
+    if (!fs.existsSync(UPLOAD_DIR)) {
+      fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+    }
+
+    // Secure destination path to prevent path traversal
+    const safeName = path.basename(input.file_name);
+    const filePath = path.join(UPLOAD_DIR, safeName);
+    if (!filePath.startsWith(UPLOAD_DIR)) {
+      throw new Error('Invalid file path detected (path traversal).');
+    }
+
+    // Decode and write to disk
+    const buffer = decodeBase64File(input.file_content);
+    fs.writeFileSync(filePath, buffer);
+
+    ctx.logger.info(`Successfully saved file: ${safeName}`);
+    return { success: true, path: filePath };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.agents/skills/ui-widgets/SKILL.md
+++ b/sample-apps/concord-governance-agent/.agents/skills/ui-widgets/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: nitrostack-ui-widgets
+description: Best practices for linking tools to interactive frontend widgets using @Widget and @nitrostack/widgets SDK (including state sync, tool calling, display modes, media queries, and chat actions).
+---
+
+## When to Use
+Use this skill when designing, building, or modifying interactive user interface widgets that display custom React content inside AI clients or NitroStudio.
+
+---
+
+## 1. Backend Definition (`@Widget`)
+To display a React-based widget for a tool's output, decorate the tool method with `@Widget`.
+
+### Options:
+* **String Route**: A simple string representing the route identifier in the frontend React app (e.g. `'product-card'`).
+* **Object Route**: Object including:
+  * `route` (required): The route path.
+  * `domain` (optional): Allowed sandbox domain.
+  * `csp` (optional): Content Security Policy guidelines.
+
+### Example:
+```typescript
+import { Tool, Widget, z } from '@nitrostack/core';
+
+export class CatalogTools {
+  @Tool({
+    name: 'fetch_product',
+    description: 'Get product information by barcode.',
+    inputSchema: z.object({ barcode: z.string() }),
+  })
+  @Widget('product-details') // Maps to the "product-details" frontend component
+  async fetchProduct(input: { barcode: string }) {
+    return {
+      name: 'Super Nitro Energy Drink',
+      price: 2.99,
+      sku: input.barcode,
+    };
+  }
+}
+```
+
+---
+
+## 2. Frontend React Widget (`@nitrostack/widgets`)
+In your React widget frontend application (typically a Next.js client component), use the `useWidgetSDK` hook to receive input data from the client host.
+
+### React Component Example:
+```tsx
+'use client';
+
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+interface ProductData {
+  name: string;
+  price: number;
+  sku: string;
+}
+
+export default function ProductDetailsWidget() {
+  const { isReady, getToolOutput, theme } = useWidgetSDK();
+  const data = getToolOutput<ProductData>();
+
+  if (!isReady) {
+    return <div className="loading">Connecting to host...</div>;
+  }
+
+  if (!data) {
+    return <div className="error">No product data received.</div>;
+  }
+
+  return (
+    <div className={`product-card ${theme === 'dark' ? 'dark' : 'light'}`}>
+      <h3>{data.name}</h3>
+      <p className="price">${data.price.toFixed(2)}</p>
+      <span className="sku">SKU: {data.sku}</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 3. State Management & Synchronization (`useWidgetState`)
+Use `useWidgetState` to manage and persist client-side widget state (e.g. selected tabs, filter values, input states). This state automatically synchronizes with the host application context, persisting it across page re-renders.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetState } from '@nitrostack/widgets';
+
+export default function StationPanelWidget() {
+  const [state, setState] = useWidgetState(() => ({
+    selectedTab: 'overview',
+    showExtendedInfo: false,
+  }));
+
+  return (
+    <div>
+      <button onClick={() => setState({ ...state, selectedTab: 'alerts' })}>
+        View Alerts
+      </button>
+      <p>Current Tab: {state?.selectedTab}</p>
+    </div>
+  );
+}
+```
+
+---
+
+## 4. Calling Core Tools from Widgets (`callTool`)
+You can invoke other backend MCP tools directly from the frontend widget using `callTool`. This is useful for tool chaining or triggering detailed audits.
+
+### Example:
+```tsx
+import React, { useState } from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function SystemDiagnostics() {
+  const { callTool, isReady } = useWidgetSDK();
+  const [isRunning, setIsRunning] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+
+  const runDiagnostic = async () => {
+    if (!isReady) return;
+    setIsRunning(true);
+    try {
+      const response = await callTool('run_diagnostic', { system: 'oxygen_scrubber' });
+      setResult(response.result as string);
+    } catch (err) {
+      setResult('Diagnostic execution failed.');
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <button onClick={runDiagnostic} disabled={isRunning}>
+      {isRunning ? 'Running...' : 'Run Diagnostics'}
+    </button>
+  );
+}
+```
+
+---
+
+## 5. Layout & Display Controls
+Widgets can dynamically request size mode changes (fullscreen, inline, picture-in-picture) and adapt layouts to safe areas (dynamic islands/notches) or maximum height constraints.
+
+### Key Methods:
+* `requestFullscreen()`: Switch host widget display to fullscreen.
+* `requestInline()`: Switch host widget display back to inline.
+* `requestPip()`: Float widget in Picture-in-Picture.
+* `requestClose()`: Dismiss the widget completely.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function StatusBoard() {
+  const { 
+    requestFullscreen, 
+    requestInline, 
+    requestClose,
+    displayMode,   // Reactive property ('fullscreen' | 'inline' | 'pip')
+    maxHeight,     // Reactive maxHeight constraint (in pixels)
+    getSafeArea    // Insets data: { top, right, bottom, left }
+  } = useWidgetSDK();
+
+  const safeArea = getSafeArea() || { top: 0, bottom: 0 };
+
+  return (
+    <div style={{ maxHeight: maxHeight || 400, paddingTop: safeArea.top }}>
+      <h3>Mode: {displayMode}</h3>
+      <button onClick={requestFullscreen}>Fullscreen</button>
+      <button onClick={requestInline}>Collapse</button>
+      <button onClick={requestClose}>Dismiss Widget</button>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. Chat Navigation & Actions
+Widgets can interact with the host chat pane using external browser links and follow-up prompts.
+
+### Key Methods:
+* `openExternal(url)`: Open the target URL safely in the user's primary external browser.
+* `sendFollowUpMessage(prompt)`: Insert a message into the chat flow, automatically submitting it to the LLM agent.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function MissionControl() {
+  const { openExternal, sendFollowUpMessage } = useWidgetSDK();
+
+  return (
+    <div>
+      {/* Open external documentation */}
+      <button onClick={() => openExternal('https://docs.nitrostack.dev')}>
+        Open Manual
+      </button>
+
+      {/* Ask LLM agent directly from the widget */}
+      <button onClick={() => sendFollowUpMessage('Analyze mission failures from last week')}>
+        Ask Agent to Analyze
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 7. Media & Accessibility Queries
+The SDK provides helper utilities to query target client capabilities for styling or accessibility.
+
+### Key Utilities:
+* `prefersReducedMotion()`: Returns `true` if client settings specify reduced motion. Disable animations.
+* `isPrimarilyTouchDevice()`: Returns `true` if the device has a coarse pointer (e.g. touch/mobile). Increase button target sizes.
+* `isHoverAvailable()`: Returns `true` if pointer supports hover states.
+* `prefersDarkColorScheme()`: Returns `true` if the system theme is dark.
+
+### Example:
+```tsx
+import React from 'react';
+import { isPrimarilyTouchDevice, prefersReducedMotion } from '@nitrostack/widgets';
+
+export default function AccessiblePanel() {
+  const isTouch = isPrimarilyTouchDevice();
+  const reducedMotion = prefersReducedMotion();
+
+  return (
+    <div className={reducedMotion ? 'no-animations' : 'smooth-transitions'}>
+      <button style={{ padding: isTouch ? '16px' : '8px' }}>
+        Interactive Button
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 8. Testing Widgets
+* Open your project in **NitroStudio** for visual preview.
+* Invoke the tool from the AI chat or testing pane to verify the widget updates instantly with the returned JSON structure.

--- a/sample-apps/concord-governance-agent/.antigravity/skills/auth-security/SKILL.md
+++ b/sample-apps/concord-governance-agent/.antigravity/skills/auth-security/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: nitrostack-auth-security
+description: Best practices for implementing JWT, API Keys, OAuth 2.1, and RBAC in a NitroStack application.
+---
+
+## When to Use
+Use this skill when configuring security modules, implementing user authentication, restricting tool access via guards, or handling sensitive tokens.
+
+---
+
+## 1. JSON Web Tokens (JWT)
+To secure tools with JWT authentication:
+
+### Register `JWTModule`:
+```typescript
+import { JWTModule, Module, McpApp } from '@nitrostack/core';
+
+@McpApp({
+  server: { name: 'my-server', version: '1.0.0' }
+})
+@Module({
+  imports: [
+    JWTModule.forRoot({
+      secret: process.env.JWT_SECRET!,
+      expiresIn: '7d',
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### Write a `JWTGuard`:
+```typescript
+import { Guard, ExecutionContext, Injectable, ConfigService } from '@nitrostack/core';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class JWTGuard implements Guard {
+  constructor(private config: ConfigService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const token = this.extractToken(context);
+    if (!token) return false;
+
+    try {
+      const secret = this.config.get('JWT_SECRET');
+      const payload = jwt.verify(token, secret) as any;
+      context.auth = {
+        subject: payload.sub,
+        role: payload.role,
+        token,
+      };
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private extractToken(context: ExecutionContext): string | null {
+    const auth = context.metadata?.authorization;
+    if (auth?.startsWith('Bearer ')) {
+      return auth.substring(7);
+    }
+    return null;
+  }
+}
+```
+
+---
+
+## 2. API Key Authentication
+Use `ApiKeyModule` for service-to-service validation.
+
+### Register `ApiKeyModule`:
+```typescript
+import { ApiKeyModule, Module } from '@nitrostack/core';
+
+@Module({
+  imports: [
+    ApiKeyModule.forRoot({
+      keysEnvPrefix: 'API_KEY', // Reads API_KEY_1, API_KEY_2, etc.
+      headerName: 'x-api-key',
+      hashed: false,
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### API Key Guard:
+```typescript
+import { Guard, ExecutionContext, ApiKeyModule } from '@nitrostack/core';
+
+export class ApiKeyGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const apiKey = context.metadata?.['x-api-key'] || context.metadata?.apiKey;
+    if (!apiKey) return false;
+
+    const isValid = await ApiKeyModule.validate(apiKey as string);
+    if (isValid) {
+      context.auth = {
+        subject: `apikey_${(apiKey as string).substring(0, 10)}`,
+        scopes: ['*'],
+      };
+      return true;
+    }
+    return false;
+  }
+}
+```
+
+---
+
+## 3. Role-Based Access Control (RBAC)
+Chain guards sequentially to implement user-role authorization.
+
+```typescript
+import { Injectable, Guard, ExecutionContext, UseGuards, Tool, z } from '@nitrostack/core';
+import { JWTGuard } from './jwt.guard.js';
+
+@Injectable()
+export class AdminGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Requires JWTGuard to have populated context.auth first
+    return context.auth?.role === 'admin';
+  }
+}
+
+// Applying chained guards to a tool
+export class SystemTools {
+  @Tool({
+    name: 'reset_database',
+    description: 'Dangerous action: wipes database. Admin only.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(JWTGuard, AdminGuard) // Chain auth first, then role check
+  async resetDatabase() {
+    return { success: true };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.antigravity/skills/mcp-app-architecture/SKILL.md
+++ b/sample-apps/concord-governance-agent/.antigravity/skills/mcp-app-architecture/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: nitrostack-mcp-app-architecture
+description: Best practices and guidelines for bootstrapping, defining modules, using dependency injection, managing server lifecycles, and handling events in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill whenever you are bootstrapping a new NitroStack MCP server, creating modules, injecting services, or handling application lifecycle events.
+
+## Bootstrapping a NitroStack App
+A NitroStack application is initialized with the `@McpApp` decorator on a root class, accompanied by a root `@Module`.
+
+```typescript
+import { McpApp, Module } from '@nitrostack/core';
+import { DatabaseModule } from './database/database.module.js';
+import { UsersModule } from './users/users.module.js';
+
+@McpApp({
+  module: AppModule,
+  server: {
+    name: 'user-management-server',
+    version: '1.0.0',
+  },
+})
+@Module({
+  imports: [DatabaseModule, UsersModule],
+})
+export class AppModule {}
+```
+
+## Modules
+Modules organize your application structure. Use the `@Module` decorator to define imports, exports, and providers.
+
+* **`imports`**: Other modules whose exported providers should be available in this module.
+* **`providers`**: Services, tools, resources, or prompts that should be instantiated and managed by the DI container within this module.
+* **`exports`**: Providers defined in this module that should be visible to other modules importing this one.
+
+```typescript
+import { Module } from '@nitrostack/core';
+import { UsersService } from './users.service.js';
+import { UsersTools } from './users.tools.js';
+
+@Module({
+  providers: [UsersService, UsersTools],
+  exports: [UsersService],
+})
+
+## Controllers
+Use the `@ControllerDecorator` (or alias it as `@Controller`) to group tools, resources, and prompts together. Controllers are automatically registered as singletons in the DI container.
+
+### Key Controller Options:
+* **`prefix`**: A string prefix applied to every `@Tool` defined in this controller. For example, `@ControllerDecorator('github')` prefixing a tool named `create_issue` exposes it to MCP clients as `github_create_issue`.
+
+```typescript
+import { ControllerDecorator as Controller, Tool, ExecutionContext } from '@nitrostack/core';
+
+@Controller('github')
+export class GitHubController {
+  @Tool({
+    name: 'create_issue',
+    description: 'Create an issue in a repository',
+    inputSchema: z.object({ /* ... */ })
+  })
+  async createIssue(input: any, ctx: ExecutionContext) {
+    // Exposed to clients as "github_create_issue"
+  }
+}
+```
+
+## Dependency Injection (DI)
+NitroStack uses a robust dependency injection container to manage class instances and lifecycles.
+
+### Injection Lifecycles
+1. **Singleton (Default)**: A single instance is shared across the entire application.
+2. **Transient**: A new instance is created every time it is resolved/injected.
+3. **Scoped**: A new instance is created per incoming request or context.
+
+```typescript
+import { Injectable, Scope } from '@nitrostack/core';
+
+@Injectable({ scope: Scope.SINGLETON })
+export class UsersService {
+  constructor(private readonly db: DatabaseService) {}
+  
+  async getUser(id: string) {
+    return this.db.query('SELECT * FROM users WHERE id = $1', [id]);
+  }
+}
+```
+
+## Lifecycles and Hooks
+Implement NestJS-style lifecycle interfaces on modules, controllers, or providers to hook into application state changes:
+
+* **`OnModuleInit`** (`onModuleInit`): Called after modules have initialized but before the server starts listening.
+* **`OnApplicationBootstrap`** (`onApplicationBootstrap`): Called once the server is fully started and listening.
+* **`OnModuleDestroy`** (`onModuleDestroy`): Called when the module or application is shutting down.
+* **`BeforeApplicationShutdown`** (`beforeApplicationShutdown(signal?: string)`): Called before the application starts shutting down. Receives the OS signal (e.g. `SIGINT`).
+* **`OnApplicationShutdown`** (`onApplicationShutdown(signal?: string)`): Called during shutdown. Receives the OS signal.
+
+```typescript
+import { 
+  Injectable, 
+  OnModuleInit, 
+  OnApplicationBootstrap,
+  OnModuleDestroy, 
+  BeforeApplicationShutdown,
+  OnApplicationShutdown 
+} from '@nitrostack/core';
+
+@Injectable()
+export class DatabaseService 
+  implements OnModuleInit, OnApplicationBootstrap, OnModuleDestroy, BeforeApplicationShutdown, OnApplicationShutdown 
+{
+  async onModuleInit() {
+    await this.connect();
+  }
+
+  async onApplicationBootstrap() {
+    console.log('App ready to handle connections.');
+  }
+
+  async onModuleDestroy() {
+    await this.cleanupPendingQueries();
+  }
+
+  async beforeApplicationShutdown(signal?: string) {
+    console.log(`Shutting down soon (signal: ${signal}).`);
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    await this.disconnect();
+  }
+}
+```
+
+---
+
+## Eventing System (`emitEvent` and `@OnEvent`)
+NitroStack includes an internal eventing system to decouple components. A service or tool can emit an event using `emitEvent`, and any injectable class (like a handler service or controller) can subscribe using the `@OnEvent` decorator.
+
+### 1. Emitting Events
+Call `emitEvent` to dispatch an event payload asynchronously.
+
+```typescript
+import { Injectable, emitEvent } from '@nitrostack/core';
+
+@Injectable()
+export class SpaceShipService {
+  async launchShip(shipId: string) {
+    // Process launch...
+    
+    // Dispatch event
+    emitEvent('ship.launched', {
+      shipId,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+```
+
+### 2. Listening to Events
+Decorate a method inside any `@Injectable()` class with `@OnEvent('event_pattern')` to register it as an event handler.
+
+```typescript
+import { Injectable, OnEvent } from '@nitrostack/core';
+
+@Injectable({ deps: [] })
+export class FlightLogHandler {
+  @OnEvent('ship.launched')
+  async logLaunch(data: { shipId: string; timestamp: string }) {
+    console.error(`🚀 [EVENT] Ship ${data.shipId} was successfully launched at ${data.timestamp}`);
+  }
+}
+```
+
+> [!NOTE]
+> For the `@OnEvent` decorator to register properly, the containing class must be declared as a provider inside an active module.

--- a/sample-apps/concord-governance-agent/.antigravity/skills/middleware-pipeline/SKILL.md
+++ b/sample-apps/concord-governance-agent/.antigravity/skills/middleware-pipeline/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: nitrostack-middleware-pipeline
+description: Best practices for implementing and applying Guards, Interceptors, Middleware, Pipes, and Exception Filters in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill when implementing request validation, authorization checks, response mapping, logging, error handling, or performance tracking on NitroStack tool methods.
+
+---
+
+## 1. Guards (`Guard` and `@UseGuards`)
+Guards determine if a request should be processed by a tool handler based on authentication, authorization, or other conditions.
+
+### Interface:
+```typescript
+import { Guard, ExecutionContext } from '@nitrostack/core';
+
+export interface Guard {
+  canActivate(context: ExecutionContext): boolean | Promise<boolean>;
+}
+```
+
+### Example:
+```typescript
+import { Guard, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class RolesGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const userRoles = context.clientMetadata?.roles || [];
+    return userRoles.includes('admin');
+  }
+}
+```
+
+Apply the guard using `@UseGuards(...)`:
+```typescript
+import { Tool, UseGuards, z } from '@nitrostack/core';
+import { RolesGuard } from './roles.guard.js';
+
+export class AdminTools {
+  @Tool({
+    name: 'delete_system_logs',
+    description: 'Delete all system logs from the server.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(RolesGuard)
+  async deleteLogs() {
+    return { success: true };
+  }
+}
+```
+
+---
+
+## 2. Interceptors (`InterceptorInterface` and `@UseInterceptors`)
+Interceptors can transform/intercept input arguments or mapped output from a tool method execution.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface InterceptorInterface {
+  intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { InterceptorInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class TimingInterceptor implements InterceptorInterface {
+  async intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    const start = Date.now();
+    const result = await next();
+    const duration = Date.now() - start;
+    context.logger.info(`Execution took ${duration}ms`);
+    return {
+      ...result,
+      _meta: { durationMs: duration }
+    };
+  }
+}
+```
+
+---
+
+## 3. Exception Filters (`ExceptionFilterInterface` and `@UseFilters`)
+Exception filters catch any errors thrown within guards, interceptors, or the tool handlers themselves, mapping them into user-friendly JSON payloads.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext): unknown | Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { ExceptionFilterInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class CustomExceptionFilter implements ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext) {
+    const message = exception instanceof Error ? exception.message : 'Unknown error';
+    return {
+      error: true,
+      message,
+      timestamp: new Date().toISOString()
+    };
+  }
+}
+```
+
+Apply the filter using `@UseFilters(...)` on a tool method:
+
+```typescript
+import { Tool, UseFilters, z } from '@nitrostack/core';
+import { CustomExceptionFilter } from './custom-exception.filter.js';
+
+export class LoggingTools {
+  @Tool({
+    name: 'generate_report',
+    description: 'Generates system usage reports.',
+    inputSchema: z.object({}),
+  })
+  @UseFilters(CustomExceptionFilter)
+  async generateReport() {
+    throw new Error('Report generation is not implemented yet.');
+  }
+}
+```
+
+---
+
+## 4. Middleware (`MiddlewareInterface`, `@Middleware` and `@UseMiddleware`)
+Middleware executes before the request reaches the tool handler, and can wrap the handler execution by invoking `next()`.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface MiddlewareInterface {
+  use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { Middleware, MiddlewareInterface, ExecutionContext } from '@nitrostack/core';
+
+@Middleware()
+export class LoggingMiddleware implements MiddlewareInterface {
+  async use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    context.logger.info(`Entering tool: ${context.toolName}`);
+    try {
+      const result = await next();
+      context.logger.info(`Exiting tool: ${context.toolName}`);
+      return result;
+    } catch (error) {
+      context.logger.error(`Error in tool: ${error}`);
+      throw error;
+    }
+  }
+}
+```
+
+Apply the middleware using `@UseMiddleware(...)` on a tool method:
+```typescript
+import { Tool, UseMiddleware, z } from '@nitrostack/core';
+import { LoggingMiddleware } from './logging.middleware.js';
+
+export class StationTools {
+  @Tool({
+    name: 'fetch_logs',
+    description: 'Fetch station operations logs.',
+    inputSchema: z.object({}),
+  })
+  @UseMiddleware(LoggingMiddleware)
+  async fetchLogs() {
+    return { status: 'operational' };
+  }
+}
+```
+
+---
+
+## 5. Pipes (`PipeInterface`, `@Pipe` and `@UsePipes`)
+Pipes are used to transform or validate input arguments before they reach the tool handler method.
+
+### Interface:
+```typescript
+import { ArgumentMetadata } from '@nitrostack/core';
+
+export interface PipeInterface<T = unknown, R = unknown> {
+  transform(value: T, metadata: ArgumentMetadata): R | Promise<R>;
+}
+```
+
+### Example:
+```typescript
+import { Pipe, PipeInterface, ArgumentMetadata } from '@nitrostack/core';
+
+@Pipe()
+export class TrimPipe implements PipeInterface<Record<string, unknown>, Record<string, unknown>> {
+  transform(value: Record<string, unknown>, metadata: ArgumentMetadata) {
+    const trimmed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      trimmed[key] = typeof val === 'string' ? val.trim() : val;
+    }
+    return trimmed;
+  }
+}
+```
+
+Apply the pipe using `@UsePipes(...)` on a tool method:
+```typescript
+import { Tool, UsePipes, z } from '@nitrostack/core';
+import { TrimPipe } from './trim.pipe.js';
+
+export class MessagingTools {
+  @Tool({
+    name: 'send_message',
+    description: 'Send a message to other stations.',
+    inputSchema: z.object({ text: z.string() }),
+  })
+  @UsePipes(TrimPipe)
+  async sendMessage(input: { text: string }) {
+    return { sentText: input.text };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.antigravity/skills/tools-resources-prompts/SKILL.md
+++ b/sample-apps/concord-governance-agent/.antigravity/skills/tools-resources-prompts/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: nitrostack-tools-resources-prompts
+description: Guidelines and patterns for defining Tools, Resources, and Prompts in a NitroStack application with schema validation via Zod, including caching, rate-limiting, and base64 file uploads.
+---
+
+## When to Use
+Use this skill whenever you are defining, editing, or validating tools, resources, or prompts on a NitroStack MCP server.
+
+## Defining Tools with `@Tool`
+An MCP tool exposes a function that an AI client can invoke. Decorate a service or controller method with `@Tool`.
+
+### Key Tool Options:
+* `name`: Kebab-case or snake_case unique identifier.
+* `description`: Detailed description explaining when and how the client should use it.
+* `inputSchema`: A Zod object schema for strict validation of inputs.
+* `outputSchema` (optional): Zod schema validating the output structure.
+
+```typescript
+import { ToolDecorator as Tool, ControllerDecorator as Controller, InitialTool, z, ExecutionContext } from '@nitrostack/core';
+
+@Controller('weather')
+export class WeatherService {
+  @Tool({
+    name: 'get_current_weather',
+    description: 'Get the current weather forecast for a specific city.',
+    inputSchema: z.object({
+      city: z.string().describe('The name of the city, e.g., San Francisco'),
+      unit: z.enum(['celsius', 'fahrenheit']).default('celsius'),
+    }),
+  })
+  @InitialTool() // Auto-invoked when the AI client initializes/starts
+  async getWeather(
+    input: { city: string; unit: 'celsius' | 'fahrenheit' },
+    ctx: ExecutionContext
+  ) {
+    ctx.logger.info(`Fetching weather for ${input.city}`);
+    // implementation
+    return {
+      city: input.city,
+      temp: 22,
+      condition: 'Sunny',
+    };
+  }
+}
+```
+
+## Defining Resources with `@Resource`
+An MCP resource exposes static or dynamic data files/URIs that the AI client can read.
+
+### Key Resource Options:
+* `uri`: URI pattern (e.g., `git://{owner}/{repo}/file` or static `app://config`).
+* `name`: Unique name of the resource.
+* `description`: Explanation of what data this resource provides.
+* `mimeType`: Mime type of the response (e.g., `text/plain`, `application/json`).
+
+```typescript
+import { Resource, ExecutionContext } from '@nitrostack/core';
+
+export class ConfigResources {
+  @Resource({
+    uri: 'app://settings',
+    name: 'Application Settings',
+    description: 'System-wide configuration settings and parameters.',
+    mimeType: 'application/json',
+  })
+  async getSettings(ctx: ExecutionContext) {
+    return {
+      environment: 'development',
+      debugMode: true,
+    };
+  }
+}
+```
+
+## Defining Prompts with `@Prompt`
+An MCP prompt exposes reusable templates or instruction sets that guide LLMs.
+
+### Key Prompt Options:
+* `name`: Name of the prompt.
+* `description`: Describes what task this prompt helps accomplish.
+* `arguments`: Declares parameters the client can supply to customize the prompt template.
+
+```typescript
+import { Prompt, ExecutionContext } from '@nitrostack/core';
+
+export class PromptTemplates {
+  @Prompt({
+    name: 'code_review',
+    description: 'Provide an intensive code review for a given code snippet.',
+    arguments: [
+      { name: 'language', description: 'The programming language, e.g., TypeScript', required: true },
+      { name: 'code', description: 'The code snippet to review', required: true },
+    ],
+  })
+  async getCodeReviewPrompt(
+    args: { language: string; code: string },
+    ctx: ExecutionContext
+  ) {
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: `You are an expert software engineer. Review this ${args.language} code:\n\n${args.code}`,
+        },
+      ],
+    };
+  }
+}
+```
+
+---
+
+## Tool Policies: Caching (`@Cache`) and Rate Limiting (`@RateLimit`)
+You can control tool execution behaviors (such as performance optimization and throttling) using method decorators.
+
+### 1. Caching with `@Cache`
+Use `@Cache` to cache tool execution outputs for a specified duration (TTL in seconds). This reduces database or API overhead for frequent identical requests.
+
+#### Options:
+* `ttl`: Cache time-to-live in seconds (required).
+* `key` (optional): Custom function `(input: any, context?: any) => string` that returns a unique cache key based on inputs. If not defined, a key is auto-generated from serialized input arguments.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, Cache, z } from '@nitrostack/core';
+
+export class StationTools {
+  @Tool({
+    name: 'get_system_status',
+    description: 'Fetch real-time station metrics. Response is cached.',
+    inputSchema: z.object({}),
+  })
+  @Cache({ ttl: 60 }) // Caches status for 60 seconds
+  async getSystemStatus() {
+    return { temperature: 21.5, oxygen: 0.98 };
+  }
+
+  @Tool({
+    name: 'get_crew_status',
+    description: 'Fetch status of a crew member. Cached by crew ID.',
+    inputSchema: z.object({ id: z.string() }),
+  })
+  @Cache({
+    ttl: 300,
+    key: (input) => `crew:status:${input.id}`
+  })
+  async getCrewStatus(input: { id: string }) {
+    // ...
+  }
+}
+```
+
+### 2. Rate Limiting with `@RateLimit`
+Use `@RateLimit` to restrict the number of tool invocations within a specified time window to prevent client abuse.
+
+#### Options:
+* `requests`: Number of allowed requests in the window (required).
+* `window`: Throttling duration window (required). Supports formats like `'1s'`, `'1m'`, `'1h'`.
+* `key` (optional): Custom function `(context: ExecutionContext) => string` to group rate limits. Useful for rate-limiting per user role or API key.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, RateLimit, z, ExecutionContext } from '@nitrostack/core';
+
+export class DiagnosticTools {
+  @Tool({
+    name: 'run_deep_diagnostic',
+    description: 'Run intensive diagnostics. Rate limited.',
+    inputSchema: z.object({}),
+  })
+  @RateLimit({ requests: 3, window: '1m' }) // Max 3 requests per minute globally
+  async runDeepDiagnostic() {
+    return { diagnosticReport: 'All systems operational.' };
+  }
+
+  @Tool({
+    name: 'request_supply_drop',
+    description: 'Request inventory supplies. Rate limited per user.',
+    inputSchema: z.object({ item: z.string() }),
+  })
+  @RateLimit({
+    requests: 5,
+    window: '1h',
+    key: (ctx: ExecutionContext) => ctx.auth?.subject || 'anonymous'
+  })
+  async requestSupply(input: { item: string }, ctx: ExecutionContext) {
+    // ...
+  }
+}
+```
+
+---
+
+## Handling File Uploads in Tools
+NitroStack supports file uploads from MCP clients (like NitroStudio) by passing the file as a base64-encoded string inside a tool's input parameters.
+
+### 1. Declaring Input Schema for File Uploads
+To accept an uploaded file, define three Zod fields in your tool's `inputSchema`:
+* `file_name`: The name of the file (e.g. `report.csv`).
+* `file_type`: The MIME type (e.g. `text/csv`).
+* `file_content`: The base64-encoded string containing the file data.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+
+export class FileTools {
+  @Tool({
+    name: 'upload_document',
+    description: 'Upload a text document or image.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async uploadDocument(input: any, ctx: ExecutionContext) {
+    // Processing logic
+  }
+}
+```
+
+### 2. Decoding Base64 Payloads
+File uploads can arrive in two formats depending on the client:
+1. **Data URL format**: `data:image/png;base64,iVBORw0KGgo...`
+2. **Raw Base64 format**: `iVBORw0KGgo...`
+
+Use the following universal decoder pattern to parse either format into a Node `Buffer`:
+
+```typescript
+import * as fs from 'fs';
+import * as path from 'path';
+
+function decodeBase64File(content: string): Buffer {
+  const matches = content.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/);
+  
+  if (matches && matches.length === 3) {
+    // Data URL format - decode matches[2]
+    return Buffer.from(matches[2], 'base64');
+  } else {
+    // Raw base64 format - decode input directly
+    return Buffer.from(content, 'base64');
+  }
+}
+```
+
+### 3. Secure File Saving Example
+Always validate the directory paths to prevent directory traversal attacks when saving files to disk.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads');
+
+export class SecureUploadTools {
+  @Tool({
+    name: 'save_uploaded_file',
+    description: 'Decodes and saves an uploaded file securely.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async saveFile(input: any, ctx: ExecutionContext) {
+    // Ensure uploads directory exists
+    if (!fs.existsSync(UPLOAD_DIR)) {
+      fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+    }
+
+    // Secure destination path to prevent path traversal
+    const safeName = path.basename(input.file_name);
+    const filePath = path.join(UPLOAD_DIR, safeName);
+    if (!filePath.startsWith(UPLOAD_DIR)) {
+      throw new Error('Invalid file path detected (path traversal).');
+    }
+
+    // Decode and write to disk
+    const buffer = decodeBase64File(input.file_content);
+    fs.writeFileSync(filePath, buffer);
+
+    ctx.logger.info(`Successfully saved file: ${safeName}`);
+    return { success: true, path: filePath };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.antigravity/skills/ui-widgets/SKILL.md
+++ b/sample-apps/concord-governance-agent/.antigravity/skills/ui-widgets/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: nitrostack-ui-widgets
+description: Best practices for linking tools to interactive frontend widgets using @Widget and @nitrostack/widgets SDK (including state sync, tool calling, display modes, media queries, and chat actions).
+---
+
+## When to Use
+Use this skill when designing, building, or modifying interactive user interface widgets that display custom React content inside AI clients or NitroStudio.
+
+---
+
+## 1. Backend Definition (`@Widget`)
+To display a React-based widget for a tool's output, decorate the tool method with `@Widget`.
+
+### Options:
+* **String Route**: A simple string representing the route identifier in the frontend React app (e.g. `'product-card'`).
+* **Object Route**: Object including:
+  * `route` (required): The route path.
+  * `domain` (optional): Allowed sandbox domain.
+  * `csp` (optional): Content Security Policy guidelines.
+
+### Example:
+```typescript
+import { Tool, Widget, z } from '@nitrostack/core';
+
+export class CatalogTools {
+  @Tool({
+    name: 'fetch_product',
+    description: 'Get product information by barcode.',
+    inputSchema: z.object({ barcode: z.string() }),
+  })
+  @Widget('product-details') // Maps to the "product-details" frontend component
+  async fetchProduct(input: { barcode: string }) {
+    return {
+      name: 'Super Nitro Energy Drink',
+      price: 2.99,
+      sku: input.barcode,
+    };
+  }
+}
+```
+
+---
+
+## 2. Frontend React Widget (`@nitrostack/widgets`)
+In your React widget frontend application (typically a Next.js client component), use the `useWidgetSDK` hook to receive input data from the client host.
+
+### React Component Example:
+```tsx
+'use client';
+
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+interface ProductData {
+  name: string;
+  price: number;
+  sku: string;
+}
+
+export default function ProductDetailsWidget() {
+  const { isReady, getToolOutput, theme } = useWidgetSDK();
+  const data = getToolOutput<ProductData>();
+
+  if (!isReady) {
+    return <div className="loading">Connecting to host...</div>;
+  }
+
+  if (!data) {
+    return <div className="error">No product data received.</div>;
+  }
+
+  return (
+    <div className={`product-card ${theme === 'dark' ? 'dark' : 'light'}`}>
+      <h3>{data.name}</h3>
+      <p className="price">${data.price.toFixed(2)}</p>
+      <span className="sku">SKU: {data.sku}</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 3. State Management & Synchronization (`useWidgetState`)
+Use `useWidgetState` to manage and persist client-side widget state (e.g. selected tabs, filter values, input states). This state automatically synchronizes with the host application context, persisting it across page re-renders.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetState } from '@nitrostack/widgets';
+
+export default function StationPanelWidget() {
+  const [state, setState] = useWidgetState(() => ({
+    selectedTab: 'overview',
+    showExtendedInfo: false,
+  }));
+
+  return (
+    <div>
+      <button onClick={() => setState({ ...state, selectedTab: 'alerts' })}>
+        View Alerts
+      </button>
+      <p>Current Tab: {state?.selectedTab}</p>
+    </div>
+  );
+}
+```
+
+---
+
+## 4. Calling Core Tools from Widgets (`callTool`)
+You can invoke other backend MCP tools directly from the frontend widget using `callTool`. This is useful for tool chaining or triggering detailed audits.
+
+### Example:
+```tsx
+import React, { useState } from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function SystemDiagnostics() {
+  const { callTool, isReady } = useWidgetSDK();
+  const [isRunning, setIsRunning] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+
+  const runDiagnostic = async () => {
+    if (!isReady) return;
+    setIsRunning(true);
+    try {
+      const response = await callTool('run_diagnostic', { system: 'oxygen_scrubber' });
+      setResult(response.result as string);
+    } catch (err) {
+      setResult('Diagnostic execution failed.');
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <button onClick={runDiagnostic} disabled={isRunning}>
+      {isRunning ? 'Running...' : 'Run Diagnostics'}
+    </button>
+  );
+}
+```
+
+---
+
+## 5. Layout & Display Controls
+Widgets can dynamically request size mode changes (fullscreen, inline, picture-in-picture) and adapt layouts to safe areas (dynamic islands/notches) or maximum height constraints.
+
+### Key Methods:
+* `requestFullscreen()`: Switch host widget display to fullscreen.
+* `requestInline()`: Switch host widget display back to inline.
+* `requestPip()`: Float widget in Picture-in-Picture.
+* `requestClose()`: Dismiss the widget completely.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function StatusBoard() {
+  const { 
+    requestFullscreen, 
+    requestInline, 
+    requestClose,
+    displayMode,   // Reactive property ('fullscreen' | 'inline' | 'pip')
+    maxHeight,     // Reactive maxHeight constraint (in pixels)
+    getSafeArea    // Insets data: { top, right, bottom, left }
+  } = useWidgetSDK();
+
+  const safeArea = getSafeArea() || { top: 0, bottom: 0 };
+
+  return (
+    <div style={{ maxHeight: maxHeight || 400, paddingTop: safeArea.top }}>
+      <h3>Mode: {displayMode}</h3>
+      <button onClick={requestFullscreen}>Fullscreen</button>
+      <button onClick={requestInline}>Collapse</button>
+      <button onClick={requestClose}>Dismiss Widget</button>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. Chat Navigation & Actions
+Widgets can interact with the host chat pane using external browser links and follow-up prompts.
+
+### Key Methods:
+* `openExternal(url)`: Open the target URL safely in the user's primary external browser.
+* `sendFollowUpMessage(prompt)`: Insert a message into the chat flow, automatically submitting it to the LLM agent.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function MissionControl() {
+  const { openExternal, sendFollowUpMessage } = useWidgetSDK();
+
+  return (
+    <div>
+      {/* Open external documentation */}
+      <button onClick={() => openExternal('https://docs.nitrostack.dev')}>
+        Open Manual
+      </button>
+
+      {/* Ask LLM agent directly from the widget */}
+      <button onClick={() => sendFollowUpMessage('Analyze mission failures from last week')}>
+        Ask Agent to Analyze
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 7. Media & Accessibility Queries
+The SDK provides helper utilities to query target client capabilities for styling or accessibility.
+
+### Key Utilities:
+* `prefersReducedMotion()`: Returns `true` if client settings specify reduced motion. Disable animations.
+* `isPrimarilyTouchDevice()`: Returns `true` if the device has a coarse pointer (e.g. touch/mobile). Increase button target sizes.
+* `isHoverAvailable()`: Returns `true` if pointer supports hover states.
+* `prefersDarkColorScheme()`: Returns `true` if the system theme is dark.
+
+### Example:
+```tsx
+import React from 'react';
+import { isPrimarilyTouchDevice, prefersReducedMotion } from '@nitrostack/widgets';
+
+export default function AccessiblePanel() {
+  const isTouch = isPrimarilyTouchDevice();
+  const reducedMotion = prefersReducedMotion();
+
+  return (
+    <div className={reducedMotion ? 'no-animations' : 'smooth-transitions'}>
+      <button style={{ padding: isTouch ? '16px' : '8px' }}>
+        Interactive Button
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 8. Testing Widgets
+* Open your project in **NitroStudio** for visual preview.
+* Invoke the tool from the AI chat or testing pane to verify the widget updates instantly with the returned JSON structure.

--- a/sample-apps/concord-governance-agent/.claude/skills/auth-security/SKILL.md
+++ b/sample-apps/concord-governance-agent/.claude/skills/auth-security/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: nitrostack-auth-security
+description: Best practices for implementing JWT, API Keys, OAuth 2.1, and RBAC in a NitroStack application.
+---
+
+## When to Use
+Use this skill when configuring security modules, implementing user authentication, restricting tool access via guards, or handling sensitive tokens.
+
+---
+
+## 1. JSON Web Tokens (JWT)
+To secure tools with JWT authentication:
+
+### Register `JWTModule`:
+```typescript
+import { JWTModule, Module, McpApp } from '@nitrostack/core';
+
+@McpApp({
+  server: { name: 'my-server', version: '1.0.0' }
+})
+@Module({
+  imports: [
+    JWTModule.forRoot({
+      secret: process.env.JWT_SECRET!,
+      expiresIn: '7d',
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### Write a `JWTGuard`:
+```typescript
+import { Guard, ExecutionContext, Injectable, ConfigService } from '@nitrostack/core';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class JWTGuard implements Guard {
+  constructor(private config: ConfigService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const token = this.extractToken(context);
+    if (!token) return false;
+
+    try {
+      const secret = this.config.get('JWT_SECRET');
+      const payload = jwt.verify(token, secret) as any;
+      context.auth = {
+        subject: payload.sub,
+        role: payload.role,
+        token,
+      };
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private extractToken(context: ExecutionContext): string | null {
+    const auth = context.metadata?.authorization;
+    if (auth?.startsWith('Bearer ')) {
+      return auth.substring(7);
+    }
+    return null;
+  }
+}
+```
+
+---
+
+## 2. API Key Authentication
+Use `ApiKeyModule` for service-to-service validation.
+
+### Register `ApiKeyModule`:
+```typescript
+import { ApiKeyModule, Module } from '@nitrostack/core';
+
+@Module({
+  imports: [
+    ApiKeyModule.forRoot({
+      keysEnvPrefix: 'API_KEY', // Reads API_KEY_1, API_KEY_2, etc.
+      headerName: 'x-api-key',
+      hashed: false,
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### API Key Guard:
+```typescript
+import { Guard, ExecutionContext, ApiKeyModule } from '@nitrostack/core';
+
+export class ApiKeyGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const apiKey = context.metadata?.['x-api-key'] || context.metadata?.apiKey;
+    if (!apiKey) return false;
+
+    const isValid = await ApiKeyModule.validate(apiKey as string);
+    if (isValid) {
+      context.auth = {
+        subject: `apikey_${(apiKey as string).substring(0, 10)}`,
+        scopes: ['*'],
+      };
+      return true;
+    }
+    return false;
+  }
+}
+```
+
+---
+
+## 3. Role-Based Access Control (RBAC)
+Chain guards sequentially to implement user-role authorization.
+
+```typescript
+import { Injectable, Guard, ExecutionContext, UseGuards, Tool, z } from '@nitrostack/core';
+import { JWTGuard } from './jwt.guard.js';
+
+@Injectable()
+export class AdminGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Requires JWTGuard to have populated context.auth first
+    return context.auth?.role === 'admin';
+  }
+}
+
+// Applying chained guards to a tool
+export class SystemTools {
+  @Tool({
+    name: 'reset_database',
+    description: 'Dangerous action: wipes database. Admin only.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(JWTGuard, AdminGuard) // Chain auth first, then role check
+  async resetDatabase() {
+    return { success: true };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.claude/skills/mcp-app-architecture/SKILL.md
+++ b/sample-apps/concord-governance-agent/.claude/skills/mcp-app-architecture/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: nitrostack-mcp-app-architecture
+description: Best practices and guidelines for bootstrapping, defining modules, using dependency injection, managing server lifecycles, and handling events in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill whenever you are bootstrapping a new NitroStack MCP server, creating modules, injecting services, or handling application lifecycle events.
+
+## Bootstrapping a NitroStack App
+A NitroStack application is initialized with the `@McpApp` decorator on a root class, accompanied by a root `@Module`.
+
+```typescript
+import { McpApp, Module } from '@nitrostack/core';
+import { DatabaseModule } from './database/database.module.js';
+import { UsersModule } from './users/users.module.js';
+
+@McpApp({
+  module: AppModule,
+  server: {
+    name: 'user-management-server',
+    version: '1.0.0',
+  },
+})
+@Module({
+  imports: [DatabaseModule, UsersModule],
+})
+export class AppModule {}
+```
+
+## Modules
+Modules organize your application structure. Use the `@Module` decorator to define imports, exports, and providers.
+
+* **`imports`**: Other modules whose exported providers should be available in this module.
+* **`providers`**: Services, tools, resources, or prompts that should be instantiated and managed by the DI container within this module.
+* **`exports`**: Providers defined in this module that should be visible to other modules importing this one.
+
+```typescript
+import { Module } from '@nitrostack/core';
+import { UsersService } from './users.service.js';
+import { UsersTools } from './users.tools.js';
+
+@Module({
+  providers: [UsersService, UsersTools],
+  exports: [UsersService],
+})
+
+## Controllers
+Use the `@ControllerDecorator` (or alias it as `@Controller`) to group tools, resources, and prompts together. Controllers are automatically registered as singletons in the DI container.
+
+### Key Controller Options:
+* **`prefix`**: A string prefix applied to every `@Tool` defined in this controller. For example, `@ControllerDecorator('github')` prefixing a tool named `create_issue` exposes it to MCP clients as `github_create_issue`.
+
+```typescript
+import { ControllerDecorator as Controller, Tool, ExecutionContext } from '@nitrostack/core';
+
+@Controller('github')
+export class GitHubController {
+  @Tool({
+    name: 'create_issue',
+    description: 'Create an issue in a repository',
+    inputSchema: z.object({ /* ... */ })
+  })
+  async createIssue(input: any, ctx: ExecutionContext) {
+    // Exposed to clients as "github_create_issue"
+  }
+}
+```
+
+## Dependency Injection (DI)
+NitroStack uses a robust dependency injection container to manage class instances and lifecycles.
+
+### Injection Lifecycles
+1. **Singleton (Default)**: A single instance is shared across the entire application.
+2. **Transient**: A new instance is created every time it is resolved/injected.
+3. **Scoped**: A new instance is created per incoming request or context.
+
+```typescript
+import { Injectable, Scope } from '@nitrostack/core';
+
+@Injectable({ scope: Scope.SINGLETON })
+export class UsersService {
+  constructor(private readonly db: DatabaseService) {}
+  
+  async getUser(id: string) {
+    return this.db.query('SELECT * FROM users WHERE id = $1', [id]);
+  }
+}
+```
+
+## Lifecycles and Hooks
+Implement NestJS-style lifecycle interfaces on modules, controllers, or providers to hook into application state changes:
+
+* **`OnModuleInit`** (`onModuleInit`): Called after modules have initialized but before the server starts listening.
+* **`OnApplicationBootstrap`** (`onApplicationBootstrap`): Called once the server is fully started and listening.
+* **`OnModuleDestroy`** (`onModuleDestroy`): Called when the module or application is shutting down.
+* **`BeforeApplicationShutdown`** (`beforeApplicationShutdown(signal?: string)`): Called before the application starts shutting down. Receives the OS signal (e.g. `SIGINT`).
+* **`OnApplicationShutdown`** (`onApplicationShutdown(signal?: string)`): Called during shutdown. Receives the OS signal.
+
+```typescript
+import { 
+  Injectable, 
+  OnModuleInit, 
+  OnApplicationBootstrap,
+  OnModuleDestroy, 
+  BeforeApplicationShutdown,
+  OnApplicationShutdown 
+} from '@nitrostack/core';
+
+@Injectable()
+export class DatabaseService 
+  implements OnModuleInit, OnApplicationBootstrap, OnModuleDestroy, BeforeApplicationShutdown, OnApplicationShutdown 
+{
+  async onModuleInit() {
+    await this.connect();
+  }
+
+  async onApplicationBootstrap() {
+    console.log('App ready to handle connections.');
+  }
+
+  async onModuleDestroy() {
+    await this.cleanupPendingQueries();
+  }
+
+  async beforeApplicationShutdown(signal?: string) {
+    console.log(`Shutting down soon (signal: ${signal}).`);
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    await this.disconnect();
+  }
+}
+```
+
+---
+
+## Eventing System (`emitEvent` and `@OnEvent`)
+NitroStack includes an internal eventing system to decouple components. A service or tool can emit an event using `emitEvent`, and any injectable class (like a handler service or controller) can subscribe using the `@OnEvent` decorator.
+
+### 1. Emitting Events
+Call `emitEvent` to dispatch an event payload asynchronously.
+
+```typescript
+import { Injectable, emitEvent } from '@nitrostack/core';
+
+@Injectable()
+export class SpaceShipService {
+  async launchShip(shipId: string) {
+    // Process launch...
+    
+    // Dispatch event
+    emitEvent('ship.launched', {
+      shipId,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+```
+
+### 2. Listening to Events
+Decorate a method inside any `@Injectable()` class with `@OnEvent('event_pattern')` to register it as an event handler.
+
+```typescript
+import { Injectable, OnEvent } from '@nitrostack/core';
+
+@Injectable({ deps: [] })
+export class FlightLogHandler {
+  @OnEvent('ship.launched')
+  async logLaunch(data: { shipId: string; timestamp: string }) {
+    console.error(`🚀 [EVENT] Ship ${data.shipId} was successfully launched at ${data.timestamp}`);
+  }
+}
+```
+
+> [!NOTE]
+> For the `@OnEvent` decorator to register properly, the containing class must be declared as a provider inside an active module.

--- a/sample-apps/concord-governance-agent/.claude/skills/middleware-pipeline/SKILL.md
+++ b/sample-apps/concord-governance-agent/.claude/skills/middleware-pipeline/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: nitrostack-middleware-pipeline
+description: Best practices for implementing and applying Guards, Interceptors, Middleware, Pipes, and Exception Filters in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill when implementing request validation, authorization checks, response mapping, logging, error handling, or performance tracking on NitroStack tool methods.
+
+---
+
+## 1. Guards (`Guard` and `@UseGuards`)
+Guards determine if a request should be processed by a tool handler based on authentication, authorization, or other conditions.
+
+### Interface:
+```typescript
+import { Guard, ExecutionContext } from '@nitrostack/core';
+
+export interface Guard {
+  canActivate(context: ExecutionContext): boolean | Promise<boolean>;
+}
+```
+
+### Example:
+```typescript
+import { Guard, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class RolesGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const userRoles = context.clientMetadata?.roles || [];
+    return userRoles.includes('admin');
+  }
+}
+```
+
+Apply the guard using `@UseGuards(...)`:
+```typescript
+import { Tool, UseGuards, z } from '@nitrostack/core';
+import { RolesGuard } from './roles.guard.js';
+
+export class AdminTools {
+  @Tool({
+    name: 'delete_system_logs',
+    description: 'Delete all system logs from the server.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(RolesGuard)
+  async deleteLogs() {
+    return { success: true };
+  }
+}
+```
+
+---
+
+## 2. Interceptors (`InterceptorInterface` and `@UseInterceptors`)
+Interceptors can transform/intercept input arguments or mapped output from a tool method execution.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface InterceptorInterface {
+  intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { InterceptorInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class TimingInterceptor implements InterceptorInterface {
+  async intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    const start = Date.now();
+    const result = await next();
+    const duration = Date.now() - start;
+    context.logger.info(`Execution took ${duration}ms`);
+    return {
+      ...result,
+      _meta: { durationMs: duration }
+    };
+  }
+}
+```
+
+---
+
+## 3. Exception Filters (`ExceptionFilterInterface` and `@UseFilters`)
+Exception filters catch any errors thrown within guards, interceptors, or the tool handlers themselves, mapping them into user-friendly JSON payloads.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext): unknown | Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { ExceptionFilterInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class CustomExceptionFilter implements ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext) {
+    const message = exception instanceof Error ? exception.message : 'Unknown error';
+    return {
+      error: true,
+      message,
+      timestamp: new Date().toISOString()
+    };
+  }
+}
+```
+
+Apply the filter using `@UseFilters(...)` on a tool method:
+
+```typescript
+import { Tool, UseFilters, z } from '@nitrostack/core';
+import { CustomExceptionFilter } from './custom-exception.filter.js';
+
+export class LoggingTools {
+  @Tool({
+    name: 'generate_report',
+    description: 'Generates system usage reports.',
+    inputSchema: z.object({}),
+  })
+  @UseFilters(CustomExceptionFilter)
+  async generateReport() {
+    throw new Error('Report generation is not implemented yet.');
+  }
+}
+```
+
+---
+
+## 4. Middleware (`MiddlewareInterface`, `@Middleware` and `@UseMiddleware`)
+Middleware executes before the request reaches the tool handler, and can wrap the handler execution by invoking `next()`.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface MiddlewareInterface {
+  use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { Middleware, MiddlewareInterface, ExecutionContext } from '@nitrostack/core';
+
+@Middleware()
+export class LoggingMiddleware implements MiddlewareInterface {
+  async use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    context.logger.info(`Entering tool: ${context.toolName}`);
+    try {
+      const result = await next();
+      context.logger.info(`Exiting tool: ${context.toolName}`);
+      return result;
+    } catch (error) {
+      context.logger.error(`Error in tool: ${error}`);
+      throw error;
+    }
+  }
+}
+```
+
+Apply the middleware using `@UseMiddleware(...)` on a tool method:
+```typescript
+import { Tool, UseMiddleware, z } from '@nitrostack/core';
+import { LoggingMiddleware } from './logging.middleware.js';
+
+export class StationTools {
+  @Tool({
+    name: 'fetch_logs',
+    description: 'Fetch station operations logs.',
+    inputSchema: z.object({}),
+  })
+  @UseMiddleware(LoggingMiddleware)
+  async fetchLogs() {
+    return { status: 'operational' };
+  }
+}
+```
+
+---
+
+## 5. Pipes (`PipeInterface`, `@Pipe` and `@UsePipes`)
+Pipes are used to transform or validate input arguments before they reach the tool handler method.
+
+### Interface:
+```typescript
+import { ArgumentMetadata } from '@nitrostack/core';
+
+export interface PipeInterface<T = unknown, R = unknown> {
+  transform(value: T, metadata: ArgumentMetadata): R | Promise<R>;
+}
+```
+
+### Example:
+```typescript
+import { Pipe, PipeInterface, ArgumentMetadata } from '@nitrostack/core';
+
+@Pipe()
+export class TrimPipe implements PipeInterface<Record<string, unknown>, Record<string, unknown>> {
+  transform(value: Record<string, unknown>, metadata: ArgumentMetadata) {
+    const trimmed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      trimmed[key] = typeof val === 'string' ? val.trim() : val;
+    }
+    return trimmed;
+  }
+}
+```
+
+Apply the pipe using `@UsePipes(...)` on a tool method:
+```typescript
+import { Tool, UsePipes, z } from '@nitrostack/core';
+import { TrimPipe } from './trim.pipe.js';
+
+export class MessagingTools {
+  @Tool({
+    name: 'send_message',
+    description: 'Send a message to other stations.',
+    inputSchema: z.object({ text: z.string() }),
+  })
+  @UsePipes(TrimPipe)
+  async sendMessage(input: { text: string }) {
+    return { sentText: input.text };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.claude/skills/tools-resources-prompts/SKILL.md
+++ b/sample-apps/concord-governance-agent/.claude/skills/tools-resources-prompts/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: nitrostack-tools-resources-prompts
+description: Guidelines and patterns for defining Tools, Resources, and Prompts in a NitroStack application with schema validation via Zod, including caching, rate-limiting, and base64 file uploads.
+---
+
+## When to Use
+Use this skill whenever you are defining, editing, or validating tools, resources, or prompts on a NitroStack MCP server.
+
+## Defining Tools with `@Tool`
+An MCP tool exposes a function that an AI client can invoke. Decorate a service or controller method with `@Tool`.
+
+### Key Tool Options:
+* `name`: Kebab-case or snake_case unique identifier.
+* `description`: Detailed description explaining when and how the client should use it.
+* `inputSchema`: A Zod object schema for strict validation of inputs.
+* `outputSchema` (optional): Zod schema validating the output structure.
+
+```typescript
+import { ToolDecorator as Tool, ControllerDecorator as Controller, InitialTool, z, ExecutionContext } from '@nitrostack/core';
+
+@Controller('weather')
+export class WeatherService {
+  @Tool({
+    name: 'get_current_weather',
+    description: 'Get the current weather forecast for a specific city.',
+    inputSchema: z.object({
+      city: z.string().describe('The name of the city, e.g., San Francisco'),
+      unit: z.enum(['celsius', 'fahrenheit']).default('celsius'),
+    }),
+  })
+  @InitialTool() // Auto-invoked when the AI client initializes/starts
+  async getWeather(
+    input: { city: string; unit: 'celsius' | 'fahrenheit' },
+    ctx: ExecutionContext
+  ) {
+    ctx.logger.info(`Fetching weather for ${input.city}`);
+    // implementation
+    return {
+      city: input.city,
+      temp: 22,
+      condition: 'Sunny',
+    };
+  }
+}
+```
+
+## Defining Resources with `@Resource`
+An MCP resource exposes static or dynamic data files/URIs that the AI client can read.
+
+### Key Resource Options:
+* `uri`: URI pattern (e.g., `git://{owner}/{repo}/file` or static `app://config`).
+* `name`: Unique name of the resource.
+* `description`: Explanation of what data this resource provides.
+* `mimeType`: Mime type of the response (e.g., `text/plain`, `application/json`).
+
+```typescript
+import { Resource, ExecutionContext } from '@nitrostack/core';
+
+export class ConfigResources {
+  @Resource({
+    uri: 'app://settings',
+    name: 'Application Settings',
+    description: 'System-wide configuration settings and parameters.',
+    mimeType: 'application/json',
+  })
+  async getSettings(ctx: ExecutionContext) {
+    return {
+      environment: 'development',
+      debugMode: true,
+    };
+  }
+}
+```
+
+## Defining Prompts with `@Prompt`
+An MCP prompt exposes reusable templates or instruction sets that guide LLMs.
+
+### Key Prompt Options:
+* `name`: Name of the prompt.
+* `description`: Describes what task this prompt helps accomplish.
+* `arguments`: Declares parameters the client can supply to customize the prompt template.
+
+```typescript
+import { Prompt, ExecutionContext } from '@nitrostack/core';
+
+export class PromptTemplates {
+  @Prompt({
+    name: 'code_review',
+    description: 'Provide an intensive code review for a given code snippet.',
+    arguments: [
+      { name: 'language', description: 'The programming language, e.g., TypeScript', required: true },
+      { name: 'code', description: 'The code snippet to review', required: true },
+    ],
+  })
+  async getCodeReviewPrompt(
+    args: { language: string; code: string },
+    ctx: ExecutionContext
+  ) {
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: `You are an expert software engineer. Review this ${args.language} code:\n\n${args.code}`,
+        },
+      ],
+    };
+  }
+}
+```
+
+---
+
+## Tool Policies: Caching (`@Cache`) and Rate Limiting (`@RateLimit`)
+You can control tool execution behaviors (such as performance optimization and throttling) using method decorators.
+
+### 1. Caching with `@Cache`
+Use `@Cache` to cache tool execution outputs for a specified duration (TTL in seconds). This reduces database or API overhead for frequent identical requests.
+
+#### Options:
+* `ttl`: Cache time-to-live in seconds (required).
+* `key` (optional): Custom function `(input: any, context?: any) => string` that returns a unique cache key based on inputs. If not defined, a key is auto-generated from serialized input arguments.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, Cache, z } from '@nitrostack/core';
+
+export class StationTools {
+  @Tool({
+    name: 'get_system_status',
+    description: 'Fetch real-time station metrics. Response is cached.',
+    inputSchema: z.object({}),
+  })
+  @Cache({ ttl: 60 }) // Caches status for 60 seconds
+  async getSystemStatus() {
+    return { temperature: 21.5, oxygen: 0.98 };
+  }
+
+  @Tool({
+    name: 'get_crew_status',
+    description: 'Fetch status of a crew member. Cached by crew ID.',
+    inputSchema: z.object({ id: z.string() }),
+  })
+  @Cache({
+    ttl: 300,
+    key: (input) => `crew:status:${input.id}`
+  })
+  async getCrewStatus(input: { id: string }) {
+    // ...
+  }
+}
+```
+
+### 2. Rate Limiting with `@RateLimit`
+Use `@RateLimit` to restrict the number of tool invocations within a specified time window to prevent client abuse.
+
+#### Options:
+* `requests`: Number of allowed requests in the window (required).
+* `window`: Throttling duration window (required). Supports formats like `'1s'`, `'1m'`, `'1h'`.
+* `key` (optional): Custom function `(context: ExecutionContext) => string` to group rate limits. Useful for rate-limiting per user role or API key.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, RateLimit, z, ExecutionContext } from '@nitrostack/core';
+
+export class DiagnosticTools {
+  @Tool({
+    name: 'run_deep_diagnostic',
+    description: 'Run intensive diagnostics. Rate limited.',
+    inputSchema: z.object({}),
+  })
+  @RateLimit({ requests: 3, window: '1m' }) // Max 3 requests per minute globally
+  async runDeepDiagnostic() {
+    return { diagnosticReport: 'All systems operational.' };
+  }
+
+  @Tool({
+    name: 'request_supply_drop',
+    description: 'Request inventory supplies. Rate limited per user.',
+    inputSchema: z.object({ item: z.string() }),
+  })
+  @RateLimit({
+    requests: 5,
+    window: '1h',
+    key: (ctx: ExecutionContext) => ctx.auth?.subject || 'anonymous'
+  })
+  async requestSupply(input: { item: string }, ctx: ExecutionContext) {
+    // ...
+  }
+}
+```
+
+---
+
+## Handling File Uploads in Tools
+NitroStack supports file uploads from MCP clients (like NitroStudio) by passing the file as a base64-encoded string inside a tool's input parameters.
+
+### 1. Declaring Input Schema for File Uploads
+To accept an uploaded file, define three Zod fields in your tool's `inputSchema`:
+* `file_name`: The name of the file (e.g. `report.csv`).
+* `file_type`: The MIME type (e.g. `text/csv`).
+* `file_content`: The base64-encoded string containing the file data.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+
+export class FileTools {
+  @Tool({
+    name: 'upload_document',
+    description: 'Upload a text document or image.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async uploadDocument(input: any, ctx: ExecutionContext) {
+    // Processing logic
+  }
+}
+```
+
+### 2. Decoding Base64 Payloads
+File uploads can arrive in two formats depending on the client:
+1. **Data URL format**: `data:image/png;base64,iVBORw0KGgo...`
+2. **Raw Base64 format**: `iVBORw0KGgo...`
+
+Use the following universal decoder pattern to parse either format into a Node `Buffer`:
+
+```typescript
+import * as fs from 'fs';
+import * as path from 'path';
+
+function decodeBase64File(content: string): Buffer {
+  const matches = content.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/);
+  
+  if (matches && matches.length === 3) {
+    // Data URL format - decode matches[2]
+    return Buffer.from(matches[2], 'base64');
+  } else {
+    // Raw base64 format - decode input directly
+    return Buffer.from(content, 'base64');
+  }
+}
+```
+
+### 3. Secure File Saving Example
+Always validate the directory paths to prevent directory traversal attacks when saving files to disk.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads');
+
+export class SecureUploadTools {
+  @Tool({
+    name: 'save_uploaded_file',
+    description: 'Decodes and saves an uploaded file securely.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async saveFile(input: any, ctx: ExecutionContext) {
+    // Ensure uploads directory exists
+    if (!fs.existsSync(UPLOAD_DIR)) {
+      fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+    }
+
+    // Secure destination path to prevent path traversal
+    const safeName = path.basename(input.file_name);
+    const filePath = path.join(UPLOAD_DIR, safeName);
+    if (!filePath.startsWith(UPLOAD_DIR)) {
+      throw new Error('Invalid file path detected (path traversal).');
+    }
+
+    // Decode and write to disk
+    const buffer = decodeBase64File(input.file_content);
+    fs.writeFileSync(filePath, buffer);
+
+    ctx.logger.info(`Successfully saved file: ${safeName}`);
+    return { success: true, path: filePath };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.claude/skills/ui-widgets/SKILL.md
+++ b/sample-apps/concord-governance-agent/.claude/skills/ui-widgets/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: nitrostack-ui-widgets
+description: Best practices for linking tools to interactive frontend widgets using @Widget and @nitrostack/widgets SDK (including state sync, tool calling, display modes, media queries, and chat actions).
+---
+
+## When to Use
+Use this skill when designing, building, or modifying interactive user interface widgets that display custom React content inside AI clients or NitroStudio.
+
+---
+
+## 1. Backend Definition (`@Widget`)
+To display a React-based widget for a tool's output, decorate the tool method with `@Widget`.
+
+### Options:
+* **String Route**: A simple string representing the route identifier in the frontend React app (e.g. `'product-card'`).
+* **Object Route**: Object including:
+  * `route` (required): The route path.
+  * `domain` (optional): Allowed sandbox domain.
+  * `csp` (optional): Content Security Policy guidelines.
+
+### Example:
+```typescript
+import { Tool, Widget, z } from '@nitrostack/core';
+
+export class CatalogTools {
+  @Tool({
+    name: 'fetch_product',
+    description: 'Get product information by barcode.',
+    inputSchema: z.object({ barcode: z.string() }),
+  })
+  @Widget('product-details') // Maps to the "product-details" frontend component
+  async fetchProduct(input: { barcode: string }) {
+    return {
+      name: 'Super Nitro Energy Drink',
+      price: 2.99,
+      sku: input.barcode,
+    };
+  }
+}
+```
+
+---
+
+## 2. Frontend React Widget (`@nitrostack/widgets`)
+In your React widget frontend application (typically a Next.js client component), use the `useWidgetSDK` hook to receive input data from the client host.
+
+### React Component Example:
+```tsx
+'use client';
+
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+interface ProductData {
+  name: string;
+  price: number;
+  sku: string;
+}
+
+export default function ProductDetailsWidget() {
+  const { isReady, getToolOutput, theme } = useWidgetSDK();
+  const data = getToolOutput<ProductData>();
+
+  if (!isReady) {
+    return <div className="loading">Connecting to host...</div>;
+  }
+
+  if (!data) {
+    return <div className="error">No product data received.</div>;
+  }
+
+  return (
+    <div className={`product-card ${theme === 'dark' ? 'dark' : 'light'}`}>
+      <h3>{data.name}</h3>
+      <p className="price">${data.price.toFixed(2)}</p>
+      <span className="sku">SKU: {data.sku}</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 3. State Management & Synchronization (`useWidgetState`)
+Use `useWidgetState` to manage and persist client-side widget state (e.g. selected tabs, filter values, input states). This state automatically synchronizes with the host application context, persisting it across page re-renders.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetState } from '@nitrostack/widgets';
+
+export default function StationPanelWidget() {
+  const [state, setState] = useWidgetState(() => ({
+    selectedTab: 'overview',
+    showExtendedInfo: false,
+  }));
+
+  return (
+    <div>
+      <button onClick={() => setState({ ...state, selectedTab: 'alerts' })}>
+        View Alerts
+      </button>
+      <p>Current Tab: {state?.selectedTab}</p>
+    </div>
+  );
+}
+```
+
+---
+
+## 4. Calling Core Tools from Widgets (`callTool`)
+You can invoke other backend MCP tools directly from the frontend widget using `callTool`. This is useful for tool chaining or triggering detailed audits.
+
+### Example:
+```tsx
+import React, { useState } from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function SystemDiagnostics() {
+  const { callTool, isReady } = useWidgetSDK();
+  const [isRunning, setIsRunning] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+
+  const runDiagnostic = async () => {
+    if (!isReady) return;
+    setIsRunning(true);
+    try {
+      const response = await callTool('run_diagnostic', { system: 'oxygen_scrubber' });
+      setResult(response.result as string);
+    } catch (err) {
+      setResult('Diagnostic execution failed.');
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <button onClick={runDiagnostic} disabled={isRunning}>
+      {isRunning ? 'Running...' : 'Run Diagnostics'}
+    </button>
+  );
+}
+```
+
+---
+
+## 5. Layout & Display Controls
+Widgets can dynamically request size mode changes (fullscreen, inline, picture-in-picture) and adapt layouts to safe areas (dynamic islands/notches) or maximum height constraints.
+
+### Key Methods:
+* `requestFullscreen()`: Switch host widget display to fullscreen.
+* `requestInline()`: Switch host widget display back to inline.
+* `requestPip()`: Float widget in Picture-in-Picture.
+* `requestClose()`: Dismiss the widget completely.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function StatusBoard() {
+  const { 
+    requestFullscreen, 
+    requestInline, 
+    requestClose,
+    displayMode,   // Reactive property ('fullscreen' | 'inline' | 'pip')
+    maxHeight,     // Reactive maxHeight constraint (in pixels)
+    getSafeArea    // Insets data: { top, right, bottom, left }
+  } = useWidgetSDK();
+
+  const safeArea = getSafeArea() || { top: 0, bottom: 0 };
+
+  return (
+    <div style={{ maxHeight: maxHeight || 400, paddingTop: safeArea.top }}>
+      <h3>Mode: {displayMode}</h3>
+      <button onClick={requestFullscreen}>Fullscreen</button>
+      <button onClick={requestInline}>Collapse</button>
+      <button onClick={requestClose}>Dismiss Widget</button>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. Chat Navigation & Actions
+Widgets can interact with the host chat pane using external browser links and follow-up prompts.
+
+### Key Methods:
+* `openExternal(url)`: Open the target URL safely in the user's primary external browser.
+* `sendFollowUpMessage(prompt)`: Insert a message into the chat flow, automatically submitting it to the LLM agent.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function MissionControl() {
+  const { openExternal, sendFollowUpMessage } = useWidgetSDK();
+
+  return (
+    <div>
+      {/* Open external documentation */}
+      <button onClick={() => openExternal('https://docs.nitrostack.dev')}>
+        Open Manual
+      </button>
+
+      {/* Ask LLM agent directly from the widget */}
+      <button onClick={() => sendFollowUpMessage('Analyze mission failures from last week')}>
+        Ask Agent to Analyze
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 7. Media & Accessibility Queries
+The SDK provides helper utilities to query target client capabilities for styling or accessibility.
+
+### Key Utilities:
+* `prefersReducedMotion()`: Returns `true` if client settings specify reduced motion. Disable animations.
+* `isPrimarilyTouchDevice()`: Returns `true` if the device has a coarse pointer (e.g. touch/mobile). Increase button target sizes.
+* `isHoverAvailable()`: Returns `true` if pointer supports hover states.
+* `prefersDarkColorScheme()`: Returns `true` if the system theme is dark.
+
+### Example:
+```tsx
+import React from 'react';
+import { isPrimarilyTouchDevice, prefersReducedMotion } from '@nitrostack/widgets';
+
+export default function AccessiblePanel() {
+  const isTouch = isPrimarilyTouchDevice();
+  const reducedMotion = prefersReducedMotion();
+
+  return (
+    <div className={reducedMotion ? 'no-animations' : 'smooth-transitions'}>
+      <button style={{ padding: isTouch ? '16px' : '8px' }}>
+        Interactive Button
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 8. Testing Widgets
+* Open your project in **NitroStudio** for visual preview.
+* Invoke the tool from the AI chat or testing pane to verify the widget updates instantly with the returned JSON structure.

--- a/sample-apps/concord-governance-agent/.codex/skills/auth-security/SKILL.md
+++ b/sample-apps/concord-governance-agent/.codex/skills/auth-security/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: nitrostack-auth-security
+description: Best practices for implementing JWT, API Keys, OAuth 2.1, and RBAC in a NitroStack application.
+---
+
+## When to Use
+Use this skill when configuring security modules, implementing user authentication, restricting tool access via guards, or handling sensitive tokens.
+
+---
+
+## 1. JSON Web Tokens (JWT)
+To secure tools with JWT authentication:
+
+### Register `JWTModule`:
+```typescript
+import { JWTModule, Module, McpApp } from '@nitrostack/core';
+
+@McpApp({
+  server: { name: 'my-server', version: '1.0.0' }
+})
+@Module({
+  imports: [
+    JWTModule.forRoot({
+      secret: process.env.JWT_SECRET!,
+      expiresIn: '7d',
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### Write a `JWTGuard`:
+```typescript
+import { Guard, ExecutionContext, Injectable, ConfigService } from '@nitrostack/core';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class JWTGuard implements Guard {
+  constructor(private config: ConfigService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const token = this.extractToken(context);
+    if (!token) return false;
+
+    try {
+      const secret = this.config.get('JWT_SECRET');
+      const payload = jwt.verify(token, secret) as any;
+      context.auth = {
+        subject: payload.sub,
+        role: payload.role,
+        token,
+      };
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private extractToken(context: ExecutionContext): string | null {
+    const auth = context.metadata?.authorization;
+    if (auth?.startsWith('Bearer ')) {
+      return auth.substring(7);
+    }
+    return null;
+  }
+}
+```
+
+---
+
+## 2. API Key Authentication
+Use `ApiKeyModule` for service-to-service validation.
+
+### Register `ApiKeyModule`:
+```typescript
+import { ApiKeyModule, Module } from '@nitrostack/core';
+
+@Module({
+  imports: [
+    ApiKeyModule.forRoot({
+      keysEnvPrefix: 'API_KEY', // Reads API_KEY_1, API_KEY_2, etc.
+      headerName: 'x-api-key',
+      hashed: false,
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### API Key Guard:
+```typescript
+import { Guard, ExecutionContext, ApiKeyModule } from '@nitrostack/core';
+
+export class ApiKeyGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const apiKey = context.metadata?.['x-api-key'] || context.metadata?.apiKey;
+    if (!apiKey) return false;
+
+    const isValid = await ApiKeyModule.validate(apiKey as string);
+    if (isValid) {
+      context.auth = {
+        subject: `apikey_${(apiKey as string).substring(0, 10)}`,
+        scopes: ['*'],
+      };
+      return true;
+    }
+    return false;
+  }
+}
+```
+
+---
+
+## 3. Role-Based Access Control (RBAC)
+Chain guards sequentially to implement user-role authorization.
+
+```typescript
+import { Injectable, Guard, ExecutionContext, UseGuards, Tool, z } from '@nitrostack/core';
+import { JWTGuard } from './jwt.guard.js';
+
+@Injectable()
+export class AdminGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Requires JWTGuard to have populated context.auth first
+    return context.auth?.role === 'admin';
+  }
+}
+
+// Applying chained guards to a tool
+export class SystemTools {
+  @Tool({
+    name: 'reset_database',
+    description: 'Dangerous action: wipes database. Admin only.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(JWTGuard, AdminGuard) // Chain auth first, then role check
+  async resetDatabase() {
+    return { success: true };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.codex/skills/mcp-app-architecture/SKILL.md
+++ b/sample-apps/concord-governance-agent/.codex/skills/mcp-app-architecture/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: nitrostack-mcp-app-architecture
+description: Best practices and guidelines for bootstrapping, defining modules, using dependency injection, managing server lifecycles, and handling events in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill whenever you are bootstrapping a new NitroStack MCP server, creating modules, injecting services, or handling application lifecycle events.
+
+## Bootstrapping a NitroStack App
+A NitroStack application is initialized with the `@McpApp` decorator on a root class, accompanied by a root `@Module`.
+
+```typescript
+import { McpApp, Module } from '@nitrostack/core';
+import { DatabaseModule } from './database/database.module.js';
+import { UsersModule } from './users/users.module.js';
+
+@McpApp({
+  module: AppModule,
+  server: {
+    name: 'user-management-server',
+    version: '1.0.0',
+  },
+})
+@Module({
+  imports: [DatabaseModule, UsersModule],
+})
+export class AppModule {}
+```
+
+## Modules
+Modules organize your application structure. Use the `@Module` decorator to define imports, exports, and providers.
+
+* **`imports`**: Other modules whose exported providers should be available in this module.
+* **`providers`**: Services, tools, resources, or prompts that should be instantiated and managed by the DI container within this module.
+* **`exports`**: Providers defined in this module that should be visible to other modules importing this one.
+
+```typescript
+import { Module } from '@nitrostack/core';
+import { UsersService } from './users.service.js';
+import { UsersTools } from './users.tools.js';
+
+@Module({
+  providers: [UsersService, UsersTools],
+  exports: [UsersService],
+})
+
+## Controllers
+Use the `@ControllerDecorator` (or alias it as `@Controller`) to group tools, resources, and prompts together. Controllers are automatically registered as singletons in the DI container.
+
+### Key Controller Options:
+* **`prefix`**: A string prefix applied to every `@Tool` defined in this controller. For example, `@ControllerDecorator('github')` prefixing a tool named `create_issue` exposes it to MCP clients as `github_create_issue`.
+
+```typescript
+import { ControllerDecorator as Controller, Tool, ExecutionContext } from '@nitrostack/core';
+
+@Controller('github')
+export class GitHubController {
+  @Tool({
+    name: 'create_issue',
+    description: 'Create an issue in a repository',
+    inputSchema: z.object({ /* ... */ })
+  })
+  async createIssue(input: any, ctx: ExecutionContext) {
+    // Exposed to clients as "github_create_issue"
+  }
+}
+```
+
+## Dependency Injection (DI)
+NitroStack uses a robust dependency injection container to manage class instances and lifecycles.
+
+### Injection Lifecycles
+1. **Singleton (Default)**: A single instance is shared across the entire application.
+2. **Transient**: A new instance is created every time it is resolved/injected.
+3. **Scoped**: A new instance is created per incoming request or context.
+
+```typescript
+import { Injectable, Scope } from '@nitrostack/core';
+
+@Injectable({ scope: Scope.SINGLETON })
+export class UsersService {
+  constructor(private readonly db: DatabaseService) {}
+  
+  async getUser(id: string) {
+    return this.db.query('SELECT * FROM users WHERE id = $1', [id]);
+  }
+}
+```
+
+## Lifecycles and Hooks
+Implement NestJS-style lifecycle interfaces on modules, controllers, or providers to hook into application state changes:
+
+* **`OnModuleInit`** (`onModuleInit`): Called after modules have initialized but before the server starts listening.
+* **`OnApplicationBootstrap`** (`onApplicationBootstrap`): Called once the server is fully started and listening.
+* **`OnModuleDestroy`** (`onModuleDestroy`): Called when the module or application is shutting down.
+* **`BeforeApplicationShutdown`** (`beforeApplicationShutdown(signal?: string)`): Called before the application starts shutting down. Receives the OS signal (e.g. `SIGINT`).
+* **`OnApplicationShutdown`** (`onApplicationShutdown(signal?: string)`): Called during shutdown. Receives the OS signal.
+
+```typescript
+import { 
+  Injectable, 
+  OnModuleInit, 
+  OnApplicationBootstrap,
+  OnModuleDestroy, 
+  BeforeApplicationShutdown,
+  OnApplicationShutdown 
+} from '@nitrostack/core';
+
+@Injectable()
+export class DatabaseService 
+  implements OnModuleInit, OnApplicationBootstrap, OnModuleDestroy, BeforeApplicationShutdown, OnApplicationShutdown 
+{
+  async onModuleInit() {
+    await this.connect();
+  }
+
+  async onApplicationBootstrap() {
+    console.log('App ready to handle connections.');
+  }
+
+  async onModuleDestroy() {
+    await this.cleanupPendingQueries();
+  }
+
+  async beforeApplicationShutdown(signal?: string) {
+    console.log(`Shutting down soon (signal: ${signal}).`);
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    await this.disconnect();
+  }
+}
+```
+
+---
+
+## Eventing System (`emitEvent` and `@OnEvent`)
+NitroStack includes an internal eventing system to decouple components. A service or tool can emit an event using `emitEvent`, and any injectable class (like a handler service or controller) can subscribe using the `@OnEvent` decorator.
+
+### 1. Emitting Events
+Call `emitEvent` to dispatch an event payload asynchronously.
+
+```typescript
+import { Injectable, emitEvent } from '@nitrostack/core';
+
+@Injectable()
+export class SpaceShipService {
+  async launchShip(shipId: string) {
+    // Process launch...
+    
+    // Dispatch event
+    emitEvent('ship.launched', {
+      shipId,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+```
+
+### 2. Listening to Events
+Decorate a method inside any `@Injectable()` class with `@OnEvent('event_pattern')` to register it as an event handler.
+
+```typescript
+import { Injectable, OnEvent } from '@nitrostack/core';
+
+@Injectable({ deps: [] })
+export class FlightLogHandler {
+  @OnEvent('ship.launched')
+  async logLaunch(data: { shipId: string; timestamp: string }) {
+    console.error(`🚀 [EVENT] Ship ${data.shipId} was successfully launched at ${data.timestamp}`);
+  }
+}
+```
+
+> [!NOTE]
+> For the `@OnEvent` decorator to register properly, the containing class must be declared as a provider inside an active module.

--- a/sample-apps/concord-governance-agent/.codex/skills/middleware-pipeline/SKILL.md
+++ b/sample-apps/concord-governance-agent/.codex/skills/middleware-pipeline/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: nitrostack-middleware-pipeline
+description: Best practices for implementing and applying Guards, Interceptors, Middleware, Pipes, and Exception Filters in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill when implementing request validation, authorization checks, response mapping, logging, error handling, or performance tracking on NitroStack tool methods.
+
+---
+
+## 1. Guards (`Guard` and `@UseGuards`)
+Guards determine if a request should be processed by a tool handler based on authentication, authorization, or other conditions.
+
+### Interface:
+```typescript
+import { Guard, ExecutionContext } from '@nitrostack/core';
+
+export interface Guard {
+  canActivate(context: ExecutionContext): boolean | Promise<boolean>;
+}
+```
+
+### Example:
+```typescript
+import { Guard, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class RolesGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const userRoles = context.clientMetadata?.roles || [];
+    return userRoles.includes('admin');
+  }
+}
+```
+
+Apply the guard using `@UseGuards(...)`:
+```typescript
+import { Tool, UseGuards, z } from '@nitrostack/core';
+import { RolesGuard } from './roles.guard.js';
+
+export class AdminTools {
+  @Tool({
+    name: 'delete_system_logs',
+    description: 'Delete all system logs from the server.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(RolesGuard)
+  async deleteLogs() {
+    return { success: true };
+  }
+}
+```
+
+---
+
+## 2. Interceptors (`InterceptorInterface` and `@UseInterceptors`)
+Interceptors can transform/intercept input arguments or mapped output from a tool method execution.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface InterceptorInterface {
+  intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { InterceptorInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class TimingInterceptor implements InterceptorInterface {
+  async intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    const start = Date.now();
+    const result = await next();
+    const duration = Date.now() - start;
+    context.logger.info(`Execution took ${duration}ms`);
+    return {
+      ...result,
+      _meta: { durationMs: duration }
+    };
+  }
+}
+```
+
+---
+
+## 3. Exception Filters (`ExceptionFilterInterface` and `@UseFilters`)
+Exception filters catch any errors thrown within guards, interceptors, or the tool handlers themselves, mapping them into user-friendly JSON payloads.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext): unknown | Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { ExceptionFilterInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class CustomExceptionFilter implements ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext) {
+    const message = exception instanceof Error ? exception.message : 'Unknown error';
+    return {
+      error: true,
+      message,
+      timestamp: new Date().toISOString()
+    };
+  }
+}
+```
+
+Apply the filter using `@UseFilters(...)` on a tool method:
+
+```typescript
+import { Tool, UseFilters, z } from '@nitrostack/core';
+import { CustomExceptionFilter } from './custom-exception.filter.js';
+
+export class LoggingTools {
+  @Tool({
+    name: 'generate_report',
+    description: 'Generates system usage reports.',
+    inputSchema: z.object({}),
+  })
+  @UseFilters(CustomExceptionFilter)
+  async generateReport() {
+    throw new Error('Report generation is not implemented yet.');
+  }
+}
+```
+
+---
+
+## 4. Middleware (`MiddlewareInterface`, `@Middleware` and `@UseMiddleware`)
+Middleware executes before the request reaches the tool handler, and can wrap the handler execution by invoking `next()`.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface MiddlewareInterface {
+  use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { Middleware, MiddlewareInterface, ExecutionContext } from '@nitrostack/core';
+
+@Middleware()
+export class LoggingMiddleware implements MiddlewareInterface {
+  async use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    context.logger.info(`Entering tool: ${context.toolName}`);
+    try {
+      const result = await next();
+      context.logger.info(`Exiting tool: ${context.toolName}`);
+      return result;
+    } catch (error) {
+      context.logger.error(`Error in tool: ${error}`);
+      throw error;
+    }
+  }
+}
+```
+
+Apply the middleware using `@UseMiddleware(...)` on a tool method:
+```typescript
+import { Tool, UseMiddleware, z } from '@nitrostack/core';
+import { LoggingMiddleware } from './logging.middleware.js';
+
+export class StationTools {
+  @Tool({
+    name: 'fetch_logs',
+    description: 'Fetch station operations logs.',
+    inputSchema: z.object({}),
+  })
+  @UseMiddleware(LoggingMiddleware)
+  async fetchLogs() {
+    return { status: 'operational' };
+  }
+}
+```
+
+---
+
+## 5. Pipes (`PipeInterface`, `@Pipe` and `@UsePipes`)
+Pipes are used to transform or validate input arguments before they reach the tool handler method.
+
+### Interface:
+```typescript
+import { ArgumentMetadata } from '@nitrostack/core';
+
+export interface PipeInterface<T = unknown, R = unknown> {
+  transform(value: T, metadata: ArgumentMetadata): R | Promise<R>;
+}
+```
+
+### Example:
+```typescript
+import { Pipe, PipeInterface, ArgumentMetadata } from '@nitrostack/core';
+
+@Pipe()
+export class TrimPipe implements PipeInterface<Record<string, unknown>, Record<string, unknown>> {
+  transform(value: Record<string, unknown>, metadata: ArgumentMetadata) {
+    const trimmed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      trimmed[key] = typeof val === 'string' ? val.trim() : val;
+    }
+    return trimmed;
+  }
+}
+```
+
+Apply the pipe using `@UsePipes(...)` on a tool method:
+```typescript
+import { Tool, UsePipes, z } from '@nitrostack/core';
+import { TrimPipe } from './trim.pipe.js';
+
+export class MessagingTools {
+  @Tool({
+    name: 'send_message',
+    description: 'Send a message to other stations.',
+    inputSchema: z.object({ text: z.string() }),
+  })
+  @UsePipes(TrimPipe)
+  async sendMessage(input: { text: string }) {
+    return { sentText: input.text };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.codex/skills/tools-resources-prompts/SKILL.md
+++ b/sample-apps/concord-governance-agent/.codex/skills/tools-resources-prompts/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: nitrostack-tools-resources-prompts
+description: Guidelines and patterns for defining Tools, Resources, and Prompts in a NitroStack application with schema validation via Zod, including caching, rate-limiting, and base64 file uploads.
+---
+
+## When to Use
+Use this skill whenever you are defining, editing, or validating tools, resources, or prompts on a NitroStack MCP server.
+
+## Defining Tools with `@Tool`
+An MCP tool exposes a function that an AI client can invoke. Decorate a service or controller method with `@Tool`.
+
+### Key Tool Options:
+* `name`: Kebab-case or snake_case unique identifier.
+* `description`: Detailed description explaining when and how the client should use it.
+* `inputSchema`: A Zod object schema for strict validation of inputs.
+* `outputSchema` (optional): Zod schema validating the output structure.
+
+```typescript
+import { ToolDecorator as Tool, ControllerDecorator as Controller, InitialTool, z, ExecutionContext } from '@nitrostack/core';
+
+@Controller('weather')
+export class WeatherService {
+  @Tool({
+    name: 'get_current_weather',
+    description: 'Get the current weather forecast for a specific city.',
+    inputSchema: z.object({
+      city: z.string().describe('The name of the city, e.g., San Francisco'),
+      unit: z.enum(['celsius', 'fahrenheit']).default('celsius'),
+    }),
+  })
+  @InitialTool() // Auto-invoked when the AI client initializes/starts
+  async getWeather(
+    input: { city: string; unit: 'celsius' | 'fahrenheit' },
+    ctx: ExecutionContext
+  ) {
+    ctx.logger.info(`Fetching weather for ${input.city}`);
+    // implementation
+    return {
+      city: input.city,
+      temp: 22,
+      condition: 'Sunny',
+    };
+  }
+}
+```
+
+## Defining Resources with `@Resource`
+An MCP resource exposes static or dynamic data files/URIs that the AI client can read.
+
+### Key Resource Options:
+* `uri`: URI pattern (e.g., `git://{owner}/{repo}/file` or static `app://config`).
+* `name`: Unique name of the resource.
+* `description`: Explanation of what data this resource provides.
+* `mimeType`: Mime type of the response (e.g., `text/plain`, `application/json`).
+
+```typescript
+import { Resource, ExecutionContext } from '@nitrostack/core';
+
+export class ConfigResources {
+  @Resource({
+    uri: 'app://settings',
+    name: 'Application Settings',
+    description: 'System-wide configuration settings and parameters.',
+    mimeType: 'application/json',
+  })
+  async getSettings(ctx: ExecutionContext) {
+    return {
+      environment: 'development',
+      debugMode: true,
+    };
+  }
+}
+```
+
+## Defining Prompts with `@Prompt`
+An MCP prompt exposes reusable templates or instruction sets that guide LLMs.
+
+### Key Prompt Options:
+* `name`: Name of the prompt.
+* `description`: Describes what task this prompt helps accomplish.
+* `arguments`: Declares parameters the client can supply to customize the prompt template.
+
+```typescript
+import { Prompt, ExecutionContext } from '@nitrostack/core';
+
+export class PromptTemplates {
+  @Prompt({
+    name: 'code_review',
+    description: 'Provide an intensive code review for a given code snippet.',
+    arguments: [
+      { name: 'language', description: 'The programming language, e.g., TypeScript', required: true },
+      { name: 'code', description: 'The code snippet to review', required: true },
+    ],
+  })
+  async getCodeReviewPrompt(
+    args: { language: string; code: string },
+    ctx: ExecutionContext
+  ) {
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: `You are an expert software engineer. Review this ${args.language} code:\n\n${args.code}`,
+        },
+      ],
+    };
+  }
+}
+```
+
+---
+
+## Tool Policies: Caching (`@Cache`) and Rate Limiting (`@RateLimit`)
+You can control tool execution behaviors (such as performance optimization and throttling) using method decorators.
+
+### 1. Caching with `@Cache`
+Use `@Cache` to cache tool execution outputs for a specified duration (TTL in seconds). This reduces database or API overhead for frequent identical requests.
+
+#### Options:
+* `ttl`: Cache time-to-live in seconds (required).
+* `key` (optional): Custom function `(input: any, context?: any) => string` that returns a unique cache key based on inputs. If not defined, a key is auto-generated from serialized input arguments.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, Cache, z } from '@nitrostack/core';
+
+export class StationTools {
+  @Tool({
+    name: 'get_system_status',
+    description: 'Fetch real-time station metrics. Response is cached.',
+    inputSchema: z.object({}),
+  })
+  @Cache({ ttl: 60 }) // Caches status for 60 seconds
+  async getSystemStatus() {
+    return { temperature: 21.5, oxygen: 0.98 };
+  }
+
+  @Tool({
+    name: 'get_crew_status',
+    description: 'Fetch status of a crew member. Cached by crew ID.',
+    inputSchema: z.object({ id: z.string() }),
+  })
+  @Cache({
+    ttl: 300,
+    key: (input) => `crew:status:${input.id}`
+  })
+  async getCrewStatus(input: { id: string }) {
+    // ...
+  }
+}
+```
+
+### 2. Rate Limiting with `@RateLimit`
+Use `@RateLimit` to restrict the number of tool invocations within a specified time window to prevent client abuse.
+
+#### Options:
+* `requests`: Number of allowed requests in the window (required).
+* `window`: Throttling duration window (required). Supports formats like `'1s'`, `'1m'`, `'1h'`.
+* `key` (optional): Custom function `(context: ExecutionContext) => string` to group rate limits. Useful for rate-limiting per user role or API key.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, RateLimit, z, ExecutionContext } from '@nitrostack/core';
+
+export class DiagnosticTools {
+  @Tool({
+    name: 'run_deep_diagnostic',
+    description: 'Run intensive diagnostics. Rate limited.',
+    inputSchema: z.object({}),
+  })
+  @RateLimit({ requests: 3, window: '1m' }) // Max 3 requests per minute globally
+  async runDeepDiagnostic() {
+    return { diagnosticReport: 'All systems operational.' };
+  }
+
+  @Tool({
+    name: 'request_supply_drop',
+    description: 'Request inventory supplies. Rate limited per user.',
+    inputSchema: z.object({ item: z.string() }),
+  })
+  @RateLimit({
+    requests: 5,
+    window: '1h',
+    key: (ctx: ExecutionContext) => ctx.auth?.subject || 'anonymous'
+  })
+  async requestSupply(input: { item: string }, ctx: ExecutionContext) {
+    // ...
+  }
+}
+```
+
+---
+
+## Handling File Uploads in Tools
+NitroStack supports file uploads from MCP clients (like NitroStudio) by passing the file as a base64-encoded string inside a tool's input parameters.
+
+### 1. Declaring Input Schema for File Uploads
+To accept an uploaded file, define three Zod fields in your tool's `inputSchema`:
+* `file_name`: The name of the file (e.g. `report.csv`).
+* `file_type`: The MIME type (e.g. `text/csv`).
+* `file_content`: The base64-encoded string containing the file data.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+
+export class FileTools {
+  @Tool({
+    name: 'upload_document',
+    description: 'Upload a text document or image.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async uploadDocument(input: any, ctx: ExecutionContext) {
+    // Processing logic
+  }
+}
+```
+
+### 2. Decoding Base64 Payloads
+File uploads can arrive in two formats depending on the client:
+1. **Data URL format**: `data:image/png;base64,iVBORw0KGgo...`
+2. **Raw Base64 format**: `iVBORw0KGgo...`
+
+Use the following universal decoder pattern to parse either format into a Node `Buffer`:
+
+```typescript
+import * as fs from 'fs';
+import * as path from 'path';
+
+function decodeBase64File(content: string): Buffer {
+  const matches = content.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/);
+  
+  if (matches && matches.length === 3) {
+    // Data URL format - decode matches[2]
+    return Buffer.from(matches[2], 'base64');
+  } else {
+    // Raw base64 format - decode input directly
+    return Buffer.from(content, 'base64');
+  }
+}
+```
+
+### 3. Secure File Saving Example
+Always validate the directory paths to prevent directory traversal attacks when saving files to disk.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads');
+
+export class SecureUploadTools {
+  @Tool({
+    name: 'save_uploaded_file',
+    description: 'Decodes and saves an uploaded file securely.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async saveFile(input: any, ctx: ExecutionContext) {
+    // Ensure uploads directory exists
+    if (!fs.existsSync(UPLOAD_DIR)) {
+      fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+    }
+
+    // Secure destination path to prevent path traversal
+    const safeName = path.basename(input.file_name);
+    const filePath = path.join(UPLOAD_DIR, safeName);
+    if (!filePath.startsWith(UPLOAD_DIR)) {
+      throw new Error('Invalid file path detected (path traversal).');
+    }
+
+    // Decode and write to disk
+    const buffer = decodeBase64File(input.file_content);
+    fs.writeFileSync(filePath, buffer);
+
+    ctx.logger.info(`Successfully saved file: ${safeName}`);
+    return { success: true, path: filePath };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.codex/skills/ui-widgets/SKILL.md
+++ b/sample-apps/concord-governance-agent/.codex/skills/ui-widgets/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: nitrostack-ui-widgets
+description: Best practices for linking tools to interactive frontend widgets using @Widget and @nitrostack/widgets SDK (including state sync, tool calling, display modes, media queries, and chat actions).
+---
+
+## When to Use
+Use this skill when designing, building, or modifying interactive user interface widgets that display custom React content inside AI clients or NitroStudio.
+
+---
+
+## 1. Backend Definition (`@Widget`)
+To display a React-based widget for a tool's output, decorate the tool method with `@Widget`.
+
+### Options:
+* **String Route**: A simple string representing the route identifier in the frontend React app (e.g. `'product-card'`).
+* **Object Route**: Object including:
+  * `route` (required): The route path.
+  * `domain` (optional): Allowed sandbox domain.
+  * `csp` (optional): Content Security Policy guidelines.
+
+### Example:
+```typescript
+import { Tool, Widget, z } from '@nitrostack/core';
+
+export class CatalogTools {
+  @Tool({
+    name: 'fetch_product',
+    description: 'Get product information by barcode.',
+    inputSchema: z.object({ barcode: z.string() }),
+  })
+  @Widget('product-details') // Maps to the "product-details" frontend component
+  async fetchProduct(input: { barcode: string }) {
+    return {
+      name: 'Super Nitro Energy Drink',
+      price: 2.99,
+      sku: input.barcode,
+    };
+  }
+}
+```
+
+---
+
+## 2. Frontend React Widget (`@nitrostack/widgets`)
+In your React widget frontend application (typically a Next.js client component), use the `useWidgetSDK` hook to receive input data from the client host.
+
+### React Component Example:
+```tsx
+'use client';
+
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+interface ProductData {
+  name: string;
+  price: number;
+  sku: string;
+}
+
+export default function ProductDetailsWidget() {
+  const { isReady, getToolOutput, theme } = useWidgetSDK();
+  const data = getToolOutput<ProductData>();
+
+  if (!isReady) {
+    return <div className="loading">Connecting to host...</div>;
+  }
+
+  if (!data) {
+    return <div className="error">No product data received.</div>;
+  }
+
+  return (
+    <div className={`product-card ${theme === 'dark' ? 'dark' : 'light'}`}>
+      <h3>{data.name}</h3>
+      <p className="price">${data.price.toFixed(2)}</p>
+      <span className="sku">SKU: {data.sku}</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 3. State Management & Synchronization (`useWidgetState`)
+Use `useWidgetState` to manage and persist client-side widget state (e.g. selected tabs, filter values, input states). This state automatically synchronizes with the host application context, persisting it across page re-renders.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetState } from '@nitrostack/widgets';
+
+export default function StationPanelWidget() {
+  const [state, setState] = useWidgetState(() => ({
+    selectedTab: 'overview',
+    showExtendedInfo: false,
+  }));
+
+  return (
+    <div>
+      <button onClick={() => setState({ ...state, selectedTab: 'alerts' })}>
+        View Alerts
+      </button>
+      <p>Current Tab: {state?.selectedTab}</p>
+    </div>
+  );
+}
+```
+
+---
+
+## 4. Calling Core Tools from Widgets (`callTool`)
+You can invoke other backend MCP tools directly from the frontend widget using `callTool`. This is useful for tool chaining or triggering detailed audits.
+
+### Example:
+```tsx
+import React, { useState } from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function SystemDiagnostics() {
+  const { callTool, isReady } = useWidgetSDK();
+  const [isRunning, setIsRunning] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+
+  const runDiagnostic = async () => {
+    if (!isReady) return;
+    setIsRunning(true);
+    try {
+      const response = await callTool('run_diagnostic', { system: 'oxygen_scrubber' });
+      setResult(response.result as string);
+    } catch (err) {
+      setResult('Diagnostic execution failed.');
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <button onClick={runDiagnostic} disabled={isRunning}>
+      {isRunning ? 'Running...' : 'Run Diagnostics'}
+    </button>
+  );
+}
+```
+
+---
+
+## 5. Layout & Display Controls
+Widgets can dynamically request size mode changes (fullscreen, inline, picture-in-picture) and adapt layouts to safe areas (dynamic islands/notches) or maximum height constraints.
+
+### Key Methods:
+* `requestFullscreen()`: Switch host widget display to fullscreen.
+* `requestInline()`: Switch host widget display back to inline.
+* `requestPip()`: Float widget in Picture-in-Picture.
+* `requestClose()`: Dismiss the widget completely.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function StatusBoard() {
+  const { 
+    requestFullscreen, 
+    requestInline, 
+    requestClose,
+    displayMode,   // Reactive property ('fullscreen' | 'inline' | 'pip')
+    maxHeight,     // Reactive maxHeight constraint (in pixels)
+    getSafeArea    // Insets data: { top, right, bottom, left }
+  } = useWidgetSDK();
+
+  const safeArea = getSafeArea() || { top: 0, bottom: 0 };
+
+  return (
+    <div style={{ maxHeight: maxHeight || 400, paddingTop: safeArea.top }}>
+      <h3>Mode: {displayMode}</h3>
+      <button onClick={requestFullscreen}>Fullscreen</button>
+      <button onClick={requestInline}>Collapse</button>
+      <button onClick={requestClose}>Dismiss Widget</button>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. Chat Navigation & Actions
+Widgets can interact with the host chat pane using external browser links and follow-up prompts.
+
+### Key Methods:
+* `openExternal(url)`: Open the target URL safely in the user's primary external browser.
+* `sendFollowUpMessage(prompt)`: Insert a message into the chat flow, automatically submitting it to the LLM agent.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function MissionControl() {
+  const { openExternal, sendFollowUpMessage } = useWidgetSDK();
+
+  return (
+    <div>
+      {/* Open external documentation */}
+      <button onClick={() => openExternal('https://docs.nitrostack.dev')}>
+        Open Manual
+      </button>
+
+      {/* Ask LLM agent directly from the widget */}
+      <button onClick={() => sendFollowUpMessage('Analyze mission failures from last week')}>
+        Ask Agent to Analyze
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 7. Media & Accessibility Queries
+The SDK provides helper utilities to query target client capabilities for styling or accessibility.
+
+### Key Utilities:
+* `prefersReducedMotion()`: Returns `true` if client settings specify reduced motion. Disable animations.
+* `isPrimarilyTouchDevice()`: Returns `true` if the device has a coarse pointer (e.g. touch/mobile). Increase button target sizes.
+* `isHoverAvailable()`: Returns `true` if pointer supports hover states.
+* `prefersDarkColorScheme()`: Returns `true` if the system theme is dark.
+
+### Example:
+```tsx
+import React from 'react';
+import { isPrimarilyTouchDevice, prefersReducedMotion } from '@nitrostack/widgets';
+
+export default function AccessiblePanel() {
+  const isTouch = isPrimarilyTouchDevice();
+  const reducedMotion = prefersReducedMotion();
+
+  return (
+    <div className={reducedMotion ? 'no-animations' : 'smooth-transitions'}>
+      <button style={{ padding: isTouch ? '16px' : '8px' }}>
+        Interactive Button
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 8. Testing Widgets
+* Open your project in **NitroStudio** for visual preview.
+* Invoke the tool from the AI chat or testing pane to verify the widget updates instantly with the returned JSON structure.

--- a/sample-apps/concord-governance-agent/.copilot/skills/auth-security/SKILL.md
+++ b/sample-apps/concord-governance-agent/.copilot/skills/auth-security/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: nitrostack-auth-security
+description: Best practices for implementing JWT, API Keys, OAuth 2.1, and RBAC in a NitroStack application.
+---
+
+## When to Use
+Use this skill when configuring security modules, implementing user authentication, restricting tool access via guards, or handling sensitive tokens.
+
+---
+
+## 1. JSON Web Tokens (JWT)
+To secure tools with JWT authentication:
+
+### Register `JWTModule`:
+```typescript
+import { JWTModule, Module, McpApp } from '@nitrostack/core';
+
+@McpApp({
+  server: { name: 'my-server', version: '1.0.0' }
+})
+@Module({
+  imports: [
+    JWTModule.forRoot({
+      secret: process.env.JWT_SECRET!,
+      expiresIn: '7d',
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### Write a `JWTGuard`:
+```typescript
+import { Guard, ExecutionContext, Injectable, ConfigService } from '@nitrostack/core';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class JWTGuard implements Guard {
+  constructor(private config: ConfigService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const token = this.extractToken(context);
+    if (!token) return false;
+
+    try {
+      const secret = this.config.get('JWT_SECRET');
+      const payload = jwt.verify(token, secret) as any;
+      context.auth = {
+        subject: payload.sub,
+        role: payload.role,
+        token,
+      };
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private extractToken(context: ExecutionContext): string | null {
+    const auth = context.metadata?.authorization;
+    if (auth?.startsWith('Bearer ')) {
+      return auth.substring(7);
+    }
+    return null;
+  }
+}
+```
+
+---
+
+## 2. API Key Authentication
+Use `ApiKeyModule` for service-to-service validation.
+
+### Register `ApiKeyModule`:
+```typescript
+import { ApiKeyModule, Module } from '@nitrostack/core';
+
+@Module({
+  imports: [
+    ApiKeyModule.forRoot({
+      keysEnvPrefix: 'API_KEY', // Reads API_KEY_1, API_KEY_2, etc.
+      headerName: 'x-api-key',
+      hashed: false,
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### API Key Guard:
+```typescript
+import { Guard, ExecutionContext, ApiKeyModule } from '@nitrostack/core';
+
+export class ApiKeyGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const apiKey = context.metadata?.['x-api-key'] || context.metadata?.apiKey;
+    if (!apiKey) return false;
+
+    const isValid = await ApiKeyModule.validate(apiKey as string);
+    if (isValid) {
+      context.auth = {
+        subject: `apikey_${(apiKey as string).substring(0, 10)}`,
+        scopes: ['*'],
+      };
+      return true;
+    }
+    return false;
+  }
+}
+```
+
+---
+
+## 3. Role-Based Access Control (RBAC)
+Chain guards sequentially to implement user-role authorization.
+
+```typescript
+import { Injectable, Guard, ExecutionContext, UseGuards, Tool, z } from '@nitrostack/core';
+import { JWTGuard } from './jwt.guard.js';
+
+@Injectable()
+export class AdminGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Requires JWTGuard to have populated context.auth first
+    return context.auth?.role === 'admin';
+  }
+}
+
+// Applying chained guards to a tool
+export class SystemTools {
+  @Tool({
+    name: 'reset_database',
+    description: 'Dangerous action: wipes database. Admin only.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(JWTGuard, AdminGuard) // Chain auth first, then role check
+  async resetDatabase() {
+    return { success: true };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.copilot/skills/mcp-app-architecture/SKILL.md
+++ b/sample-apps/concord-governance-agent/.copilot/skills/mcp-app-architecture/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: nitrostack-mcp-app-architecture
+description: Best practices and guidelines for bootstrapping, defining modules, using dependency injection, managing server lifecycles, and handling events in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill whenever you are bootstrapping a new NitroStack MCP server, creating modules, injecting services, or handling application lifecycle events.
+
+## Bootstrapping a NitroStack App
+A NitroStack application is initialized with the `@McpApp` decorator on a root class, accompanied by a root `@Module`.
+
+```typescript
+import { McpApp, Module } from '@nitrostack/core';
+import { DatabaseModule } from './database/database.module.js';
+import { UsersModule } from './users/users.module.js';
+
+@McpApp({
+  module: AppModule,
+  server: {
+    name: 'user-management-server',
+    version: '1.0.0',
+  },
+})
+@Module({
+  imports: [DatabaseModule, UsersModule],
+})
+export class AppModule {}
+```
+
+## Modules
+Modules organize your application structure. Use the `@Module` decorator to define imports, exports, and providers.
+
+* **`imports`**: Other modules whose exported providers should be available in this module.
+* **`providers`**: Services, tools, resources, or prompts that should be instantiated and managed by the DI container within this module.
+* **`exports`**: Providers defined in this module that should be visible to other modules importing this one.
+
+```typescript
+import { Module } from '@nitrostack/core';
+import { UsersService } from './users.service.js';
+import { UsersTools } from './users.tools.js';
+
+@Module({
+  providers: [UsersService, UsersTools],
+  exports: [UsersService],
+})
+
+## Controllers
+Use the `@ControllerDecorator` (or alias it as `@Controller`) to group tools, resources, and prompts together. Controllers are automatically registered as singletons in the DI container.
+
+### Key Controller Options:
+* **`prefix`**: A string prefix applied to every `@Tool` defined in this controller. For example, `@ControllerDecorator('github')` prefixing a tool named `create_issue` exposes it to MCP clients as `github_create_issue`.
+
+```typescript
+import { ControllerDecorator as Controller, Tool, ExecutionContext } from '@nitrostack/core';
+
+@Controller('github')
+export class GitHubController {
+  @Tool({
+    name: 'create_issue',
+    description: 'Create an issue in a repository',
+    inputSchema: z.object({ /* ... */ })
+  })
+  async createIssue(input: any, ctx: ExecutionContext) {
+    // Exposed to clients as "github_create_issue"
+  }
+}
+```
+
+## Dependency Injection (DI)
+NitroStack uses a robust dependency injection container to manage class instances and lifecycles.
+
+### Injection Lifecycles
+1. **Singleton (Default)**: A single instance is shared across the entire application.
+2. **Transient**: A new instance is created every time it is resolved/injected.
+3. **Scoped**: A new instance is created per incoming request or context.
+
+```typescript
+import { Injectable, Scope } from '@nitrostack/core';
+
+@Injectable({ scope: Scope.SINGLETON })
+export class UsersService {
+  constructor(private readonly db: DatabaseService) {}
+  
+  async getUser(id: string) {
+    return this.db.query('SELECT * FROM users WHERE id = $1', [id]);
+  }
+}
+```
+
+## Lifecycles and Hooks
+Implement NestJS-style lifecycle interfaces on modules, controllers, or providers to hook into application state changes:
+
+* **`OnModuleInit`** (`onModuleInit`): Called after modules have initialized but before the server starts listening.
+* **`OnApplicationBootstrap`** (`onApplicationBootstrap`): Called once the server is fully started and listening.
+* **`OnModuleDestroy`** (`onModuleDestroy`): Called when the module or application is shutting down.
+* **`BeforeApplicationShutdown`** (`beforeApplicationShutdown(signal?: string)`): Called before the application starts shutting down. Receives the OS signal (e.g. `SIGINT`).
+* **`OnApplicationShutdown`** (`onApplicationShutdown(signal?: string)`): Called during shutdown. Receives the OS signal.
+
+```typescript
+import { 
+  Injectable, 
+  OnModuleInit, 
+  OnApplicationBootstrap,
+  OnModuleDestroy, 
+  BeforeApplicationShutdown,
+  OnApplicationShutdown 
+} from '@nitrostack/core';
+
+@Injectable()
+export class DatabaseService 
+  implements OnModuleInit, OnApplicationBootstrap, OnModuleDestroy, BeforeApplicationShutdown, OnApplicationShutdown 
+{
+  async onModuleInit() {
+    await this.connect();
+  }
+
+  async onApplicationBootstrap() {
+    console.log('App ready to handle connections.');
+  }
+
+  async onModuleDestroy() {
+    await this.cleanupPendingQueries();
+  }
+
+  async beforeApplicationShutdown(signal?: string) {
+    console.log(`Shutting down soon (signal: ${signal}).`);
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    await this.disconnect();
+  }
+}
+```
+
+---
+
+## Eventing System (`emitEvent` and `@OnEvent`)
+NitroStack includes an internal eventing system to decouple components. A service or tool can emit an event using `emitEvent`, and any injectable class (like a handler service or controller) can subscribe using the `@OnEvent` decorator.
+
+### 1. Emitting Events
+Call `emitEvent` to dispatch an event payload asynchronously.
+
+```typescript
+import { Injectable, emitEvent } from '@nitrostack/core';
+
+@Injectable()
+export class SpaceShipService {
+  async launchShip(shipId: string) {
+    // Process launch...
+    
+    // Dispatch event
+    emitEvent('ship.launched', {
+      shipId,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+```
+
+### 2. Listening to Events
+Decorate a method inside any `@Injectable()` class with `@OnEvent('event_pattern')` to register it as an event handler.
+
+```typescript
+import { Injectable, OnEvent } from '@nitrostack/core';
+
+@Injectable({ deps: [] })
+export class FlightLogHandler {
+  @OnEvent('ship.launched')
+  async logLaunch(data: { shipId: string; timestamp: string }) {
+    console.error(`🚀 [EVENT] Ship ${data.shipId} was successfully launched at ${data.timestamp}`);
+  }
+}
+```
+
+> [!NOTE]
+> For the `@OnEvent` decorator to register properly, the containing class must be declared as a provider inside an active module.

--- a/sample-apps/concord-governance-agent/.copilot/skills/middleware-pipeline/SKILL.md
+++ b/sample-apps/concord-governance-agent/.copilot/skills/middleware-pipeline/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: nitrostack-middleware-pipeline
+description: Best practices for implementing and applying Guards, Interceptors, Middleware, Pipes, and Exception Filters in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill when implementing request validation, authorization checks, response mapping, logging, error handling, or performance tracking on NitroStack tool methods.
+
+---
+
+## 1. Guards (`Guard` and `@UseGuards`)
+Guards determine if a request should be processed by a tool handler based on authentication, authorization, or other conditions.
+
+### Interface:
+```typescript
+import { Guard, ExecutionContext } from '@nitrostack/core';
+
+export interface Guard {
+  canActivate(context: ExecutionContext): boolean | Promise<boolean>;
+}
+```
+
+### Example:
+```typescript
+import { Guard, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class RolesGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const userRoles = context.clientMetadata?.roles || [];
+    return userRoles.includes('admin');
+  }
+}
+```
+
+Apply the guard using `@UseGuards(...)`:
+```typescript
+import { Tool, UseGuards, z } from '@nitrostack/core';
+import { RolesGuard } from './roles.guard.js';
+
+export class AdminTools {
+  @Tool({
+    name: 'delete_system_logs',
+    description: 'Delete all system logs from the server.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(RolesGuard)
+  async deleteLogs() {
+    return { success: true };
+  }
+}
+```
+
+---
+
+## 2. Interceptors (`InterceptorInterface` and `@UseInterceptors`)
+Interceptors can transform/intercept input arguments or mapped output from a tool method execution.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface InterceptorInterface {
+  intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { InterceptorInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class TimingInterceptor implements InterceptorInterface {
+  async intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    const start = Date.now();
+    const result = await next();
+    const duration = Date.now() - start;
+    context.logger.info(`Execution took ${duration}ms`);
+    return {
+      ...result,
+      _meta: { durationMs: duration }
+    };
+  }
+}
+```
+
+---
+
+## 3. Exception Filters (`ExceptionFilterInterface` and `@UseFilters`)
+Exception filters catch any errors thrown within guards, interceptors, or the tool handlers themselves, mapping them into user-friendly JSON payloads.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext): unknown | Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { ExceptionFilterInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class CustomExceptionFilter implements ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext) {
+    const message = exception instanceof Error ? exception.message : 'Unknown error';
+    return {
+      error: true,
+      message,
+      timestamp: new Date().toISOString()
+    };
+  }
+}
+```
+
+Apply the filter using `@UseFilters(...)` on a tool method:
+
+```typescript
+import { Tool, UseFilters, z } from '@nitrostack/core';
+import { CustomExceptionFilter } from './custom-exception.filter.js';
+
+export class LoggingTools {
+  @Tool({
+    name: 'generate_report',
+    description: 'Generates system usage reports.',
+    inputSchema: z.object({}),
+  })
+  @UseFilters(CustomExceptionFilter)
+  async generateReport() {
+    throw new Error('Report generation is not implemented yet.');
+  }
+}
+```
+
+---
+
+## 4. Middleware (`MiddlewareInterface`, `@Middleware` and `@UseMiddleware`)
+Middleware executes before the request reaches the tool handler, and can wrap the handler execution by invoking `next()`.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface MiddlewareInterface {
+  use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { Middleware, MiddlewareInterface, ExecutionContext } from '@nitrostack/core';
+
+@Middleware()
+export class LoggingMiddleware implements MiddlewareInterface {
+  async use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    context.logger.info(`Entering tool: ${context.toolName}`);
+    try {
+      const result = await next();
+      context.logger.info(`Exiting tool: ${context.toolName}`);
+      return result;
+    } catch (error) {
+      context.logger.error(`Error in tool: ${error}`);
+      throw error;
+    }
+  }
+}
+```
+
+Apply the middleware using `@UseMiddleware(...)` on a tool method:
+```typescript
+import { Tool, UseMiddleware, z } from '@nitrostack/core';
+import { LoggingMiddleware } from './logging.middleware.js';
+
+export class StationTools {
+  @Tool({
+    name: 'fetch_logs',
+    description: 'Fetch station operations logs.',
+    inputSchema: z.object({}),
+  })
+  @UseMiddleware(LoggingMiddleware)
+  async fetchLogs() {
+    return { status: 'operational' };
+  }
+}
+```
+
+---
+
+## 5. Pipes (`PipeInterface`, `@Pipe` and `@UsePipes`)
+Pipes are used to transform or validate input arguments before they reach the tool handler method.
+
+### Interface:
+```typescript
+import { ArgumentMetadata } from '@nitrostack/core';
+
+export interface PipeInterface<T = unknown, R = unknown> {
+  transform(value: T, metadata: ArgumentMetadata): R | Promise<R>;
+}
+```
+
+### Example:
+```typescript
+import { Pipe, PipeInterface, ArgumentMetadata } from '@nitrostack/core';
+
+@Pipe()
+export class TrimPipe implements PipeInterface<Record<string, unknown>, Record<string, unknown>> {
+  transform(value: Record<string, unknown>, metadata: ArgumentMetadata) {
+    const trimmed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      trimmed[key] = typeof val === 'string' ? val.trim() : val;
+    }
+    return trimmed;
+  }
+}
+```
+
+Apply the pipe using `@UsePipes(...)` on a tool method:
+```typescript
+import { Tool, UsePipes, z } from '@nitrostack/core';
+import { TrimPipe } from './trim.pipe.js';
+
+export class MessagingTools {
+  @Tool({
+    name: 'send_message',
+    description: 'Send a message to other stations.',
+    inputSchema: z.object({ text: z.string() }),
+  })
+  @UsePipes(TrimPipe)
+  async sendMessage(input: { text: string }) {
+    return { sentText: input.text };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.copilot/skills/tools-resources-prompts/SKILL.md
+++ b/sample-apps/concord-governance-agent/.copilot/skills/tools-resources-prompts/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: nitrostack-tools-resources-prompts
+description: Guidelines and patterns for defining Tools, Resources, and Prompts in a NitroStack application with schema validation via Zod, including caching, rate-limiting, and base64 file uploads.
+---
+
+## When to Use
+Use this skill whenever you are defining, editing, or validating tools, resources, or prompts on a NitroStack MCP server.
+
+## Defining Tools with `@Tool`
+An MCP tool exposes a function that an AI client can invoke. Decorate a service or controller method with `@Tool`.
+
+### Key Tool Options:
+* `name`: Kebab-case or snake_case unique identifier.
+* `description`: Detailed description explaining when and how the client should use it.
+* `inputSchema`: A Zod object schema for strict validation of inputs.
+* `outputSchema` (optional): Zod schema validating the output structure.
+
+```typescript
+import { ToolDecorator as Tool, ControllerDecorator as Controller, InitialTool, z, ExecutionContext } from '@nitrostack/core';
+
+@Controller('weather')
+export class WeatherService {
+  @Tool({
+    name: 'get_current_weather',
+    description: 'Get the current weather forecast for a specific city.',
+    inputSchema: z.object({
+      city: z.string().describe('The name of the city, e.g., San Francisco'),
+      unit: z.enum(['celsius', 'fahrenheit']).default('celsius'),
+    }),
+  })
+  @InitialTool() // Auto-invoked when the AI client initializes/starts
+  async getWeather(
+    input: { city: string; unit: 'celsius' | 'fahrenheit' },
+    ctx: ExecutionContext
+  ) {
+    ctx.logger.info(`Fetching weather for ${input.city}`);
+    // implementation
+    return {
+      city: input.city,
+      temp: 22,
+      condition: 'Sunny',
+    };
+  }
+}
+```
+
+## Defining Resources with `@Resource`
+An MCP resource exposes static or dynamic data files/URIs that the AI client can read.
+
+### Key Resource Options:
+* `uri`: URI pattern (e.g., `git://{owner}/{repo}/file` or static `app://config`).
+* `name`: Unique name of the resource.
+* `description`: Explanation of what data this resource provides.
+* `mimeType`: Mime type of the response (e.g., `text/plain`, `application/json`).
+
+```typescript
+import { Resource, ExecutionContext } from '@nitrostack/core';
+
+export class ConfigResources {
+  @Resource({
+    uri: 'app://settings',
+    name: 'Application Settings',
+    description: 'System-wide configuration settings and parameters.',
+    mimeType: 'application/json',
+  })
+  async getSettings(ctx: ExecutionContext) {
+    return {
+      environment: 'development',
+      debugMode: true,
+    };
+  }
+}
+```
+
+## Defining Prompts with `@Prompt`
+An MCP prompt exposes reusable templates or instruction sets that guide LLMs.
+
+### Key Prompt Options:
+* `name`: Name of the prompt.
+* `description`: Describes what task this prompt helps accomplish.
+* `arguments`: Declares parameters the client can supply to customize the prompt template.
+
+```typescript
+import { Prompt, ExecutionContext } from '@nitrostack/core';
+
+export class PromptTemplates {
+  @Prompt({
+    name: 'code_review',
+    description: 'Provide an intensive code review for a given code snippet.',
+    arguments: [
+      { name: 'language', description: 'The programming language, e.g., TypeScript', required: true },
+      { name: 'code', description: 'The code snippet to review', required: true },
+    ],
+  })
+  async getCodeReviewPrompt(
+    args: { language: string; code: string },
+    ctx: ExecutionContext
+  ) {
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: `You are an expert software engineer. Review this ${args.language} code:\n\n${args.code}`,
+        },
+      ],
+    };
+  }
+}
+```
+
+---
+
+## Tool Policies: Caching (`@Cache`) and Rate Limiting (`@RateLimit`)
+You can control tool execution behaviors (such as performance optimization and throttling) using method decorators.
+
+### 1. Caching with `@Cache`
+Use `@Cache` to cache tool execution outputs for a specified duration (TTL in seconds). This reduces database or API overhead for frequent identical requests.
+
+#### Options:
+* `ttl`: Cache time-to-live in seconds (required).
+* `key` (optional): Custom function `(input: any, context?: any) => string` that returns a unique cache key based on inputs. If not defined, a key is auto-generated from serialized input arguments.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, Cache, z } from '@nitrostack/core';
+
+export class StationTools {
+  @Tool({
+    name: 'get_system_status',
+    description: 'Fetch real-time station metrics. Response is cached.',
+    inputSchema: z.object({}),
+  })
+  @Cache({ ttl: 60 }) // Caches status for 60 seconds
+  async getSystemStatus() {
+    return { temperature: 21.5, oxygen: 0.98 };
+  }
+
+  @Tool({
+    name: 'get_crew_status',
+    description: 'Fetch status of a crew member. Cached by crew ID.',
+    inputSchema: z.object({ id: z.string() }),
+  })
+  @Cache({
+    ttl: 300,
+    key: (input) => `crew:status:${input.id}`
+  })
+  async getCrewStatus(input: { id: string }) {
+    // ...
+  }
+}
+```
+
+### 2. Rate Limiting with `@RateLimit`
+Use `@RateLimit` to restrict the number of tool invocations within a specified time window to prevent client abuse.
+
+#### Options:
+* `requests`: Number of allowed requests in the window (required).
+* `window`: Throttling duration window (required). Supports formats like `'1s'`, `'1m'`, `'1h'`.
+* `key` (optional): Custom function `(context: ExecutionContext) => string` to group rate limits. Useful for rate-limiting per user role or API key.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, RateLimit, z, ExecutionContext } from '@nitrostack/core';
+
+export class DiagnosticTools {
+  @Tool({
+    name: 'run_deep_diagnostic',
+    description: 'Run intensive diagnostics. Rate limited.',
+    inputSchema: z.object({}),
+  })
+  @RateLimit({ requests: 3, window: '1m' }) // Max 3 requests per minute globally
+  async runDeepDiagnostic() {
+    return { diagnosticReport: 'All systems operational.' };
+  }
+
+  @Tool({
+    name: 'request_supply_drop',
+    description: 'Request inventory supplies. Rate limited per user.',
+    inputSchema: z.object({ item: z.string() }),
+  })
+  @RateLimit({
+    requests: 5,
+    window: '1h',
+    key: (ctx: ExecutionContext) => ctx.auth?.subject || 'anonymous'
+  })
+  async requestSupply(input: { item: string }, ctx: ExecutionContext) {
+    // ...
+  }
+}
+```
+
+---
+
+## Handling File Uploads in Tools
+NitroStack supports file uploads from MCP clients (like NitroStudio) by passing the file as a base64-encoded string inside a tool's input parameters.
+
+### 1. Declaring Input Schema for File Uploads
+To accept an uploaded file, define three Zod fields in your tool's `inputSchema`:
+* `file_name`: The name of the file (e.g. `report.csv`).
+* `file_type`: The MIME type (e.g. `text/csv`).
+* `file_content`: The base64-encoded string containing the file data.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+
+export class FileTools {
+  @Tool({
+    name: 'upload_document',
+    description: 'Upload a text document or image.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async uploadDocument(input: any, ctx: ExecutionContext) {
+    // Processing logic
+  }
+}
+```
+
+### 2. Decoding Base64 Payloads
+File uploads can arrive in two formats depending on the client:
+1. **Data URL format**: `data:image/png;base64,iVBORw0KGgo...`
+2. **Raw Base64 format**: `iVBORw0KGgo...`
+
+Use the following universal decoder pattern to parse either format into a Node `Buffer`:
+
+```typescript
+import * as fs from 'fs';
+import * as path from 'path';
+
+function decodeBase64File(content: string): Buffer {
+  const matches = content.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/);
+  
+  if (matches && matches.length === 3) {
+    // Data URL format - decode matches[2]
+    return Buffer.from(matches[2], 'base64');
+  } else {
+    // Raw base64 format - decode input directly
+    return Buffer.from(content, 'base64');
+  }
+}
+```
+
+### 3. Secure File Saving Example
+Always validate the directory paths to prevent directory traversal attacks when saving files to disk.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads');
+
+export class SecureUploadTools {
+  @Tool({
+    name: 'save_uploaded_file',
+    description: 'Decodes and saves an uploaded file securely.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async saveFile(input: any, ctx: ExecutionContext) {
+    // Ensure uploads directory exists
+    if (!fs.existsSync(UPLOAD_DIR)) {
+      fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+    }
+
+    // Secure destination path to prevent path traversal
+    const safeName = path.basename(input.file_name);
+    const filePath = path.join(UPLOAD_DIR, safeName);
+    if (!filePath.startsWith(UPLOAD_DIR)) {
+      throw new Error('Invalid file path detected (path traversal).');
+    }
+
+    // Decode and write to disk
+    const buffer = decodeBase64File(input.file_content);
+    fs.writeFileSync(filePath, buffer);
+
+    ctx.logger.info(`Successfully saved file: ${safeName}`);
+    return { success: true, path: filePath };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.copilot/skills/ui-widgets/SKILL.md
+++ b/sample-apps/concord-governance-agent/.copilot/skills/ui-widgets/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: nitrostack-ui-widgets
+description: Best practices for linking tools to interactive frontend widgets using @Widget and @nitrostack/widgets SDK (including state sync, tool calling, display modes, media queries, and chat actions).
+---
+
+## When to Use
+Use this skill when designing, building, or modifying interactive user interface widgets that display custom React content inside AI clients or NitroStudio.
+
+---
+
+## 1. Backend Definition (`@Widget`)
+To display a React-based widget for a tool's output, decorate the tool method with `@Widget`.
+
+### Options:
+* **String Route**: A simple string representing the route identifier in the frontend React app (e.g. `'product-card'`).
+* **Object Route**: Object including:
+  * `route` (required): The route path.
+  * `domain` (optional): Allowed sandbox domain.
+  * `csp` (optional): Content Security Policy guidelines.
+
+### Example:
+```typescript
+import { Tool, Widget, z } from '@nitrostack/core';
+
+export class CatalogTools {
+  @Tool({
+    name: 'fetch_product',
+    description: 'Get product information by barcode.',
+    inputSchema: z.object({ barcode: z.string() }),
+  })
+  @Widget('product-details') // Maps to the "product-details" frontend component
+  async fetchProduct(input: { barcode: string }) {
+    return {
+      name: 'Super Nitro Energy Drink',
+      price: 2.99,
+      sku: input.barcode,
+    };
+  }
+}
+```
+
+---
+
+## 2. Frontend React Widget (`@nitrostack/widgets`)
+In your React widget frontend application (typically a Next.js client component), use the `useWidgetSDK` hook to receive input data from the client host.
+
+### React Component Example:
+```tsx
+'use client';
+
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+interface ProductData {
+  name: string;
+  price: number;
+  sku: string;
+}
+
+export default function ProductDetailsWidget() {
+  const { isReady, getToolOutput, theme } = useWidgetSDK();
+  const data = getToolOutput<ProductData>();
+
+  if (!isReady) {
+    return <div className="loading">Connecting to host...</div>;
+  }
+
+  if (!data) {
+    return <div className="error">No product data received.</div>;
+  }
+
+  return (
+    <div className={`product-card ${theme === 'dark' ? 'dark' : 'light'}`}>
+      <h3>{data.name}</h3>
+      <p className="price">${data.price.toFixed(2)}</p>
+      <span className="sku">SKU: {data.sku}</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 3. State Management & Synchronization (`useWidgetState`)
+Use `useWidgetState` to manage and persist client-side widget state (e.g. selected tabs, filter values, input states). This state automatically synchronizes with the host application context, persisting it across page re-renders.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetState } from '@nitrostack/widgets';
+
+export default function StationPanelWidget() {
+  const [state, setState] = useWidgetState(() => ({
+    selectedTab: 'overview',
+    showExtendedInfo: false,
+  }));
+
+  return (
+    <div>
+      <button onClick={() => setState({ ...state, selectedTab: 'alerts' })}>
+        View Alerts
+      </button>
+      <p>Current Tab: {state?.selectedTab}</p>
+    </div>
+  );
+}
+```
+
+---
+
+## 4. Calling Core Tools from Widgets (`callTool`)
+You can invoke other backend MCP tools directly from the frontend widget using `callTool`. This is useful for tool chaining or triggering detailed audits.
+
+### Example:
+```tsx
+import React, { useState } from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function SystemDiagnostics() {
+  const { callTool, isReady } = useWidgetSDK();
+  const [isRunning, setIsRunning] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+
+  const runDiagnostic = async () => {
+    if (!isReady) return;
+    setIsRunning(true);
+    try {
+      const response = await callTool('run_diagnostic', { system: 'oxygen_scrubber' });
+      setResult(response.result as string);
+    } catch (err) {
+      setResult('Diagnostic execution failed.');
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <button onClick={runDiagnostic} disabled={isRunning}>
+      {isRunning ? 'Running...' : 'Run Diagnostics'}
+    </button>
+  );
+}
+```
+
+---
+
+## 5. Layout & Display Controls
+Widgets can dynamically request size mode changes (fullscreen, inline, picture-in-picture) and adapt layouts to safe areas (dynamic islands/notches) or maximum height constraints.
+
+### Key Methods:
+* `requestFullscreen()`: Switch host widget display to fullscreen.
+* `requestInline()`: Switch host widget display back to inline.
+* `requestPip()`: Float widget in Picture-in-Picture.
+* `requestClose()`: Dismiss the widget completely.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function StatusBoard() {
+  const { 
+    requestFullscreen, 
+    requestInline, 
+    requestClose,
+    displayMode,   // Reactive property ('fullscreen' | 'inline' | 'pip')
+    maxHeight,     // Reactive maxHeight constraint (in pixels)
+    getSafeArea    // Insets data: { top, right, bottom, left }
+  } = useWidgetSDK();
+
+  const safeArea = getSafeArea() || { top: 0, bottom: 0 };
+
+  return (
+    <div style={{ maxHeight: maxHeight || 400, paddingTop: safeArea.top }}>
+      <h3>Mode: {displayMode}</h3>
+      <button onClick={requestFullscreen}>Fullscreen</button>
+      <button onClick={requestInline}>Collapse</button>
+      <button onClick={requestClose}>Dismiss Widget</button>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. Chat Navigation & Actions
+Widgets can interact with the host chat pane using external browser links and follow-up prompts.
+
+### Key Methods:
+* `openExternal(url)`: Open the target URL safely in the user's primary external browser.
+* `sendFollowUpMessage(prompt)`: Insert a message into the chat flow, automatically submitting it to the LLM agent.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function MissionControl() {
+  const { openExternal, sendFollowUpMessage } = useWidgetSDK();
+
+  return (
+    <div>
+      {/* Open external documentation */}
+      <button onClick={() => openExternal('https://docs.nitrostack.dev')}>
+        Open Manual
+      </button>
+
+      {/* Ask LLM agent directly from the widget */}
+      <button onClick={() => sendFollowUpMessage('Analyze mission failures from last week')}>
+        Ask Agent to Analyze
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 7. Media & Accessibility Queries
+The SDK provides helper utilities to query target client capabilities for styling or accessibility.
+
+### Key Utilities:
+* `prefersReducedMotion()`: Returns `true` if client settings specify reduced motion. Disable animations.
+* `isPrimarilyTouchDevice()`: Returns `true` if the device has a coarse pointer (e.g. touch/mobile). Increase button target sizes.
+* `isHoverAvailable()`: Returns `true` if pointer supports hover states.
+* `prefersDarkColorScheme()`: Returns `true` if the system theme is dark.
+
+### Example:
+```tsx
+import React from 'react';
+import { isPrimarilyTouchDevice, prefersReducedMotion } from '@nitrostack/widgets';
+
+export default function AccessiblePanel() {
+  const isTouch = isPrimarilyTouchDevice();
+  const reducedMotion = prefersReducedMotion();
+
+  return (
+    <div className={reducedMotion ? 'no-animations' : 'smooth-transitions'}>
+      <button style={{ padding: isTouch ? '16px' : '8px' }}>
+        Interactive Button
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 8. Testing Widgets
+* Open your project in **NitroStudio** for visual preview.
+* Invoke the tool from the AI chat or testing pane to verify the widget updates instantly with the returned JSON structure.

--- a/sample-apps/concord-governance-agent/.cursor/skills/auth-security/SKILL.md
+++ b/sample-apps/concord-governance-agent/.cursor/skills/auth-security/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: nitrostack-auth-security
+description: Best practices for implementing JWT, API Keys, OAuth 2.1, and RBAC in a NitroStack application.
+---
+
+## When to Use
+Use this skill when configuring security modules, implementing user authentication, restricting tool access via guards, or handling sensitive tokens.
+
+---
+
+## 1. JSON Web Tokens (JWT)
+To secure tools with JWT authentication:
+
+### Register `JWTModule`:
+```typescript
+import { JWTModule, Module, McpApp } from '@nitrostack/core';
+
+@McpApp({
+  server: { name: 'my-server', version: '1.0.0' }
+})
+@Module({
+  imports: [
+    JWTModule.forRoot({
+      secret: process.env.JWT_SECRET!,
+      expiresIn: '7d',
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### Write a `JWTGuard`:
+```typescript
+import { Guard, ExecutionContext, Injectable, ConfigService } from '@nitrostack/core';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class JWTGuard implements Guard {
+  constructor(private config: ConfigService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const token = this.extractToken(context);
+    if (!token) return false;
+
+    try {
+      const secret = this.config.get('JWT_SECRET');
+      const payload = jwt.verify(token, secret) as any;
+      context.auth = {
+        subject: payload.sub,
+        role: payload.role,
+        token,
+      };
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private extractToken(context: ExecutionContext): string | null {
+    const auth = context.metadata?.authorization;
+    if (auth?.startsWith('Bearer ')) {
+      return auth.substring(7);
+    }
+    return null;
+  }
+}
+```
+
+---
+
+## 2. API Key Authentication
+Use `ApiKeyModule` for service-to-service validation.
+
+### Register `ApiKeyModule`:
+```typescript
+import { ApiKeyModule, Module } from '@nitrostack/core';
+
+@Module({
+  imports: [
+    ApiKeyModule.forRoot({
+      keysEnvPrefix: 'API_KEY', // Reads API_KEY_1, API_KEY_2, etc.
+      headerName: 'x-api-key',
+      hashed: false,
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### API Key Guard:
+```typescript
+import { Guard, ExecutionContext, ApiKeyModule } from '@nitrostack/core';
+
+export class ApiKeyGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const apiKey = context.metadata?.['x-api-key'] || context.metadata?.apiKey;
+    if (!apiKey) return false;
+
+    const isValid = await ApiKeyModule.validate(apiKey as string);
+    if (isValid) {
+      context.auth = {
+        subject: `apikey_${(apiKey as string).substring(0, 10)}`,
+        scopes: ['*'],
+      };
+      return true;
+    }
+    return false;
+  }
+}
+```
+
+---
+
+## 3. Role-Based Access Control (RBAC)
+Chain guards sequentially to implement user-role authorization.
+
+```typescript
+import { Injectable, Guard, ExecutionContext, UseGuards, Tool, z } from '@nitrostack/core';
+import { JWTGuard } from './jwt.guard.js';
+
+@Injectable()
+export class AdminGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Requires JWTGuard to have populated context.auth first
+    return context.auth?.role === 'admin';
+  }
+}
+
+// Applying chained guards to a tool
+export class SystemTools {
+  @Tool({
+    name: 'reset_database',
+    description: 'Dangerous action: wipes database. Admin only.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(JWTGuard, AdminGuard) // Chain auth first, then role check
+  async resetDatabase() {
+    return { success: true };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.cursor/skills/mcp-app-architecture/SKILL.md
+++ b/sample-apps/concord-governance-agent/.cursor/skills/mcp-app-architecture/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: nitrostack-mcp-app-architecture
+description: Best practices and guidelines for bootstrapping, defining modules, using dependency injection, managing server lifecycles, and handling events in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill whenever you are bootstrapping a new NitroStack MCP server, creating modules, injecting services, or handling application lifecycle events.
+
+## Bootstrapping a NitroStack App
+A NitroStack application is initialized with the `@McpApp` decorator on a root class, accompanied by a root `@Module`.
+
+```typescript
+import { McpApp, Module } from '@nitrostack/core';
+import { DatabaseModule } from './database/database.module.js';
+import { UsersModule } from './users/users.module.js';
+
+@McpApp({
+  module: AppModule,
+  server: {
+    name: 'user-management-server',
+    version: '1.0.0',
+  },
+})
+@Module({
+  imports: [DatabaseModule, UsersModule],
+})
+export class AppModule {}
+```
+
+## Modules
+Modules organize your application structure. Use the `@Module` decorator to define imports, exports, and providers.
+
+* **`imports`**: Other modules whose exported providers should be available in this module.
+* **`providers`**: Services, tools, resources, or prompts that should be instantiated and managed by the DI container within this module.
+* **`exports`**: Providers defined in this module that should be visible to other modules importing this one.
+
+```typescript
+import { Module } from '@nitrostack/core';
+import { UsersService } from './users.service.js';
+import { UsersTools } from './users.tools.js';
+
+@Module({
+  providers: [UsersService, UsersTools],
+  exports: [UsersService],
+})
+
+## Controllers
+Use the `@ControllerDecorator` (or alias it as `@Controller`) to group tools, resources, and prompts together. Controllers are automatically registered as singletons in the DI container.
+
+### Key Controller Options:
+* **`prefix`**: A string prefix applied to every `@Tool` defined in this controller. For example, `@ControllerDecorator('github')` prefixing a tool named `create_issue` exposes it to MCP clients as `github_create_issue`.
+
+```typescript
+import { ControllerDecorator as Controller, Tool, ExecutionContext } from '@nitrostack/core';
+
+@Controller('github')
+export class GitHubController {
+  @Tool({
+    name: 'create_issue',
+    description: 'Create an issue in a repository',
+    inputSchema: z.object({ /* ... */ })
+  })
+  async createIssue(input: any, ctx: ExecutionContext) {
+    // Exposed to clients as "github_create_issue"
+  }
+}
+```
+
+## Dependency Injection (DI)
+NitroStack uses a robust dependency injection container to manage class instances and lifecycles.
+
+### Injection Lifecycles
+1. **Singleton (Default)**: A single instance is shared across the entire application.
+2. **Transient**: A new instance is created every time it is resolved/injected.
+3. **Scoped**: A new instance is created per incoming request or context.
+
+```typescript
+import { Injectable, Scope } from '@nitrostack/core';
+
+@Injectable({ scope: Scope.SINGLETON })
+export class UsersService {
+  constructor(private readonly db: DatabaseService) {}
+  
+  async getUser(id: string) {
+    return this.db.query('SELECT * FROM users WHERE id = $1', [id]);
+  }
+}
+```
+
+## Lifecycles and Hooks
+Implement NestJS-style lifecycle interfaces on modules, controllers, or providers to hook into application state changes:
+
+* **`OnModuleInit`** (`onModuleInit`): Called after modules have initialized but before the server starts listening.
+* **`OnApplicationBootstrap`** (`onApplicationBootstrap`): Called once the server is fully started and listening.
+* **`OnModuleDestroy`** (`onModuleDestroy`): Called when the module or application is shutting down.
+* **`BeforeApplicationShutdown`** (`beforeApplicationShutdown(signal?: string)`): Called before the application starts shutting down. Receives the OS signal (e.g. `SIGINT`).
+* **`OnApplicationShutdown`** (`onApplicationShutdown(signal?: string)`): Called during shutdown. Receives the OS signal.
+
+```typescript
+import { 
+  Injectable, 
+  OnModuleInit, 
+  OnApplicationBootstrap,
+  OnModuleDestroy, 
+  BeforeApplicationShutdown,
+  OnApplicationShutdown 
+} from '@nitrostack/core';
+
+@Injectable()
+export class DatabaseService 
+  implements OnModuleInit, OnApplicationBootstrap, OnModuleDestroy, BeforeApplicationShutdown, OnApplicationShutdown 
+{
+  async onModuleInit() {
+    await this.connect();
+  }
+
+  async onApplicationBootstrap() {
+    console.log('App ready to handle connections.');
+  }
+
+  async onModuleDestroy() {
+    await this.cleanupPendingQueries();
+  }
+
+  async beforeApplicationShutdown(signal?: string) {
+    console.log(`Shutting down soon (signal: ${signal}).`);
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    await this.disconnect();
+  }
+}
+```
+
+---
+
+## Eventing System (`emitEvent` and `@OnEvent`)
+NitroStack includes an internal eventing system to decouple components. A service or tool can emit an event using `emitEvent`, and any injectable class (like a handler service or controller) can subscribe using the `@OnEvent` decorator.
+
+### 1. Emitting Events
+Call `emitEvent` to dispatch an event payload asynchronously.
+
+```typescript
+import { Injectable, emitEvent } from '@nitrostack/core';
+
+@Injectable()
+export class SpaceShipService {
+  async launchShip(shipId: string) {
+    // Process launch...
+    
+    // Dispatch event
+    emitEvent('ship.launched', {
+      shipId,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+```
+
+### 2. Listening to Events
+Decorate a method inside any `@Injectable()` class with `@OnEvent('event_pattern')` to register it as an event handler.
+
+```typescript
+import { Injectable, OnEvent } from '@nitrostack/core';
+
+@Injectable({ deps: [] })
+export class FlightLogHandler {
+  @OnEvent('ship.launched')
+  async logLaunch(data: { shipId: string; timestamp: string }) {
+    console.error(`🚀 [EVENT] Ship ${data.shipId} was successfully launched at ${data.timestamp}`);
+  }
+}
+```
+
+> [!NOTE]
+> For the `@OnEvent` decorator to register properly, the containing class must be declared as a provider inside an active module.

--- a/sample-apps/concord-governance-agent/.cursor/skills/middleware-pipeline/SKILL.md
+++ b/sample-apps/concord-governance-agent/.cursor/skills/middleware-pipeline/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: nitrostack-middleware-pipeline
+description: Best practices for implementing and applying Guards, Interceptors, Middleware, Pipes, and Exception Filters in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill when implementing request validation, authorization checks, response mapping, logging, error handling, or performance tracking on NitroStack tool methods.
+
+---
+
+## 1. Guards (`Guard` and `@UseGuards`)
+Guards determine if a request should be processed by a tool handler based on authentication, authorization, or other conditions.
+
+### Interface:
+```typescript
+import { Guard, ExecutionContext } from '@nitrostack/core';
+
+export interface Guard {
+  canActivate(context: ExecutionContext): boolean | Promise<boolean>;
+}
+```
+
+### Example:
+```typescript
+import { Guard, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class RolesGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const userRoles = context.clientMetadata?.roles || [];
+    return userRoles.includes('admin');
+  }
+}
+```
+
+Apply the guard using `@UseGuards(...)`:
+```typescript
+import { Tool, UseGuards, z } from '@nitrostack/core';
+import { RolesGuard } from './roles.guard.js';
+
+export class AdminTools {
+  @Tool({
+    name: 'delete_system_logs',
+    description: 'Delete all system logs from the server.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(RolesGuard)
+  async deleteLogs() {
+    return { success: true };
+  }
+}
+```
+
+---
+
+## 2. Interceptors (`InterceptorInterface` and `@UseInterceptors`)
+Interceptors can transform/intercept input arguments or mapped output from a tool method execution.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface InterceptorInterface {
+  intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { InterceptorInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class TimingInterceptor implements InterceptorInterface {
+  async intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    const start = Date.now();
+    const result = await next();
+    const duration = Date.now() - start;
+    context.logger.info(`Execution took ${duration}ms`);
+    return {
+      ...result,
+      _meta: { durationMs: duration }
+    };
+  }
+}
+```
+
+---
+
+## 3. Exception Filters (`ExceptionFilterInterface` and `@UseFilters`)
+Exception filters catch any errors thrown within guards, interceptors, or the tool handlers themselves, mapping them into user-friendly JSON payloads.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext): unknown | Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { ExceptionFilterInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class CustomExceptionFilter implements ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext) {
+    const message = exception instanceof Error ? exception.message : 'Unknown error';
+    return {
+      error: true,
+      message,
+      timestamp: new Date().toISOString()
+    };
+  }
+}
+```
+
+Apply the filter using `@UseFilters(...)` on a tool method:
+
+```typescript
+import { Tool, UseFilters, z } from '@nitrostack/core';
+import { CustomExceptionFilter } from './custom-exception.filter.js';
+
+export class LoggingTools {
+  @Tool({
+    name: 'generate_report',
+    description: 'Generates system usage reports.',
+    inputSchema: z.object({}),
+  })
+  @UseFilters(CustomExceptionFilter)
+  async generateReport() {
+    throw new Error('Report generation is not implemented yet.');
+  }
+}
+```
+
+---
+
+## 4. Middleware (`MiddlewareInterface`, `@Middleware` and `@UseMiddleware`)
+Middleware executes before the request reaches the tool handler, and can wrap the handler execution by invoking `next()`.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface MiddlewareInterface {
+  use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { Middleware, MiddlewareInterface, ExecutionContext } from '@nitrostack/core';
+
+@Middleware()
+export class LoggingMiddleware implements MiddlewareInterface {
+  async use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    context.logger.info(`Entering tool: ${context.toolName}`);
+    try {
+      const result = await next();
+      context.logger.info(`Exiting tool: ${context.toolName}`);
+      return result;
+    } catch (error) {
+      context.logger.error(`Error in tool: ${error}`);
+      throw error;
+    }
+  }
+}
+```
+
+Apply the middleware using `@UseMiddleware(...)` on a tool method:
+```typescript
+import { Tool, UseMiddleware, z } from '@nitrostack/core';
+import { LoggingMiddleware } from './logging.middleware.js';
+
+export class StationTools {
+  @Tool({
+    name: 'fetch_logs',
+    description: 'Fetch station operations logs.',
+    inputSchema: z.object({}),
+  })
+  @UseMiddleware(LoggingMiddleware)
+  async fetchLogs() {
+    return { status: 'operational' };
+  }
+}
+```
+
+---
+
+## 5. Pipes (`PipeInterface`, `@Pipe` and `@UsePipes`)
+Pipes are used to transform or validate input arguments before they reach the tool handler method.
+
+### Interface:
+```typescript
+import { ArgumentMetadata } from '@nitrostack/core';
+
+export interface PipeInterface<T = unknown, R = unknown> {
+  transform(value: T, metadata: ArgumentMetadata): R | Promise<R>;
+}
+```
+
+### Example:
+```typescript
+import { Pipe, PipeInterface, ArgumentMetadata } from '@nitrostack/core';
+
+@Pipe()
+export class TrimPipe implements PipeInterface<Record<string, unknown>, Record<string, unknown>> {
+  transform(value: Record<string, unknown>, metadata: ArgumentMetadata) {
+    const trimmed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      trimmed[key] = typeof val === 'string' ? val.trim() : val;
+    }
+    return trimmed;
+  }
+}
+```
+
+Apply the pipe using `@UsePipes(...)` on a tool method:
+```typescript
+import { Tool, UsePipes, z } from '@nitrostack/core';
+import { TrimPipe } from './trim.pipe.js';
+
+export class MessagingTools {
+  @Tool({
+    name: 'send_message',
+    description: 'Send a message to other stations.',
+    inputSchema: z.object({ text: z.string() }),
+  })
+  @UsePipes(TrimPipe)
+  async sendMessage(input: { text: string }) {
+    return { sentText: input.text };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.cursor/skills/tools-resources-prompts/SKILL.md
+++ b/sample-apps/concord-governance-agent/.cursor/skills/tools-resources-prompts/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: nitrostack-tools-resources-prompts
+description: Guidelines and patterns for defining Tools, Resources, and Prompts in a NitroStack application with schema validation via Zod, including caching, rate-limiting, and base64 file uploads.
+---
+
+## When to Use
+Use this skill whenever you are defining, editing, or validating tools, resources, or prompts on a NitroStack MCP server.
+
+## Defining Tools with `@Tool`
+An MCP tool exposes a function that an AI client can invoke. Decorate a service or controller method with `@Tool`.
+
+### Key Tool Options:
+* `name`: Kebab-case or snake_case unique identifier.
+* `description`: Detailed description explaining when and how the client should use it.
+* `inputSchema`: A Zod object schema for strict validation of inputs.
+* `outputSchema` (optional): Zod schema validating the output structure.
+
+```typescript
+import { ToolDecorator as Tool, ControllerDecorator as Controller, InitialTool, z, ExecutionContext } from '@nitrostack/core';
+
+@Controller('weather')
+export class WeatherService {
+  @Tool({
+    name: 'get_current_weather',
+    description: 'Get the current weather forecast for a specific city.',
+    inputSchema: z.object({
+      city: z.string().describe('The name of the city, e.g., San Francisco'),
+      unit: z.enum(['celsius', 'fahrenheit']).default('celsius'),
+    }),
+  })
+  @InitialTool() // Auto-invoked when the AI client initializes/starts
+  async getWeather(
+    input: { city: string; unit: 'celsius' | 'fahrenheit' },
+    ctx: ExecutionContext
+  ) {
+    ctx.logger.info(`Fetching weather for ${input.city}`);
+    // implementation
+    return {
+      city: input.city,
+      temp: 22,
+      condition: 'Sunny',
+    };
+  }
+}
+```
+
+## Defining Resources with `@Resource`
+An MCP resource exposes static or dynamic data files/URIs that the AI client can read.
+
+### Key Resource Options:
+* `uri`: URI pattern (e.g., `git://{owner}/{repo}/file` or static `app://config`).
+* `name`: Unique name of the resource.
+* `description`: Explanation of what data this resource provides.
+* `mimeType`: Mime type of the response (e.g., `text/plain`, `application/json`).
+
+```typescript
+import { Resource, ExecutionContext } from '@nitrostack/core';
+
+export class ConfigResources {
+  @Resource({
+    uri: 'app://settings',
+    name: 'Application Settings',
+    description: 'System-wide configuration settings and parameters.',
+    mimeType: 'application/json',
+  })
+  async getSettings(ctx: ExecutionContext) {
+    return {
+      environment: 'development',
+      debugMode: true,
+    };
+  }
+}
+```
+
+## Defining Prompts with `@Prompt`
+An MCP prompt exposes reusable templates or instruction sets that guide LLMs.
+
+### Key Prompt Options:
+* `name`: Name of the prompt.
+* `description`: Describes what task this prompt helps accomplish.
+* `arguments`: Declares parameters the client can supply to customize the prompt template.
+
+```typescript
+import { Prompt, ExecutionContext } from '@nitrostack/core';
+
+export class PromptTemplates {
+  @Prompt({
+    name: 'code_review',
+    description: 'Provide an intensive code review for a given code snippet.',
+    arguments: [
+      { name: 'language', description: 'The programming language, e.g., TypeScript', required: true },
+      { name: 'code', description: 'The code snippet to review', required: true },
+    ],
+  })
+  async getCodeReviewPrompt(
+    args: { language: string; code: string },
+    ctx: ExecutionContext
+  ) {
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: `You are an expert software engineer. Review this ${args.language} code:\n\n${args.code}`,
+        },
+      ],
+    };
+  }
+}
+```
+
+---
+
+## Tool Policies: Caching (`@Cache`) and Rate Limiting (`@RateLimit`)
+You can control tool execution behaviors (such as performance optimization and throttling) using method decorators.
+
+### 1. Caching with `@Cache`
+Use `@Cache` to cache tool execution outputs for a specified duration (TTL in seconds). This reduces database or API overhead for frequent identical requests.
+
+#### Options:
+* `ttl`: Cache time-to-live in seconds (required).
+* `key` (optional): Custom function `(input: any, context?: any) => string` that returns a unique cache key based on inputs. If not defined, a key is auto-generated from serialized input arguments.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, Cache, z } from '@nitrostack/core';
+
+export class StationTools {
+  @Tool({
+    name: 'get_system_status',
+    description: 'Fetch real-time station metrics. Response is cached.',
+    inputSchema: z.object({}),
+  })
+  @Cache({ ttl: 60 }) // Caches status for 60 seconds
+  async getSystemStatus() {
+    return { temperature: 21.5, oxygen: 0.98 };
+  }
+
+  @Tool({
+    name: 'get_crew_status',
+    description: 'Fetch status of a crew member. Cached by crew ID.',
+    inputSchema: z.object({ id: z.string() }),
+  })
+  @Cache({
+    ttl: 300,
+    key: (input) => `crew:status:${input.id}`
+  })
+  async getCrewStatus(input: { id: string }) {
+    // ...
+  }
+}
+```
+
+### 2. Rate Limiting with `@RateLimit`
+Use `@RateLimit` to restrict the number of tool invocations within a specified time window to prevent client abuse.
+
+#### Options:
+* `requests`: Number of allowed requests in the window (required).
+* `window`: Throttling duration window (required). Supports formats like `'1s'`, `'1m'`, `'1h'`.
+* `key` (optional): Custom function `(context: ExecutionContext) => string` to group rate limits. Useful for rate-limiting per user role or API key.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, RateLimit, z, ExecutionContext } from '@nitrostack/core';
+
+export class DiagnosticTools {
+  @Tool({
+    name: 'run_deep_diagnostic',
+    description: 'Run intensive diagnostics. Rate limited.',
+    inputSchema: z.object({}),
+  })
+  @RateLimit({ requests: 3, window: '1m' }) // Max 3 requests per minute globally
+  async runDeepDiagnostic() {
+    return { diagnosticReport: 'All systems operational.' };
+  }
+
+  @Tool({
+    name: 'request_supply_drop',
+    description: 'Request inventory supplies. Rate limited per user.',
+    inputSchema: z.object({ item: z.string() }),
+  })
+  @RateLimit({
+    requests: 5,
+    window: '1h',
+    key: (ctx: ExecutionContext) => ctx.auth?.subject || 'anonymous'
+  })
+  async requestSupply(input: { item: string }, ctx: ExecutionContext) {
+    // ...
+  }
+}
+```
+
+---
+
+## Handling File Uploads in Tools
+NitroStack supports file uploads from MCP clients (like NitroStudio) by passing the file as a base64-encoded string inside a tool's input parameters.
+
+### 1. Declaring Input Schema for File Uploads
+To accept an uploaded file, define three Zod fields in your tool's `inputSchema`:
+* `file_name`: The name of the file (e.g. `report.csv`).
+* `file_type`: The MIME type (e.g. `text/csv`).
+* `file_content`: The base64-encoded string containing the file data.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+
+export class FileTools {
+  @Tool({
+    name: 'upload_document',
+    description: 'Upload a text document or image.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async uploadDocument(input: any, ctx: ExecutionContext) {
+    // Processing logic
+  }
+}
+```
+
+### 2. Decoding Base64 Payloads
+File uploads can arrive in two formats depending on the client:
+1. **Data URL format**: `data:image/png;base64,iVBORw0KGgo...`
+2. **Raw Base64 format**: `iVBORw0KGgo...`
+
+Use the following universal decoder pattern to parse either format into a Node `Buffer`:
+
+```typescript
+import * as fs from 'fs';
+import * as path from 'path';
+
+function decodeBase64File(content: string): Buffer {
+  const matches = content.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/);
+  
+  if (matches && matches.length === 3) {
+    // Data URL format - decode matches[2]
+    return Buffer.from(matches[2], 'base64');
+  } else {
+    // Raw base64 format - decode input directly
+    return Buffer.from(content, 'base64');
+  }
+}
+```
+
+### 3. Secure File Saving Example
+Always validate the directory paths to prevent directory traversal attacks when saving files to disk.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads');
+
+export class SecureUploadTools {
+  @Tool({
+    name: 'save_uploaded_file',
+    description: 'Decodes and saves an uploaded file securely.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async saveFile(input: any, ctx: ExecutionContext) {
+    // Ensure uploads directory exists
+    if (!fs.existsSync(UPLOAD_DIR)) {
+      fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+    }
+
+    // Secure destination path to prevent path traversal
+    const safeName = path.basename(input.file_name);
+    const filePath = path.join(UPLOAD_DIR, safeName);
+    if (!filePath.startsWith(UPLOAD_DIR)) {
+      throw new Error('Invalid file path detected (path traversal).');
+    }
+
+    // Decode and write to disk
+    const buffer = decodeBase64File(input.file_content);
+    fs.writeFileSync(filePath, buffer);
+
+    ctx.logger.info(`Successfully saved file: ${safeName}`);
+    return { success: true, path: filePath };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.cursor/skills/ui-widgets/SKILL.md
+++ b/sample-apps/concord-governance-agent/.cursor/skills/ui-widgets/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: nitrostack-ui-widgets
+description: Best practices for linking tools to interactive frontend widgets using @Widget and @nitrostack/widgets SDK (including state sync, tool calling, display modes, media queries, and chat actions).
+---
+
+## When to Use
+Use this skill when designing, building, or modifying interactive user interface widgets that display custom React content inside AI clients or NitroStudio.
+
+---
+
+## 1. Backend Definition (`@Widget`)
+To display a React-based widget for a tool's output, decorate the tool method with `@Widget`.
+
+### Options:
+* **String Route**: A simple string representing the route identifier in the frontend React app (e.g. `'product-card'`).
+* **Object Route**: Object including:
+  * `route` (required): The route path.
+  * `domain` (optional): Allowed sandbox domain.
+  * `csp` (optional): Content Security Policy guidelines.
+
+### Example:
+```typescript
+import { Tool, Widget, z } from '@nitrostack/core';
+
+export class CatalogTools {
+  @Tool({
+    name: 'fetch_product',
+    description: 'Get product information by barcode.',
+    inputSchema: z.object({ barcode: z.string() }),
+  })
+  @Widget('product-details') // Maps to the "product-details" frontend component
+  async fetchProduct(input: { barcode: string }) {
+    return {
+      name: 'Super Nitro Energy Drink',
+      price: 2.99,
+      sku: input.barcode,
+    };
+  }
+}
+```
+
+---
+
+## 2. Frontend React Widget (`@nitrostack/widgets`)
+In your React widget frontend application (typically a Next.js client component), use the `useWidgetSDK` hook to receive input data from the client host.
+
+### React Component Example:
+```tsx
+'use client';
+
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+interface ProductData {
+  name: string;
+  price: number;
+  sku: string;
+}
+
+export default function ProductDetailsWidget() {
+  const { isReady, getToolOutput, theme } = useWidgetSDK();
+  const data = getToolOutput<ProductData>();
+
+  if (!isReady) {
+    return <div className="loading">Connecting to host...</div>;
+  }
+
+  if (!data) {
+    return <div className="error">No product data received.</div>;
+  }
+
+  return (
+    <div className={`product-card ${theme === 'dark' ? 'dark' : 'light'}`}>
+      <h3>{data.name}</h3>
+      <p className="price">${data.price.toFixed(2)}</p>
+      <span className="sku">SKU: {data.sku}</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 3. State Management & Synchronization (`useWidgetState`)
+Use `useWidgetState` to manage and persist client-side widget state (e.g. selected tabs, filter values, input states). This state automatically synchronizes with the host application context, persisting it across page re-renders.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetState } from '@nitrostack/widgets';
+
+export default function StationPanelWidget() {
+  const [state, setState] = useWidgetState(() => ({
+    selectedTab: 'overview',
+    showExtendedInfo: false,
+  }));
+
+  return (
+    <div>
+      <button onClick={() => setState({ ...state, selectedTab: 'alerts' })}>
+        View Alerts
+      </button>
+      <p>Current Tab: {state?.selectedTab}</p>
+    </div>
+  );
+}
+```
+
+---
+
+## 4. Calling Core Tools from Widgets (`callTool`)
+You can invoke other backend MCP tools directly from the frontend widget using `callTool`. This is useful for tool chaining or triggering detailed audits.
+
+### Example:
+```tsx
+import React, { useState } from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function SystemDiagnostics() {
+  const { callTool, isReady } = useWidgetSDK();
+  const [isRunning, setIsRunning] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+
+  const runDiagnostic = async () => {
+    if (!isReady) return;
+    setIsRunning(true);
+    try {
+      const response = await callTool('run_diagnostic', { system: 'oxygen_scrubber' });
+      setResult(response.result as string);
+    } catch (err) {
+      setResult('Diagnostic execution failed.');
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <button onClick={runDiagnostic} disabled={isRunning}>
+      {isRunning ? 'Running...' : 'Run Diagnostics'}
+    </button>
+  );
+}
+```
+
+---
+
+## 5. Layout & Display Controls
+Widgets can dynamically request size mode changes (fullscreen, inline, picture-in-picture) and adapt layouts to safe areas (dynamic islands/notches) or maximum height constraints.
+
+### Key Methods:
+* `requestFullscreen()`: Switch host widget display to fullscreen.
+* `requestInline()`: Switch host widget display back to inline.
+* `requestPip()`: Float widget in Picture-in-Picture.
+* `requestClose()`: Dismiss the widget completely.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function StatusBoard() {
+  const { 
+    requestFullscreen, 
+    requestInline, 
+    requestClose,
+    displayMode,   // Reactive property ('fullscreen' | 'inline' | 'pip')
+    maxHeight,     // Reactive maxHeight constraint (in pixels)
+    getSafeArea    // Insets data: { top, right, bottom, left }
+  } = useWidgetSDK();
+
+  const safeArea = getSafeArea() || { top: 0, bottom: 0 };
+
+  return (
+    <div style={{ maxHeight: maxHeight || 400, paddingTop: safeArea.top }}>
+      <h3>Mode: {displayMode}</h3>
+      <button onClick={requestFullscreen}>Fullscreen</button>
+      <button onClick={requestInline}>Collapse</button>
+      <button onClick={requestClose}>Dismiss Widget</button>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. Chat Navigation & Actions
+Widgets can interact with the host chat pane using external browser links and follow-up prompts.
+
+### Key Methods:
+* `openExternal(url)`: Open the target URL safely in the user's primary external browser.
+* `sendFollowUpMessage(prompt)`: Insert a message into the chat flow, automatically submitting it to the LLM agent.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function MissionControl() {
+  const { openExternal, sendFollowUpMessage } = useWidgetSDK();
+
+  return (
+    <div>
+      {/* Open external documentation */}
+      <button onClick={() => openExternal('https://docs.nitrostack.dev')}>
+        Open Manual
+      </button>
+
+      {/* Ask LLM agent directly from the widget */}
+      <button onClick={() => sendFollowUpMessage('Analyze mission failures from last week')}>
+        Ask Agent to Analyze
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 7. Media & Accessibility Queries
+The SDK provides helper utilities to query target client capabilities for styling or accessibility.
+
+### Key Utilities:
+* `prefersReducedMotion()`: Returns `true` if client settings specify reduced motion. Disable animations.
+* `isPrimarilyTouchDevice()`: Returns `true` if the device has a coarse pointer (e.g. touch/mobile). Increase button target sizes.
+* `isHoverAvailable()`: Returns `true` if pointer supports hover states.
+* `prefersDarkColorScheme()`: Returns `true` if the system theme is dark.
+
+### Example:
+```tsx
+import React from 'react';
+import { isPrimarilyTouchDevice, prefersReducedMotion } from '@nitrostack/widgets';
+
+export default function AccessiblePanel() {
+  const isTouch = isPrimarilyTouchDevice();
+  const reducedMotion = prefersReducedMotion();
+
+  return (
+    <div className={reducedMotion ? 'no-animations' : 'smooth-transitions'}>
+      <button style={{ padding: isTouch ? '16px' : '8px' }}>
+        Interactive Button
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 8. Testing Widgets
+* Open your project in **NitroStudio** for visual preview.
+* Invoke the tool from the AI chat or testing pane to verify the widget updates instantly with the returned JSON structure.

--- a/sample-apps/concord-governance-agent/.env.example
+++ b/sample-apps/concord-governance-agent/.env.example
@@ -1,0 +1,88 @@
+# NitroStack Configuration
+NITRO_LOG_LEVEL=info
+NITROSTACK_APP_MODE=openai
+
+# Server Transport Configuration (Optional)
+# =============================================================================
+# MCP_TRANSPORT_TYPE: Toggles transport mode. Values: stdio | http | dual.
+# Defaults to 'stdio' in development and 'dual' in production/NODE_ENV=production.
+# =============================================================================
+# MCP_TRANSPORT_TYPE=dual
+# PORT=3000
+# HOST=localhost
+# ENABLE_CORS=true
+
+# Streamable HTTP Session Limits (Optional)
+# =============================================================================
+# Bounds memory against unauthenticated initialize floods. Defaults: 1000 sessions,
+# 30-minute idle timeout. Only applies when running in http or dual transport mode.
+# =============================================================================
+# MCP_MAX_SESSIONS=1000
+# MCP_SESSION_TIMEOUT_MS=1800000
+
+# OAuth 2.1 MCP Server Configuration
+# =============================================================================
+# Enforcement Gate (Optional)
+# =============================================================================
+# OAUTH_REQUIRED controls whether authentication is enforced.
+#   - Unset / false (default): auth is NOT enforced. The server runs out-of-the-box
+#     and protected endpoints are reachable without a token. Best for local dev.
+#   - true: auth is enforced (fail-closed). If neither JWKS_URI nor
+#     INTROSPECTION_ENDPOINT is configured, the server STILL starts and logs a
+#     clear warning, but rejects all protected requests until a verifier is set.
+# Set this to true (and configure a verifier below) before deploying.
+# =============================================================================
+# OAUTH_REQUIRED=true
+
+# =============================================================================
+# REQUIRED: Server Configuration
+# =============================================================================
+# Your Auth0 API Identifier (from APIs → MCP Server → Identifier)
+# This MUST match exactly what you set when creating the API
+RESOURCE_URI=https://mcplocal
+
+# Your Auth0 tenant domain (authorization server URL)
+AUTH_SERVER_URL=https://dev-5dt0utuk315713tjm.us.auth0.com
+
+# Cryptographic JWKS Signature Verification (Recommended)
+# =============================================================================
+# If configured, the SDK cryptographically verifies token signatures using JWKS keys.
+# Token validation is SECURE BY DEFAULT (fail-closed): if neither JWKS_URI nor an
+# introspection endpoint (below) is configured, ALL tokens are rejected. Configure
+# one of them for a working server.
+# NOTE: Unsigned/signature-less token decoding is disabled by default and is only
+# available via the in-code `allowInsecureTokenDecode: true` option in
+# OAuthModule.forRoot(...) — intended for local development only, never production.
+# =============================================================================
+# JWKS_URI=https://dev-5dt0utuk315713tjm.us.auth0.com/.well-known/jwks.json
+
+# Expected token validation audience (should match RESOURCE_URI)
+TOKEN_AUDIENCE=https://mcplocal
+
+# Expected token validation issuer (your authorization server tenant domain)
+TOKEN_ISSUER=https://dev-5dt0utuk315713tjm.us.auth0.com
+
+# Token Introspection Configuration (Alternative to JWKS signature verification)
+# =============================================================================
+# INTROSPECTION_ENDPOINT=https://dev-5dt0utuk315713tjm.us.auth0.com/oauth/introspect
+# INTROSPECTION_CLIENT_ID=your-introspection-client-id
+# INTROSPECTION_CLIENT_SECRET=your-introspection-client-secret
+
+# OAuth Discovery Settings (Optional)
+# =============================================================================
+# OAUTH_DISCOVERY_PORT=3005
+# OAUTH_DISCOVERY_AUTO_RETRY=true
+# MCP_SERVER_PORT=3000
+
+# Dynamic Client Registration (Optional / disabled by default)
+# =============================================================================
+# Set to 'true' to expose the /oauth/v2/register endpoint. It only serves the
+# statically configured client below; without OAUTH_CLIENT_ID it stays disabled.
+# =============================================================================
+# OAUTH_ENABLE_CLIENT_REGISTRATION=true
+# OAUTH_CLIENT_ID=your-client-id
+# OAUTH_CLIENT_SECRET=your-client-secret
+
+# Duffel API Integration (Required for Flight Search & Booking)
+# =============================================================================
+DUFFEL_API_KEY=your-duffel-api-key

--- a/sample-apps/concord-governance-agent/.gemini/skills/auth-security/SKILL.md
+++ b/sample-apps/concord-governance-agent/.gemini/skills/auth-security/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: nitrostack-auth-security
+description: Best practices for implementing JWT, API Keys, OAuth 2.1, and RBAC in a NitroStack application.
+---
+
+## When to Use
+Use this skill when configuring security modules, implementing user authentication, restricting tool access via guards, or handling sensitive tokens.
+
+---
+
+## 1. JSON Web Tokens (JWT)
+To secure tools with JWT authentication:
+
+### Register `JWTModule`:
+```typescript
+import { JWTModule, Module, McpApp } from '@nitrostack/core';
+
+@McpApp({
+  server: { name: 'my-server', version: '1.0.0' }
+})
+@Module({
+  imports: [
+    JWTModule.forRoot({
+      secret: process.env.JWT_SECRET!,
+      expiresIn: '7d',
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### Write a `JWTGuard`:
+```typescript
+import { Guard, ExecutionContext, Injectable, ConfigService } from '@nitrostack/core';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class JWTGuard implements Guard {
+  constructor(private config: ConfigService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const token = this.extractToken(context);
+    if (!token) return false;
+
+    try {
+      const secret = this.config.get('JWT_SECRET');
+      const payload = jwt.verify(token, secret) as any;
+      context.auth = {
+        subject: payload.sub,
+        role: payload.role,
+        token,
+      };
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private extractToken(context: ExecutionContext): string | null {
+    const auth = context.metadata?.authorization;
+    if (auth?.startsWith('Bearer ')) {
+      return auth.substring(7);
+    }
+    return null;
+  }
+}
+```
+
+---
+
+## 2. API Key Authentication
+Use `ApiKeyModule` for service-to-service validation.
+
+### Register `ApiKeyModule`:
+```typescript
+import { ApiKeyModule, Module } from '@nitrostack/core';
+
+@Module({
+  imports: [
+    ApiKeyModule.forRoot({
+      keysEnvPrefix: 'API_KEY', // Reads API_KEY_1, API_KEY_2, etc.
+      headerName: 'x-api-key',
+      hashed: false,
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### API Key Guard:
+```typescript
+import { Guard, ExecutionContext, ApiKeyModule } from '@nitrostack/core';
+
+export class ApiKeyGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const apiKey = context.metadata?.['x-api-key'] || context.metadata?.apiKey;
+    if (!apiKey) return false;
+
+    const isValid = await ApiKeyModule.validate(apiKey as string);
+    if (isValid) {
+      context.auth = {
+        subject: `apikey_${(apiKey as string).substring(0, 10)}`,
+        scopes: ['*'],
+      };
+      return true;
+    }
+    return false;
+  }
+}
+```
+
+---
+
+## 3. Role-Based Access Control (RBAC)
+Chain guards sequentially to implement user-role authorization.
+
+```typescript
+import { Injectable, Guard, ExecutionContext, UseGuards, Tool, z } from '@nitrostack/core';
+import { JWTGuard } from './jwt.guard.js';
+
+@Injectable()
+export class AdminGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Requires JWTGuard to have populated context.auth first
+    return context.auth?.role === 'admin';
+  }
+}
+
+// Applying chained guards to a tool
+export class SystemTools {
+  @Tool({
+    name: 'reset_database',
+    description: 'Dangerous action: wipes database. Admin only.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(JWTGuard, AdminGuard) // Chain auth first, then role check
+  async resetDatabase() {
+    return { success: true };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.gemini/skills/mcp-app-architecture/SKILL.md
+++ b/sample-apps/concord-governance-agent/.gemini/skills/mcp-app-architecture/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: nitrostack-mcp-app-architecture
+description: Best practices and guidelines for bootstrapping, defining modules, using dependency injection, managing server lifecycles, and handling events in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill whenever you are bootstrapping a new NitroStack MCP server, creating modules, injecting services, or handling application lifecycle events.
+
+## Bootstrapping a NitroStack App
+A NitroStack application is initialized with the `@McpApp` decorator on a root class, accompanied by a root `@Module`.
+
+```typescript
+import { McpApp, Module } from '@nitrostack/core';
+import { DatabaseModule } from './database/database.module.js';
+import { UsersModule } from './users/users.module.js';
+
+@McpApp({
+  module: AppModule,
+  server: {
+    name: 'user-management-server',
+    version: '1.0.0',
+  },
+})
+@Module({
+  imports: [DatabaseModule, UsersModule],
+})
+export class AppModule {}
+```
+
+## Modules
+Modules organize your application structure. Use the `@Module` decorator to define imports, exports, and providers.
+
+* **`imports`**: Other modules whose exported providers should be available in this module.
+* **`providers`**: Services, tools, resources, or prompts that should be instantiated and managed by the DI container within this module.
+* **`exports`**: Providers defined in this module that should be visible to other modules importing this one.
+
+```typescript
+import { Module } from '@nitrostack/core';
+import { UsersService } from './users.service.js';
+import { UsersTools } from './users.tools.js';
+
+@Module({
+  providers: [UsersService, UsersTools],
+  exports: [UsersService],
+})
+
+## Controllers
+Use the `@ControllerDecorator` (or alias it as `@Controller`) to group tools, resources, and prompts together. Controllers are automatically registered as singletons in the DI container.
+
+### Key Controller Options:
+* **`prefix`**: A string prefix applied to every `@Tool` defined in this controller. For example, `@ControllerDecorator('github')` prefixing a tool named `create_issue` exposes it to MCP clients as `github_create_issue`.
+
+```typescript
+import { ControllerDecorator as Controller, Tool, ExecutionContext } from '@nitrostack/core';
+
+@Controller('github')
+export class GitHubController {
+  @Tool({
+    name: 'create_issue',
+    description: 'Create an issue in a repository',
+    inputSchema: z.object({ /* ... */ })
+  })
+  async createIssue(input: any, ctx: ExecutionContext) {
+    // Exposed to clients as "github_create_issue"
+  }
+}
+```
+
+## Dependency Injection (DI)
+NitroStack uses a robust dependency injection container to manage class instances and lifecycles.
+
+### Injection Lifecycles
+1. **Singleton (Default)**: A single instance is shared across the entire application.
+2. **Transient**: A new instance is created every time it is resolved/injected.
+3. **Scoped**: A new instance is created per incoming request or context.
+
+```typescript
+import { Injectable, Scope } from '@nitrostack/core';
+
+@Injectable({ scope: Scope.SINGLETON })
+export class UsersService {
+  constructor(private readonly db: DatabaseService) {}
+  
+  async getUser(id: string) {
+    return this.db.query('SELECT * FROM users WHERE id = $1', [id]);
+  }
+}
+```
+
+## Lifecycles and Hooks
+Implement NestJS-style lifecycle interfaces on modules, controllers, or providers to hook into application state changes:
+
+* **`OnModuleInit`** (`onModuleInit`): Called after modules have initialized but before the server starts listening.
+* **`OnApplicationBootstrap`** (`onApplicationBootstrap`): Called once the server is fully started and listening.
+* **`OnModuleDestroy`** (`onModuleDestroy`): Called when the module or application is shutting down.
+* **`BeforeApplicationShutdown`** (`beforeApplicationShutdown(signal?: string)`): Called before the application starts shutting down. Receives the OS signal (e.g. `SIGINT`).
+* **`OnApplicationShutdown`** (`onApplicationShutdown(signal?: string)`): Called during shutdown. Receives the OS signal.
+
+```typescript
+import { 
+  Injectable, 
+  OnModuleInit, 
+  OnApplicationBootstrap,
+  OnModuleDestroy, 
+  BeforeApplicationShutdown,
+  OnApplicationShutdown 
+} from '@nitrostack/core';
+
+@Injectable()
+export class DatabaseService 
+  implements OnModuleInit, OnApplicationBootstrap, OnModuleDestroy, BeforeApplicationShutdown, OnApplicationShutdown 
+{
+  async onModuleInit() {
+    await this.connect();
+  }
+
+  async onApplicationBootstrap() {
+    console.log('App ready to handle connections.');
+  }
+
+  async onModuleDestroy() {
+    await this.cleanupPendingQueries();
+  }
+
+  async beforeApplicationShutdown(signal?: string) {
+    console.log(`Shutting down soon (signal: ${signal}).`);
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    await this.disconnect();
+  }
+}
+```
+
+---
+
+## Eventing System (`emitEvent` and `@OnEvent`)
+NitroStack includes an internal eventing system to decouple components. A service or tool can emit an event using `emitEvent`, and any injectable class (like a handler service or controller) can subscribe using the `@OnEvent` decorator.
+
+### 1. Emitting Events
+Call `emitEvent` to dispatch an event payload asynchronously.
+
+```typescript
+import { Injectable, emitEvent } from '@nitrostack/core';
+
+@Injectable()
+export class SpaceShipService {
+  async launchShip(shipId: string) {
+    // Process launch...
+    
+    // Dispatch event
+    emitEvent('ship.launched', {
+      shipId,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+```
+
+### 2. Listening to Events
+Decorate a method inside any `@Injectable()` class with `@OnEvent('event_pattern')` to register it as an event handler.
+
+```typescript
+import { Injectable, OnEvent } from '@nitrostack/core';
+
+@Injectable({ deps: [] })
+export class FlightLogHandler {
+  @OnEvent('ship.launched')
+  async logLaunch(data: { shipId: string; timestamp: string }) {
+    console.error(`🚀 [EVENT] Ship ${data.shipId} was successfully launched at ${data.timestamp}`);
+  }
+}
+```
+
+> [!NOTE]
+> For the `@OnEvent` decorator to register properly, the containing class must be declared as a provider inside an active module.

--- a/sample-apps/concord-governance-agent/.gemini/skills/middleware-pipeline/SKILL.md
+++ b/sample-apps/concord-governance-agent/.gemini/skills/middleware-pipeline/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: nitrostack-middleware-pipeline
+description: Best practices for implementing and applying Guards, Interceptors, Middleware, Pipes, and Exception Filters in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill when implementing request validation, authorization checks, response mapping, logging, error handling, or performance tracking on NitroStack tool methods.
+
+---
+
+## 1. Guards (`Guard` and `@UseGuards`)
+Guards determine if a request should be processed by a tool handler based on authentication, authorization, or other conditions.
+
+### Interface:
+```typescript
+import { Guard, ExecutionContext } from '@nitrostack/core';
+
+export interface Guard {
+  canActivate(context: ExecutionContext): boolean | Promise<boolean>;
+}
+```
+
+### Example:
+```typescript
+import { Guard, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class RolesGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const userRoles = context.clientMetadata?.roles || [];
+    return userRoles.includes('admin');
+  }
+}
+```
+
+Apply the guard using `@UseGuards(...)`:
+```typescript
+import { Tool, UseGuards, z } from '@nitrostack/core';
+import { RolesGuard } from './roles.guard.js';
+
+export class AdminTools {
+  @Tool({
+    name: 'delete_system_logs',
+    description: 'Delete all system logs from the server.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(RolesGuard)
+  async deleteLogs() {
+    return { success: true };
+  }
+}
+```
+
+---
+
+## 2. Interceptors (`InterceptorInterface` and `@UseInterceptors`)
+Interceptors can transform/intercept input arguments or mapped output from a tool method execution.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface InterceptorInterface {
+  intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { InterceptorInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class TimingInterceptor implements InterceptorInterface {
+  async intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    const start = Date.now();
+    const result = await next();
+    const duration = Date.now() - start;
+    context.logger.info(`Execution took ${duration}ms`);
+    return {
+      ...result,
+      _meta: { durationMs: duration }
+    };
+  }
+}
+```
+
+---
+
+## 3. Exception Filters (`ExceptionFilterInterface` and `@UseFilters`)
+Exception filters catch any errors thrown within guards, interceptors, or the tool handlers themselves, mapping them into user-friendly JSON payloads.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext): unknown | Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { ExceptionFilterInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class CustomExceptionFilter implements ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext) {
+    const message = exception instanceof Error ? exception.message : 'Unknown error';
+    return {
+      error: true,
+      message,
+      timestamp: new Date().toISOString()
+    };
+  }
+}
+```
+
+Apply the filter using `@UseFilters(...)` on a tool method:
+
+```typescript
+import { Tool, UseFilters, z } from '@nitrostack/core';
+import { CustomExceptionFilter } from './custom-exception.filter.js';
+
+export class LoggingTools {
+  @Tool({
+    name: 'generate_report',
+    description: 'Generates system usage reports.',
+    inputSchema: z.object({}),
+  })
+  @UseFilters(CustomExceptionFilter)
+  async generateReport() {
+    throw new Error('Report generation is not implemented yet.');
+  }
+}
+```
+
+---
+
+## 4. Middleware (`MiddlewareInterface`, `@Middleware` and `@UseMiddleware`)
+Middleware executes before the request reaches the tool handler, and can wrap the handler execution by invoking `next()`.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface MiddlewareInterface {
+  use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { Middleware, MiddlewareInterface, ExecutionContext } from '@nitrostack/core';
+
+@Middleware()
+export class LoggingMiddleware implements MiddlewareInterface {
+  async use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    context.logger.info(`Entering tool: ${context.toolName}`);
+    try {
+      const result = await next();
+      context.logger.info(`Exiting tool: ${context.toolName}`);
+      return result;
+    } catch (error) {
+      context.logger.error(`Error in tool: ${error}`);
+      throw error;
+    }
+  }
+}
+```
+
+Apply the middleware using `@UseMiddleware(...)` on a tool method:
+```typescript
+import { Tool, UseMiddleware, z } from '@nitrostack/core';
+import { LoggingMiddleware } from './logging.middleware.js';
+
+export class StationTools {
+  @Tool({
+    name: 'fetch_logs',
+    description: 'Fetch station operations logs.',
+    inputSchema: z.object({}),
+  })
+  @UseMiddleware(LoggingMiddleware)
+  async fetchLogs() {
+    return { status: 'operational' };
+  }
+}
+```
+
+---
+
+## 5. Pipes (`PipeInterface`, `@Pipe` and `@UsePipes`)
+Pipes are used to transform or validate input arguments before they reach the tool handler method.
+
+### Interface:
+```typescript
+import { ArgumentMetadata } from '@nitrostack/core';
+
+export interface PipeInterface<T = unknown, R = unknown> {
+  transform(value: T, metadata: ArgumentMetadata): R | Promise<R>;
+}
+```
+
+### Example:
+```typescript
+import { Pipe, PipeInterface, ArgumentMetadata } from '@nitrostack/core';
+
+@Pipe()
+export class TrimPipe implements PipeInterface<Record<string, unknown>, Record<string, unknown>> {
+  transform(value: Record<string, unknown>, metadata: ArgumentMetadata) {
+    const trimmed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      trimmed[key] = typeof val === 'string' ? val.trim() : val;
+    }
+    return trimmed;
+  }
+}
+```
+
+Apply the pipe using `@UsePipes(...)` on a tool method:
+```typescript
+import { Tool, UsePipes, z } from '@nitrostack/core';
+import { TrimPipe } from './trim.pipe.js';
+
+export class MessagingTools {
+  @Tool({
+    name: 'send_message',
+    description: 'Send a message to other stations.',
+    inputSchema: z.object({ text: z.string() }),
+  })
+  @UsePipes(TrimPipe)
+  async sendMessage(input: { text: string }) {
+    return { sentText: input.text };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.gemini/skills/tools-resources-prompts/SKILL.md
+++ b/sample-apps/concord-governance-agent/.gemini/skills/tools-resources-prompts/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: nitrostack-tools-resources-prompts
+description: Guidelines and patterns for defining Tools, Resources, and Prompts in a NitroStack application with schema validation via Zod, including caching, rate-limiting, and base64 file uploads.
+---
+
+## When to Use
+Use this skill whenever you are defining, editing, or validating tools, resources, or prompts on a NitroStack MCP server.
+
+## Defining Tools with `@Tool`
+An MCP tool exposes a function that an AI client can invoke. Decorate a service or controller method with `@Tool`.
+
+### Key Tool Options:
+* `name`: Kebab-case or snake_case unique identifier.
+* `description`: Detailed description explaining when and how the client should use it.
+* `inputSchema`: A Zod object schema for strict validation of inputs.
+* `outputSchema` (optional): Zod schema validating the output structure.
+
+```typescript
+import { ToolDecorator as Tool, ControllerDecorator as Controller, InitialTool, z, ExecutionContext } from '@nitrostack/core';
+
+@Controller('weather')
+export class WeatherService {
+  @Tool({
+    name: 'get_current_weather',
+    description: 'Get the current weather forecast for a specific city.',
+    inputSchema: z.object({
+      city: z.string().describe('The name of the city, e.g., San Francisco'),
+      unit: z.enum(['celsius', 'fahrenheit']).default('celsius'),
+    }),
+  })
+  @InitialTool() // Auto-invoked when the AI client initializes/starts
+  async getWeather(
+    input: { city: string; unit: 'celsius' | 'fahrenheit' },
+    ctx: ExecutionContext
+  ) {
+    ctx.logger.info(`Fetching weather for ${input.city}`);
+    // implementation
+    return {
+      city: input.city,
+      temp: 22,
+      condition: 'Sunny',
+    };
+  }
+}
+```
+
+## Defining Resources with `@Resource`
+An MCP resource exposes static or dynamic data files/URIs that the AI client can read.
+
+### Key Resource Options:
+* `uri`: URI pattern (e.g., `git://{owner}/{repo}/file` or static `app://config`).
+* `name`: Unique name of the resource.
+* `description`: Explanation of what data this resource provides.
+* `mimeType`: Mime type of the response (e.g., `text/plain`, `application/json`).
+
+```typescript
+import { Resource, ExecutionContext } from '@nitrostack/core';
+
+export class ConfigResources {
+  @Resource({
+    uri: 'app://settings',
+    name: 'Application Settings',
+    description: 'System-wide configuration settings and parameters.',
+    mimeType: 'application/json',
+  })
+  async getSettings(ctx: ExecutionContext) {
+    return {
+      environment: 'development',
+      debugMode: true,
+    };
+  }
+}
+```
+
+## Defining Prompts with `@Prompt`
+An MCP prompt exposes reusable templates or instruction sets that guide LLMs.
+
+### Key Prompt Options:
+* `name`: Name of the prompt.
+* `description`: Describes what task this prompt helps accomplish.
+* `arguments`: Declares parameters the client can supply to customize the prompt template.
+
+```typescript
+import { Prompt, ExecutionContext } from '@nitrostack/core';
+
+export class PromptTemplates {
+  @Prompt({
+    name: 'code_review',
+    description: 'Provide an intensive code review for a given code snippet.',
+    arguments: [
+      { name: 'language', description: 'The programming language, e.g., TypeScript', required: true },
+      { name: 'code', description: 'The code snippet to review', required: true },
+    ],
+  })
+  async getCodeReviewPrompt(
+    args: { language: string; code: string },
+    ctx: ExecutionContext
+  ) {
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: `You are an expert software engineer. Review this ${args.language} code:\n\n${args.code}`,
+        },
+      ],
+    };
+  }
+}
+```
+
+---
+
+## Tool Policies: Caching (`@Cache`) and Rate Limiting (`@RateLimit`)
+You can control tool execution behaviors (such as performance optimization and throttling) using method decorators.
+
+### 1. Caching with `@Cache`
+Use `@Cache` to cache tool execution outputs for a specified duration (TTL in seconds). This reduces database or API overhead for frequent identical requests.
+
+#### Options:
+* `ttl`: Cache time-to-live in seconds (required).
+* `key` (optional): Custom function `(input: any, context?: any) => string` that returns a unique cache key based on inputs. If not defined, a key is auto-generated from serialized input arguments.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, Cache, z } from '@nitrostack/core';
+
+export class StationTools {
+  @Tool({
+    name: 'get_system_status',
+    description: 'Fetch real-time station metrics. Response is cached.',
+    inputSchema: z.object({}),
+  })
+  @Cache({ ttl: 60 }) // Caches status for 60 seconds
+  async getSystemStatus() {
+    return { temperature: 21.5, oxygen: 0.98 };
+  }
+
+  @Tool({
+    name: 'get_crew_status',
+    description: 'Fetch status of a crew member. Cached by crew ID.',
+    inputSchema: z.object({ id: z.string() }),
+  })
+  @Cache({
+    ttl: 300,
+    key: (input) => `crew:status:${input.id}`
+  })
+  async getCrewStatus(input: { id: string }) {
+    // ...
+  }
+}
+```
+
+### 2. Rate Limiting with `@RateLimit`
+Use `@RateLimit` to restrict the number of tool invocations within a specified time window to prevent client abuse.
+
+#### Options:
+* `requests`: Number of allowed requests in the window (required).
+* `window`: Throttling duration window (required). Supports formats like `'1s'`, `'1m'`, `'1h'`.
+* `key` (optional): Custom function `(context: ExecutionContext) => string` to group rate limits. Useful for rate-limiting per user role or API key.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, RateLimit, z, ExecutionContext } from '@nitrostack/core';
+
+export class DiagnosticTools {
+  @Tool({
+    name: 'run_deep_diagnostic',
+    description: 'Run intensive diagnostics. Rate limited.',
+    inputSchema: z.object({}),
+  })
+  @RateLimit({ requests: 3, window: '1m' }) // Max 3 requests per minute globally
+  async runDeepDiagnostic() {
+    return { diagnosticReport: 'All systems operational.' };
+  }
+
+  @Tool({
+    name: 'request_supply_drop',
+    description: 'Request inventory supplies. Rate limited per user.',
+    inputSchema: z.object({ item: z.string() }),
+  })
+  @RateLimit({
+    requests: 5,
+    window: '1h',
+    key: (ctx: ExecutionContext) => ctx.auth?.subject || 'anonymous'
+  })
+  async requestSupply(input: { item: string }, ctx: ExecutionContext) {
+    // ...
+  }
+}
+```
+
+---
+
+## Handling File Uploads in Tools
+NitroStack supports file uploads from MCP clients (like NitroStudio) by passing the file as a base64-encoded string inside a tool's input parameters.
+
+### 1. Declaring Input Schema for File Uploads
+To accept an uploaded file, define three Zod fields in your tool's `inputSchema`:
+* `file_name`: The name of the file (e.g. `report.csv`).
+* `file_type`: The MIME type (e.g. `text/csv`).
+* `file_content`: The base64-encoded string containing the file data.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+
+export class FileTools {
+  @Tool({
+    name: 'upload_document',
+    description: 'Upload a text document or image.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async uploadDocument(input: any, ctx: ExecutionContext) {
+    // Processing logic
+  }
+}
+```
+
+### 2. Decoding Base64 Payloads
+File uploads can arrive in two formats depending on the client:
+1. **Data URL format**: `data:image/png;base64,iVBORw0KGgo...`
+2. **Raw Base64 format**: `iVBORw0KGgo...`
+
+Use the following universal decoder pattern to parse either format into a Node `Buffer`:
+
+```typescript
+import * as fs from 'fs';
+import * as path from 'path';
+
+function decodeBase64File(content: string): Buffer {
+  const matches = content.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/);
+  
+  if (matches && matches.length === 3) {
+    // Data URL format - decode matches[2]
+    return Buffer.from(matches[2], 'base64');
+  } else {
+    // Raw base64 format - decode input directly
+    return Buffer.from(content, 'base64');
+  }
+}
+```
+
+### 3. Secure File Saving Example
+Always validate the directory paths to prevent directory traversal attacks when saving files to disk.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads');
+
+export class SecureUploadTools {
+  @Tool({
+    name: 'save_uploaded_file',
+    description: 'Decodes and saves an uploaded file securely.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async saveFile(input: any, ctx: ExecutionContext) {
+    // Ensure uploads directory exists
+    if (!fs.existsSync(UPLOAD_DIR)) {
+      fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+    }
+
+    // Secure destination path to prevent path traversal
+    const safeName = path.basename(input.file_name);
+    const filePath = path.join(UPLOAD_DIR, safeName);
+    if (!filePath.startsWith(UPLOAD_DIR)) {
+      throw new Error('Invalid file path detected (path traversal).');
+    }
+
+    // Decode and write to disk
+    const buffer = decodeBase64File(input.file_content);
+    fs.writeFileSync(filePath, buffer);
+
+    ctx.logger.info(`Successfully saved file: ${safeName}`);
+    return { success: true, path: filePath };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.gemini/skills/ui-widgets/SKILL.md
+++ b/sample-apps/concord-governance-agent/.gemini/skills/ui-widgets/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: nitrostack-ui-widgets
+description: Best practices for linking tools to interactive frontend widgets using @Widget and @nitrostack/widgets SDK (including state sync, tool calling, display modes, media queries, and chat actions).
+---
+
+## When to Use
+Use this skill when designing, building, or modifying interactive user interface widgets that display custom React content inside AI clients or NitroStudio.
+
+---
+
+## 1. Backend Definition (`@Widget`)
+To display a React-based widget for a tool's output, decorate the tool method with `@Widget`.
+
+### Options:
+* **String Route**: A simple string representing the route identifier in the frontend React app (e.g. `'product-card'`).
+* **Object Route**: Object including:
+  * `route` (required): The route path.
+  * `domain` (optional): Allowed sandbox domain.
+  * `csp` (optional): Content Security Policy guidelines.
+
+### Example:
+```typescript
+import { Tool, Widget, z } from '@nitrostack/core';
+
+export class CatalogTools {
+  @Tool({
+    name: 'fetch_product',
+    description: 'Get product information by barcode.',
+    inputSchema: z.object({ barcode: z.string() }),
+  })
+  @Widget('product-details') // Maps to the "product-details" frontend component
+  async fetchProduct(input: { barcode: string }) {
+    return {
+      name: 'Super Nitro Energy Drink',
+      price: 2.99,
+      sku: input.barcode,
+    };
+  }
+}
+```
+
+---
+
+## 2. Frontend React Widget (`@nitrostack/widgets`)
+In your React widget frontend application (typically a Next.js client component), use the `useWidgetSDK` hook to receive input data from the client host.
+
+### React Component Example:
+```tsx
+'use client';
+
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+interface ProductData {
+  name: string;
+  price: number;
+  sku: string;
+}
+
+export default function ProductDetailsWidget() {
+  const { isReady, getToolOutput, theme } = useWidgetSDK();
+  const data = getToolOutput<ProductData>();
+
+  if (!isReady) {
+    return <div className="loading">Connecting to host...</div>;
+  }
+
+  if (!data) {
+    return <div className="error">No product data received.</div>;
+  }
+
+  return (
+    <div className={`product-card ${theme === 'dark' ? 'dark' : 'light'}`}>
+      <h3>{data.name}</h3>
+      <p className="price">${data.price.toFixed(2)}</p>
+      <span className="sku">SKU: {data.sku}</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 3. State Management & Synchronization (`useWidgetState`)
+Use `useWidgetState` to manage and persist client-side widget state (e.g. selected tabs, filter values, input states). This state automatically synchronizes with the host application context, persisting it across page re-renders.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetState } from '@nitrostack/widgets';
+
+export default function StationPanelWidget() {
+  const [state, setState] = useWidgetState(() => ({
+    selectedTab: 'overview',
+    showExtendedInfo: false,
+  }));
+
+  return (
+    <div>
+      <button onClick={() => setState({ ...state, selectedTab: 'alerts' })}>
+        View Alerts
+      </button>
+      <p>Current Tab: {state?.selectedTab}</p>
+    </div>
+  );
+}
+```
+
+---
+
+## 4. Calling Core Tools from Widgets (`callTool`)
+You can invoke other backend MCP tools directly from the frontend widget using `callTool`. This is useful for tool chaining or triggering detailed audits.
+
+### Example:
+```tsx
+import React, { useState } from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function SystemDiagnostics() {
+  const { callTool, isReady } = useWidgetSDK();
+  const [isRunning, setIsRunning] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+
+  const runDiagnostic = async () => {
+    if (!isReady) return;
+    setIsRunning(true);
+    try {
+      const response = await callTool('run_diagnostic', { system: 'oxygen_scrubber' });
+      setResult(response.result as string);
+    } catch (err) {
+      setResult('Diagnostic execution failed.');
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <button onClick={runDiagnostic} disabled={isRunning}>
+      {isRunning ? 'Running...' : 'Run Diagnostics'}
+    </button>
+  );
+}
+```
+
+---
+
+## 5. Layout & Display Controls
+Widgets can dynamically request size mode changes (fullscreen, inline, picture-in-picture) and adapt layouts to safe areas (dynamic islands/notches) or maximum height constraints.
+
+### Key Methods:
+* `requestFullscreen()`: Switch host widget display to fullscreen.
+* `requestInline()`: Switch host widget display back to inline.
+* `requestPip()`: Float widget in Picture-in-Picture.
+* `requestClose()`: Dismiss the widget completely.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function StatusBoard() {
+  const { 
+    requestFullscreen, 
+    requestInline, 
+    requestClose,
+    displayMode,   // Reactive property ('fullscreen' | 'inline' | 'pip')
+    maxHeight,     // Reactive maxHeight constraint (in pixels)
+    getSafeArea    // Insets data: { top, right, bottom, left }
+  } = useWidgetSDK();
+
+  const safeArea = getSafeArea() || { top: 0, bottom: 0 };
+
+  return (
+    <div style={{ maxHeight: maxHeight || 400, paddingTop: safeArea.top }}>
+      <h3>Mode: {displayMode}</h3>
+      <button onClick={requestFullscreen}>Fullscreen</button>
+      <button onClick={requestInline}>Collapse</button>
+      <button onClick={requestClose}>Dismiss Widget</button>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. Chat Navigation & Actions
+Widgets can interact with the host chat pane using external browser links and follow-up prompts.
+
+### Key Methods:
+* `openExternal(url)`: Open the target URL safely in the user's primary external browser.
+* `sendFollowUpMessage(prompt)`: Insert a message into the chat flow, automatically submitting it to the LLM agent.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function MissionControl() {
+  const { openExternal, sendFollowUpMessage } = useWidgetSDK();
+
+  return (
+    <div>
+      {/* Open external documentation */}
+      <button onClick={() => openExternal('https://docs.nitrostack.dev')}>
+        Open Manual
+      </button>
+
+      {/* Ask LLM agent directly from the widget */}
+      <button onClick={() => sendFollowUpMessage('Analyze mission failures from last week')}>
+        Ask Agent to Analyze
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 7. Media & Accessibility Queries
+The SDK provides helper utilities to query target client capabilities for styling or accessibility.
+
+### Key Utilities:
+* `prefersReducedMotion()`: Returns `true` if client settings specify reduced motion. Disable animations.
+* `isPrimarilyTouchDevice()`: Returns `true` if the device has a coarse pointer (e.g. touch/mobile). Increase button target sizes.
+* `isHoverAvailable()`: Returns `true` if pointer supports hover states.
+* `prefersDarkColorScheme()`: Returns `true` if the system theme is dark.
+
+### Example:
+```tsx
+import React from 'react';
+import { isPrimarilyTouchDevice, prefersReducedMotion } from '@nitrostack/widgets';
+
+export default function AccessiblePanel() {
+  const isTouch = isPrimarilyTouchDevice();
+  const reducedMotion = prefersReducedMotion();
+
+  return (
+    <div className={reducedMotion ? 'no-animations' : 'smooth-transitions'}>
+      <button style={{ padding: isTouch ? '16px' : '8px' }}>
+        Interactive Button
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 8. Testing Widgets
+* Open your project in **NitroStudio** for visual preview.
+* Invoke the tool from the AI chat or testing pane to verify the widget updates instantly with the returned JSON structure.

--- a/sample-apps/concord-governance-agent/.gitignore
+++ b/sample-apps/concord-governance-agent/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+dist/
+.env
+.env.local
+!.env.example
+*.log
+audit-chain.jsonl
+.nitrostudio/
+src/widgets/.next/
+src/widgets/out/
+src/widgets/node_modules/

--- a/sample-apps/concord-governance-agent/.opencode/skills/auth-security/SKILL.md
+++ b/sample-apps/concord-governance-agent/.opencode/skills/auth-security/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: nitrostack-auth-security
+description: Best practices for implementing JWT, API Keys, OAuth 2.1, and RBAC in a NitroStack application.
+---
+
+## When to Use
+Use this skill when configuring security modules, implementing user authentication, restricting tool access via guards, or handling sensitive tokens.
+
+---
+
+## 1. JSON Web Tokens (JWT)
+To secure tools with JWT authentication:
+
+### Register `JWTModule`:
+```typescript
+import { JWTModule, Module, McpApp } from '@nitrostack/core';
+
+@McpApp({
+  server: { name: 'my-server', version: '1.0.0' }
+})
+@Module({
+  imports: [
+    JWTModule.forRoot({
+      secret: process.env.JWT_SECRET!,
+      expiresIn: '7d',
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### Write a `JWTGuard`:
+```typescript
+import { Guard, ExecutionContext, Injectable, ConfigService } from '@nitrostack/core';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class JWTGuard implements Guard {
+  constructor(private config: ConfigService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const token = this.extractToken(context);
+    if (!token) return false;
+
+    try {
+      const secret = this.config.get('JWT_SECRET');
+      const payload = jwt.verify(token, secret) as any;
+      context.auth = {
+        subject: payload.sub,
+        role: payload.role,
+        token,
+      };
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private extractToken(context: ExecutionContext): string | null {
+    const auth = context.metadata?.authorization;
+    if (auth?.startsWith('Bearer ')) {
+      return auth.substring(7);
+    }
+    return null;
+  }
+}
+```
+
+---
+
+## 2. API Key Authentication
+Use `ApiKeyModule` for service-to-service validation.
+
+### Register `ApiKeyModule`:
+```typescript
+import { ApiKeyModule, Module } from '@nitrostack/core';
+
+@Module({
+  imports: [
+    ApiKeyModule.forRoot({
+      keysEnvPrefix: 'API_KEY', // Reads API_KEY_1, API_KEY_2, etc.
+      headerName: 'x-api-key',
+      hashed: false,
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### API Key Guard:
+```typescript
+import { Guard, ExecutionContext, ApiKeyModule } from '@nitrostack/core';
+
+export class ApiKeyGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const apiKey = context.metadata?.['x-api-key'] || context.metadata?.apiKey;
+    if (!apiKey) return false;
+
+    const isValid = await ApiKeyModule.validate(apiKey as string);
+    if (isValid) {
+      context.auth = {
+        subject: `apikey_${(apiKey as string).substring(0, 10)}`,
+        scopes: ['*'],
+      };
+      return true;
+    }
+    return false;
+  }
+}
+```
+
+---
+
+## 3. Role-Based Access Control (RBAC)
+Chain guards sequentially to implement user-role authorization.
+
+```typescript
+import { Injectable, Guard, ExecutionContext, UseGuards, Tool, z } from '@nitrostack/core';
+import { JWTGuard } from './jwt.guard.js';
+
+@Injectable()
+export class AdminGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Requires JWTGuard to have populated context.auth first
+    return context.auth?.role === 'admin';
+  }
+}
+
+// Applying chained guards to a tool
+export class SystemTools {
+  @Tool({
+    name: 'reset_database',
+    description: 'Dangerous action: wipes database. Admin only.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(JWTGuard, AdminGuard) // Chain auth first, then role check
+  async resetDatabase() {
+    return { success: true };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.opencode/skills/mcp-app-architecture/SKILL.md
+++ b/sample-apps/concord-governance-agent/.opencode/skills/mcp-app-architecture/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: nitrostack-mcp-app-architecture
+description: Best practices and guidelines for bootstrapping, defining modules, using dependency injection, managing server lifecycles, and handling events in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill whenever you are bootstrapping a new NitroStack MCP server, creating modules, injecting services, or handling application lifecycle events.
+
+## Bootstrapping a NitroStack App
+A NitroStack application is initialized with the `@McpApp` decorator on a root class, accompanied by a root `@Module`.
+
+```typescript
+import { McpApp, Module } from '@nitrostack/core';
+import { DatabaseModule } from './database/database.module.js';
+import { UsersModule } from './users/users.module.js';
+
+@McpApp({
+  module: AppModule,
+  server: {
+    name: 'user-management-server',
+    version: '1.0.0',
+  },
+})
+@Module({
+  imports: [DatabaseModule, UsersModule],
+})
+export class AppModule {}
+```
+
+## Modules
+Modules organize your application structure. Use the `@Module` decorator to define imports, exports, and providers.
+
+* **`imports`**: Other modules whose exported providers should be available in this module.
+* **`providers`**: Services, tools, resources, or prompts that should be instantiated and managed by the DI container within this module.
+* **`exports`**: Providers defined in this module that should be visible to other modules importing this one.
+
+```typescript
+import { Module } from '@nitrostack/core';
+import { UsersService } from './users.service.js';
+import { UsersTools } from './users.tools.js';
+
+@Module({
+  providers: [UsersService, UsersTools],
+  exports: [UsersService],
+})
+
+## Controllers
+Use the `@ControllerDecorator` (or alias it as `@Controller`) to group tools, resources, and prompts together. Controllers are automatically registered as singletons in the DI container.
+
+### Key Controller Options:
+* **`prefix`**: A string prefix applied to every `@Tool` defined in this controller. For example, `@ControllerDecorator('github')` prefixing a tool named `create_issue` exposes it to MCP clients as `github_create_issue`.
+
+```typescript
+import { ControllerDecorator as Controller, Tool, ExecutionContext } from '@nitrostack/core';
+
+@Controller('github')
+export class GitHubController {
+  @Tool({
+    name: 'create_issue',
+    description: 'Create an issue in a repository',
+    inputSchema: z.object({ /* ... */ })
+  })
+  async createIssue(input: any, ctx: ExecutionContext) {
+    // Exposed to clients as "github_create_issue"
+  }
+}
+```
+
+## Dependency Injection (DI)
+NitroStack uses a robust dependency injection container to manage class instances and lifecycles.
+
+### Injection Lifecycles
+1. **Singleton (Default)**: A single instance is shared across the entire application.
+2. **Transient**: A new instance is created every time it is resolved/injected.
+3. **Scoped**: A new instance is created per incoming request or context.
+
+```typescript
+import { Injectable, Scope } from '@nitrostack/core';
+
+@Injectable({ scope: Scope.SINGLETON })
+export class UsersService {
+  constructor(private readonly db: DatabaseService) {}
+  
+  async getUser(id: string) {
+    return this.db.query('SELECT * FROM users WHERE id = $1', [id]);
+  }
+}
+```
+
+## Lifecycles and Hooks
+Implement NestJS-style lifecycle interfaces on modules, controllers, or providers to hook into application state changes:
+
+* **`OnModuleInit`** (`onModuleInit`): Called after modules have initialized but before the server starts listening.
+* **`OnApplicationBootstrap`** (`onApplicationBootstrap`): Called once the server is fully started and listening.
+* **`OnModuleDestroy`** (`onModuleDestroy`): Called when the module or application is shutting down.
+* **`BeforeApplicationShutdown`** (`beforeApplicationShutdown(signal?: string)`): Called before the application starts shutting down. Receives the OS signal (e.g. `SIGINT`).
+* **`OnApplicationShutdown`** (`onApplicationShutdown(signal?: string)`): Called during shutdown. Receives the OS signal.
+
+```typescript
+import { 
+  Injectable, 
+  OnModuleInit, 
+  OnApplicationBootstrap,
+  OnModuleDestroy, 
+  BeforeApplicationShutdown,
+  OnApplicationShutdown 
+} from '@nitrostack/core';
+
+@Injectable()
+export class DatabaseService 
+  implements OnModuleInit, OnApplicationBootstrap, OnModuleDestroy, BeforeApplicationShutdown, OnApplicationShutdown 
+{
+  async onModuleInit() {
+    await this.connect();
+  }
+
+  async onApplicationBootstrap() {
+    console.log('App ready to handle connections.');
+  }
+
+  async onModuleDestroy() {
+    await this.cleanupPendingQueries();
+  }
+
+  async beforeApplicationShutdown(signal?: string) {
+    console.log(`Shutting down soon (signal: ${signal}).`);
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    await this.disconnect();
+  }
+}
+```
+
+---
+
+## Eventing System (`emitEvent` and `@OnEvent`)
+NitroStack includes an internal eventing system to decouple components. A service or tool can emit an event using `emitEvent`, and any injectable class (like a handler service or controller) can subscribe using the `@OnEvent` decorator.
+
+### 1. Emitting Events
+Call `emitEvent` to dispatch an event payload asynchronously.
+
+```typescript
+import { Injectable, emitEvent } from '@nitrostack/core';
+
+@Injectable()
+export class SpaceShipService {
+  async launchShip(shipId: string) {
+    // Process launch...
+    
+    // Dispatch event
+    emitEvent('ship.launched', {
+      shipId,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+```
+
+### 2. Listening to Events
+Decorate a method inside any `@Injectable()` class with `@OnEvent('event_pattern')` to register it as an event handler.
+
+```typescript
+import { Injectable, OnEvent } from '@nitrostack/core';
+
+@Injectable({ deps: [] })
+export class FlightLogHandler {
+  @OnEvent('ship.launched')
+  async logLaunch(data: { shipId: string; timestamp: string }) {
+    console.error(`🚀 [EVENT] Ship ${data.shipId} was successfully launched at ${data.timestamp}`);
+  }
+}
+```
+
+> [!NOTE]
+> For the `@OnEvent` decorator to register properly, the containing class must be declared as a provider inside an active module.

--- a/sample-apps/concord-governance-agent/.opencode/skills/middleware-pipeline/SKILL.md
+++ b/sample-apps/concord-governance-agent/.opencode/skills/middleware-pipeline/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: nitrostack-middleware-pipeline
+description: Best practices for implementing and applying Guards, Interceptors, Middleware, Pipes, and Exception Filters in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill when implementing request validation, authorization checks, response mapping, logging, error handling, or performance tracking on NitroStack tool methods.
+
+---
+
+## 1. Guards (`Guard` and `@UseGuards`)
+Guards determine if a request should be processed by a tool handler based on authentication, authorization, or other conditions.
+
+### Interface:
+```typescript
+import { Guard, ExecutionContext } from '@nitrostack/core';
+
+export interface Guard {
+  canActivate(context: ExecutionContext): boolean | Promise<boolean>;
+}
+```
+
+### Example:
+```typescript
+import { Guard, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class RolesGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const userRoles = context.clientMetadata?.roles || [];
+    return userRoles.includes('admin');
+  }
+}
+```
+
+Apply the guard using `@UseGuards(...)`:
+```typescript
+import { Tool, UseGuards, z } from '@nitrostack/core';
+import { RolesGuard } from './roles.guard.js';
+
+export class AdminTools {
+  @Tool({
+    name: 'delete_system_logs',
+    description: 'Delete all system logs from the server.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(RolesGuard)
+  async deleteLogs() {
+    return { success: true };
+  }
+}
+```
+
+---
+
+## 2. Interceptors (`InterceptorInterface` and `@UseInterceptors`)
+Interceptors can transform/intercept input arguments or mapped output from a tool method execution.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface InterceptorInterface {
+  intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { InterceptorInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class TimingInterceptor implements InterceptorInterface {
+  async intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    const start = Date.now();
+    const result = await next();
+    const duration = Date.now() - start;
+    context.logger.info(`Execution took ${duration}ms`);
+    return {
+      ...result,
+      _meta: { durationMs: duration }
+    };
+  }
+}
+```
+
+---
+
+## 3. Exception Filters (`ExceptionFilterInterface` and `@UseFilters`)
+Exception filters catch any errors thrown within guards, interceptors, or the tool handlers themselves, mapping them into user-friendly JSON payloads.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext): unknown | Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { ExceptionFilterInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class CustomExceptionFilter implements ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext) {
+    const message = exception instanceof Error ? exception.message : 'Unknown error';
+    return {
+      error: true,
+      message,
+      timestamp: new Date().toISOString()
+    };
+  }
+}
+```
+
+Apply the filter using `@UseFilters(...)` on a tool method:
+
+```typescript
+import { Tool, UseFilters, z } from '@nitrostack/core';
+import { CustomExceptionFilter } from './custom-exception.filter.js';
+
+export class LoggingTools {
+  @Tool({
+    name: 'generate_report',
+    description: 'Generates system usage reports.',
+    inputSchema: z.object({}),
+  })
+  @UseFilters(CustomExceptionFilter)
+  async generateReport() {
+    throw new Error('Report generation is not implemented yet.');
+  }
+}
+```
+
+---
+
+## 4. Middleware (`MiddlewareInterface`, `@Middleware` and `@UseMiddleware`)
+Middleware executes before the request reaches the tool handler, and can wrap the handler execution by invoking `next()`.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface MiddlewareInterface {
+  use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { Middleware, MiddlewareInterface, ExecutionContext } from '@nitrostack/core';
+
+@Middleware()
+export class LoggingMiddleware implements MiddlewareInterface {
+  async use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    context.logger.info(`Entering tool: ${context.toolName}`);
+    try {
+      const result = await next();
+      context.logger.info(`Exiting tool: ${context.toolName}`);
+      return result;
+    } catch (error) {
+      context.logger.error(`Error in tool: ${error}`);
+      throw error;
+    }
+  }
+}
+```
+
+Apply the middleware using `@UseMiddleware(...)` on a tool method:
+```typescript
+import { Tool, UseMiddleware, z } from '@nitrostack/core';
+import { LoggingMiddleware } from './logging.middleware.js';
+
+export class StationTools {
+  @Tool({
+    name: 'fetch_logs',
+    description: 'Fetch station operations logs.',
+    inputSchema: z.object({}),
+  })
+  @UseMiddleware(LoggingMiddleware)
+  async fetchLogs() {
+    return { status: 'operational' };
+  }
+}
+```
+
+---
+
+## 5. Pipes (`PipeInterface`, `@Pipe` and `@UsePipes`)
+Pipes are used to transform or validate input arguments before they reach the tool handler method.
+
+### Interface:
+```typescript
+import { ArgumentMetadata } from '@nitrostack/core';
+
+export interface PipeInterface<T = unknown, R = unknown> {
+  transform(value: T, metadata: ArgumentMetadata): R | Promise<R>;
+}
+```
+
+### Example:
+```typescript
+import { Pipe, PipeInterface, ArgumentMetadata } from '@nitrostack/core';
+
+@Pipe()
+export class TrimPipe implements PipeInterface<Record<string, unknown>, Record<string, unknown>> {
+  transform(value: Record<string, unknown>, metadata: ArgumentMetadata) {
+    const trimmed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      trimmed[key] = typeof val === 'string' ? val.trim() : val;
+    }
+    return trimmed;
+  }
+}
+```
+
+Apply the pipe using `@UsePipes(...)` on a tool method:
+```typescript
+import { Tool, UsePipes, z } from '@nitrostack/core';
+import { TrimPipe } from './trim.pipe.js';
+
+export class MessagingTools {
+  @Tool({
+    name: 'send_message',
+    description: 'Send a message to other stations.',
+    inputSchema: z.object({ text: z.string() }),
+  })
+  @UsePipes(TrimPipe)
+  async sendMessage(input: { text: string }) {
+    return { sentText: input.text };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.opencode/skills/tools-resources-prompts/SKILL.md
+++ b/sample-apps/concord-governance-agent/.opencode/skills/tools-resources-prompts/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: nitrostack-tools-resources-prompts
+description: Guidelines and patterns for defining Tools, Resources, and Prompts in a NitroStack application with schema validation via Zod, including caching, rate-limiting, and base64 file uploads.
+---
+
+## When to Use
+Use this skill whenever you are defining, editing, or validating tools, resources, or prompts on a NitroStack MCP server.
+
+## Defining Tools with `@Tool`
+An MCP tool exposes a function that an AI client can invoke. Decorate a service or controller method with `@Tool`.
+
+### Key Tool Options:
+* `name`: Kebab-case or snake_case unique identifier.
+* `description`: Detailed description explaining when and how the client should use it.
+* `inputSchema`: A Zod object schema for strict validation of inputs.
+* `outputSchema` (optional): Zod schema validating the output structure.
+
+```typescript
+import { ToolDecorator as Tool, ControllerDecorator as Controller, InitialTool, z, ExecutionContext } from '@nitrostack/core';
+
+@Controller('weather')
+export class WeatherService {
+  @Tool({
+    name: 'get_current_weather',
+    description: 'Get the current weather forecast for a specific city.',
+    inputSchema: z.object({
+      city: z.string().describe('The name of the city, e.g., San Francisco'),
+      unit: z.enum(['celsius', 'fahrenheit']).default('celsius'),
+    }),
+  })
+  @InitialTool() // Auto-invoked when the AI client initializes/starts
+  async getWeather(
+    input: { city: string; unit: 'celsius' | 'fahrenheit' },
+    ctx: ExecutionContext
+  ) {
+    ctx.logger.info(`Fetching weather for ${input.city}`);
+    // implementation
+    return {
+      city: input.city,
+      temp: 22,
+      condition: 'Sunny',
+    };
+  }
+}
+```
+
+## Defining Resources with `@Resource`
+An MCP resource exposes static or dynamic data files/URIs that the AI client can read.
+
+### Key Resource Options:
+* `uri`: URI pattern (e.g., `git://{owner}/{repo}/file` or static `app://config`).
+* `name`: Unique name of the resource.
+* `description`: Explanation of what data this resource provides.
+* `mimeType`: Mime type of the response (e.g., `text/plain`, `application/json`).
+
+```typescript
+import { Resource, ExecutionContext } from '@nitrostack/core';
+
+export class ConfigResources {
+  @Resource({
+    uri: 'app://settings',
+    name: 'Application Settings',
+    description: 'System-wide configuration settings and parameters.',
+    mimeType: 'application/json',
+  })
+  async getSettings(ctx: ExecutionContext) {
+    return {
+      environment: 'development',
+      debugMode: true,
+    };
+  }
+}
+```
+
+## Defining Prompts with `@Prompt`
+An MCP prompt exposes reusable templates or instruction sets that guide LLMs.
+
+### Key Prompt Options:
+* `name`: Name of the prompt.
+* `description`: Describes what task this prompt helps accomplish.
+* `arguments`: Declares parameters the client can supply to customize the prompt template.
+
+```typescript
+import { Prompt, ExecutionContext } from '@nitrostack/core';
+
+export class PromptTemplates {
+  @Prompt({
+    name: 'code_review',
+    description: 'Provide an intensive code review for a given code snippet.',
+    arguments: [
+      { name: 'language', description: 'The programming language, e.g., TypeScript', required: true },
+      { name: 'code', description: 'The code snippet to review', required: true },
+    ],
+  })
+  async getCodeReviewPrompt(
+    args: { language: string; code: string },
+    ctx: ExecutionContext
+  ) {
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: `You are an expert software engineer. Review this ${args.language} code:\n\n${args.code}`,
+        },
+      ],
+    };
+  }
+}
+```
+
+---
+
+## Tool Policies: Caching (`@Cache`) and Rate Limiting (`@RateLimit`)
+You can control tool execution behaviors (such as performance optimization and throttling) using method decorators.
+
+### 1. Caching with `@Cache`
+Use `@Cache` to cache tool execution outputs for a specified duration (TTL in seconds). This reduces database or API overhead for frequent identical requests.
+
+#### Options:
+* `ttl`: Cache time-to-live in seconds (required).
+* `key` (optional): Custom function `(input: any, context?: any) => string` that returns a unique cache key based on inputs. If not defined, a key is auto-generated from serialized input arguments.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, Cache, z } from '@nitrostack/core';
+
+export class StationTools {
+  @Tool({
+    name: 'get_system_status',
+    description: 'Fetch real-time station metrics. Response is cached.',
+    inputSchema: z.object({}),
+  })
+  @Cache({ ttl: 60 }) // Caches status for 60 seconds
+  async getSystemStatus() {
+    return { temperature: 21.5, oxygen: 0.98 };
+  }
+
+  @Tool({
+    name: 'get_crew_status',
+    description: 'Fetch status of a crew member. Cached by crew ID.',
+    inputSchema: z.object({ id: z.string() }),
+  })
+  @Cache({
+    ttl: 300,
+    key: (input) => `crew:status:${input.id}`
+  })
+  async getCrewStatus(input: { id: string }) {
+    // ...
+  }
+}
+```
+
+### 2. Rate Limiting with `@RateLimit`
+Use `@RateLimit` to restrict the number of tool invocations within a specified time window to prevent client abuse.
+
+#### Options:
+* `requests`: Number of allowed requests in the window (required).
+* `window`: Throttling duration window (required). Supports formats like `'1s'`, `'1m'`, `'1h'`.
+* `key` (optional): Custom function `(context: ExecutionContext) => string` to group rate limits. Useful for rate-limiting per user role or API key.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, RateLimit, z, ExecutionContext } from '@nitrostack/core';
+
+export class DiagnosticTools {
+  @Tool({
+    name: 'run_deep_diagnostic',
+    description: 'Run intensive diagnostics. Rate limited.',
+    inputSchema: z.object({}),
+  })
+  @RateLimit({ requests: 3, window: '1m' }) // Max 3 requests per minute globally
+  async runDeepDiagnostic() {
+    return { diagnosticReport: 'All systems operational.' };
+  }
+
+  @Tool({
+    name: 'request_supply_drop',
+    description: 'Request inventory supplies. Rate limited per user.',
+    inputSchema: z.object({ item: z.string() }),
+  })
+  @RateLimit({
+    requests: 5,
+    window: '1h',
+    key: (ctx: ExecutionContext) => ctx.auth?.subject || 'anonymous'
+  })
+  async requestSupply(input: { item: string }, ctx: ExecutionContext) {
+    // ...
+  }
+}
+```
+
+---
+
+## Handling File Uploads in Tools
+NitroStack supports file uploads from MCP clients (like NitroStudio) by passing the file as a base64-encoded string inside a tool's input parameters.
+
+### 1. Declaring Input Schema for File Uploads
+To accept an uploaded file, define three Zod fields in your tool's `inputSchema`:
+* `file_name`: The name of the file (e.g. `report.csv`).
+* `file_type`: The MIME type (e.g. `text/csv`).
+* `file_content`: The base64-encoded string containing the file data.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+
+export class FileTools {
+  @Tool({
+    name: 'upload_document',
+    description: 'Upload a text document or image.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async uploadDocument(input: any, ctx: ExecutionContext) {
+    // Processing logic
+  }
+}
+```
+
+### 2. Decoding Base64 Payloads
+File uploads can arrive in two formats depending on the client:
+1. **Data URL format**: `data:image/png;base64,iVBORw0KGgo...`
+2. **Raw Base64 format**: `iVBORw0KGgo...`
+
+Use the following universal decoder pattern to parse either format into a Node `Buffer`:
+
+```typescript
+import * as fs from 'fs';
+import * as path from 'path';
+
+function decodeBase64File(content: string): Buffer {
+  const matches = content.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/);
+  
+  if (matches && matches.length === 3) {
+    // Data URL format - decode matches[2]
+    return Buffer.from(matches[2], 'base64');
+  } else {
+    // Raw base64 format - decode input directly
+    return Buffer.from(content, 'base64');
+  }
+}
+```
+
+### 3. Secure File Saving Example
+Always validate the directory paths to prevent directory traversal attacks when saving files to disk.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads');
+
+export class SecureUploadTools {
+  @Tool({
+    name: 'save_uploaded_file',
+    description: 'Decodes and saves an uploaded file securely.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async saveFile(input: any, ctx: ExecutionContext) {
+    // Ensure uploads directory exists
+    if (!fs.existsSync(UPLOAD_DIR)) {
+      fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+    }
+
+    // Secure destination path to prevent path traversal
+    const safeName = path.basename(input.file_name);
+    const filePath = path.join(UPLOAD_DIR, safeName);
+    if (!filePath.startsWith(UPLOAD_DIR)) {
+      throw new Error('Invalid file path detected (path traversal).');
+    }
+
+    // Decode and write to disk
+    const buffer = decodeBase64File(input.file_content);
+    fs.writeFileSync(filePath, buffer);
+
+    ctx.logger.info(`Successfully saved file: ${safeName}`);
+    return { success: true, path: filePath };
+  }
+}
+```

--- a/sample-apps/concord-governance-agent/.opencode/skills/ui-widgets/SKILL.md
+++ b/sample-apps/concord-governance-agent/.opencode/skills/ui-widgets/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: nitrostack-ui-widgets
+description: Best practices for linking tools to interactive frontend widgets using @Widget and @nitrostack/widgets SDK (including state sync, tool calling, display modes, media queries, and chat actions).
+---
+
+## When to Use
+Use this skill when designing, building, or modifying interactive user interface widgets that display custom React content inside AI clients or NitroStudio.
+
+---
+
+## 1. Backend Definition (`@Widget`)
+To display a React-based widget for a tool's output, decorate the tool method with `@Widget`.
+
+### Options:
+* **String Route**: A simple string representing the route identifier in the frontend React app (e.g. `'product-card'`).
+* **Object Route**: Object including:
+  * `route` (required): The route path.
+  * `domain` (optional): Allowed sandbox domain.
+  * `csp` (optional): Content Security Policy guidelines.
+
+### Example:
+```typescript
+import { Tool, Widget, z } from '@nitrostack/core';
+
+export class CatalogTools {
+  @Tool({
+    name: 'fetch_product',
+    description: 'Get product information by barcode.',
+    inputSchema: z.object({ barcode: z.string() }),
+  })
+  @Widget('product-details') // Maps to the "product-details" frontend component
+  async fetchProduct(input: { barcode: string }) {
+    return {
+      name: 'Super Nitro Energy Drink',
+      price: 2.99,
+      sku: input.barcode,
+    };
+  }
+}
+```
+
+---
+
+## 2. Frontend React Widget (`@nitrostack/widgets`)
+In your React widget frontend application (typically a Next.js client component), use the `useWidgetSDK` hook to receive input data from the client host.
+
+### React Component Example:
+```tsx
+'use client';
+
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+interface ProductData {
+  name: string;
+  price: number;
+  sku: string;
+}
+
+export default function ProductDetailsWidget() {
+  const { isReady, getToolOutput, theme } = useWidgetSDK();
+  const data = getToolOutput<ProductData>();
+
+  if (!isReady) {
+    return <div className="loading">Connecting to host...</div>;
+  }
+
+  if (!data) {
+    return <div className="error">No product data received.</div>;
+  }
+
+  return (
+    <div className={`product-card ${theme === 'dark' ? 'dark' : 'light'}`}>
+      <h3>{data.name}</h3>
+      <p className="price">${data.price.toFixed(2)}</p>
+      <span className="sku">SKU: {data.sku}</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 3. State Management & Synchronization (`useWidgetState`)
+Use `useWidgetState` to manage and persist client-side widget state (e.g. selected tabs, filter values, input states). This state automatically synchronizes with the host application context, persisting it across page re-renders.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetState } from '@nitrostack/widgets';
+
+export default function StationPanelWidget() {
+  const [state, setState] = useWidgetState(() => ({
+    selectedTab: 'overview',
+    showExtendedInfo: false,
+  }));
+
+  return (
+    <div>
+      <button onClick={() => setState({ ...state, selectedTab: 'alerts' })}>
+        View Alerts
+      </button>
+      <p>Current Tab: {state?.selectedTab}</p>
+    </div>
+  );
+}
+```
+
+---
+
+## 4. Calling Core Tools from Widgets (`callTool`)
+You can invoke other backend MCP tools directly from the frontend widget using `callTool`. This is useful for tool chaining or triggering detailed audits.
+
+### Example:
+```tsx
+import React, { useState } from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function SystemDiagnostics() {
+  const { callTool, isReady } = useWidgetSDK();
+  const [isRunning, setIsRunning] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+
+  const runDiagnostic = async () => {
+    if (!isReady) return;
+    setIsRunning(true);
+    try {
+      const response = await callTool('run_diagnostic', { system: 'oxygen_scrubber' });
+      setResult(response.result as string);
+    } catch (err) {
+      setResult('Diagnostic execution failed.');
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <button onClick={runDiagnostic} disabled={isRunning}>
+      {isRunning ? 'Running...' : 'Run Diagnostics'}
+    </button>
+  );
+}
+```
+
+---
+
+## 5. Layout & Display Controls
+Widgets can dynamically request size mode changes (fullscreen, inline, picture-in-picture) and adapt layouts to safe areas (dynamic islands/notches) or maximum height constraints.
+
+### Key Methods:
+* `requestFullscreen()`: Switch host widget display to fullscreen.
+* `requestInline()`: Switch host widget display back to inline.
+* `requestPip()`: Float widget in Picture-in-Picture.
+* `requestClose()`: Dismiss the widget completely.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function StatusBoard() {
+  const { 
+    requestFullscreen, 
+    requestInline, 
+    requestClose,
+    displayMode,   // Reactive property ('fullscreen' | 'inline' | 'pip')
+    maxHeight,     // Reactive maxHeight constraint (in pixels)
+    getSafeArea    // Insets data: { top, right, bottom, left }
+  } = useWidgetSDK();
+
+  const safeArea = getSafeArea() || { top: 0, bottom: 0 };
+
+  return (
+    <div style={{ maxHeight: maxHeight || 400, paddingTop: safeArea.top }}>
+      <h3>Mode: {displayMode}</h3>
+      <button onClick={requestFullscreen}>Fullscreen</button>
+      <button onClick={requestInline}>Collapse</button>
+      <button onClick={requestClose}>Dismiss Widget</button>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. Chat Navigation & Actions
+Widgets can interact with the host chat pane using external browser links and follow-up prompts.
+
+### Key Methods:
+* `openExternal(url)`: Open the target URL safely in the user's primary external browser.
+* `sendFollowUpMessage(prompt)`: Insert a message into the chat flow, automatically submitting it to the LLM agent.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function MissionControl() {
+  const { openExternal, sendFollowUpMessage } = useWidgetSDK();
+
+  return (
+    <div>
+      {/* Open external documentation */}
+      <button onClick={() => openExternal('https://docs.nitrostack.dev')}>
+        Open Manual
+      </button>
+
+      {/* Ask LLM agent directly from the widget */}
+      <button onClick={() => sendFollowUpMessage('Analyze mission failures from last week')}>
+        Ask Agent to Analyze
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 7. Media & Accessibility Queries
+The SDK provides helper utilities to query target client capabilities for styling or accessibility.
+
+### Key Utilities:
+* `prefersReducedMotion()`: Returns `true` if client settings specify reduced motion. Disable animations.
+* `isPrimarilyTouchDevice()`: Returns `true` if the device has a coarse pointer (e.g. touch/mobile). Increase button target sizes.
+* `isHoverAvailable()`: Returns `true` if pointer supports hover states.
+* `prefersDarkColorScheme()`: Returns `true` if the system theme is dark.
+
+### Example:
+```tsx
+import React from 'react';
+import { isPrimarilyTouchDevice, prefersReducedMotion } from '@nitrostack/widgets';
+
+export default function AccessiblePanel() {
+  const isTouch = isPrimarilyTouchDevice();
+  const reducedMotion = prefersReducedMotion();
+
+  return (
+    <div className={reducedMotion ? 'no-animations' : 'smooth-transitions'}>
+      <button style={{ padding: isTouch ? '16px' : '8px' }}>
+        Interactive Button
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 8. Testing Widgets
+* Open your project in **NitroStudio** for visual preview.
+* Invoke the tool from the AI chat or testing pane to verify the widget updates instantly with the returned JSON structure.

--- a/sample-apps/concord-governance-agent/OAUTH_SETUP.md
+++ b/sample-apps/concord-governance-agent/OAUTH_SETUP.md
@@ -1,0 +1,592 @@
+# Complete OAuth 2.1 Setup Guide for NitroStack
+
+This guide shows you **exactly** how to set up OAuth 2.1 authentication from scratch with **zero issues**.
+
+## 🎯 What You'll Learn
+
+- ✅ How to configure Auth0 correctly (avoiding common pitfalls)
+- ✅ How to set up your MCP server environment
+- ✅ How to test the complete OAuth flow in Studio
+- ✅ How to troubleshoot common issues
+
+---
+
+## 🚀 Quick Start with Auth0 (10 Minutes)
+
+### Why Auth0?
+- ✅ **Free tier** (7,000 active users, no credit card)
+- ✅ **Fastest setup** (10 minutes)
+- ✅ **Best for testing** and learning
+- ✅ **Production-ready** when you need it
+
+---
+
+## Step 1: Create Auth0 Account
+
+1. Go to **[auth0.com/signup](https://auth0.com/signup)**
+2. Sign up for free (choose "Personal" plan)
+3. Complete email verification
+
+---
+
+## Step 2: Create Auth0 API (Protected Resource)
+
+**⚠️ DO THIS FIRST!** The API represents your MCP server as a protected resource.
+
+1. Go to **Applications** → **APIs** in Auth0 Dashboard
+2. Click **"Create API"**
+3. **Settings:**
+   ```
+   Name: MCP Server API
+   Identifier: https://mcplocal
+   Signing Algorithm: RS256
+   ```
+   
+   **⚠️ CRITICAL NOTES:**
+   - The **Identifier** can be any unique URI (doesn't need to be a real URL)
+   - For development, use `https://mcplocal` (simple and clear)
+   - For production, use your actual domain like `https://api.yourapp.com`
+   - This **MUST** match your `RESOURCE_URI` in `.env` **EXACTLY**
+   - **JWT Profile**: Select **RFC 9068** (OAuth 2.0 Access Token JWT Profile)
+   - **RBAC**: You can leave this **disabled** for basic OAuth (only needed for role-based permissions)
+
+4. Click **"Create"**
+
+5. Go to **Permissions** tab
+6. Add these scopes:
+   ```
+   Scope          Description
+   -----          -----------
+   read           Read access to resources
+   write          Write/modify resources
+   admin          Administrative operations
+   ```
+
+7. Click **"Add"** for each scope
+8. **Save Changes**
+
+---
+
+## Step 3: Create Auth0 Application (OAuth Client)
+
+**⚠️ Application Type Matters!** This is where many users get stuck.
+
+1. Go to **Applications** → **Applications**
+2. Click **"Create Application"**
+3. **Settings:**
+   ```
+   Name: MCP Server OAuth
+   Application Type: Regular Web Application  ← CRITICAL!
+   ```
+   
+   **⚠️ WHY "Regular Web Application"?**
+   - ❌ **NOT** "Single Page Application" (SPA) - Won't show in API authorization
+   - ❌ **NOT** "Machine to Machine" - Different auth flow, not compatible with OpenAI Studio
+   - ✅ **YES** "Regular Web Application" - Supports confidential clients with client secret
+
+4. Click **"Create"**
+
+5. Go to **Settings** tab and configure:
+
+   **Allowed Callback URLs** (supports both dev and prod):
+   ```
+   http://localhost:3005/auth/callback,http://localhost:3000/auth/callback
+   ```
+   
+   **Why both ports?**
+   - `3005`: Dev mode (DiscoveryHttpServer handles OAuth callbacks)
+   - `3000`: Prod mode (HttpServerTransport handles OAuth callbacks)
+
+   **Allowed Logout URLs**:
+   ```
+   http://localhost:3005,http://localhost:3000
+   ```
+
+   **Allowed Web Origins**:
+   ```
+   http://localhost:3005,http://localhost:3000
+   ```
+
+6. Scroll down to **Advanced Settings**
+7. Go to **Grant Types** tab:
+   ```
+   ✅ Authorization Code
+   ✅ Refresh Token
+   ❌ Implicit (disable - deprecated in OAuth 2.1)
+   ❌ Client Credentials (not needed for this use case)
+   ```
+
+8. Go to **OAuth** tab:
+   ```
+   ✅ OIDC Conformant: ON (enabled)
+   JsonWebToken Signature Algorithm: RS256
+   ```
+
+9. Go to **ID Token** tab:
+   ```
+   ❌ ID Token Encryption: NONE/Disabled
+   ```
+   
+   **⚠️ CRITICAL:** If encryption is enabled, you'll receive JWE (encrypted) tokens instead of JWT tokens, which will fail validation!
+
+10. **Save Changes**
+
+11. **Copy these values** (you'll need them later):
+    - **Domain** (e.g., `dev-abc123.us.auth0.com`)
+    - **Client ID** (e.g., `aBc123XyZ...`)
+    - **Client Secret** (click "Show" to reveal it)
+
+---
+
+## Step 4: Link Application to API
+
+**⚠️ REQUIRED STEP!** Many users miss this.
+
+1. Go back to **Applications** → **APIs**
+2. Click on your **"MCP Server API"** (created in Step 2)
+3. Click the **"Machine to Machine Applications"** tab
+   
+   **Note:** Despite the confusing name, this tab shows which applications can access your API
+
+4. Find your **"MCP Server OAuth"** application in the list
+5. **Toggle the switch to "Authorized"** (should turn green)
+6. Click the **dropdown arrow** to expand permissions
+7. **Select all scopes** you want to grant (`read`, `write`, `admin`)
+8. Click **"Update"**
+
+**✅ Verification:** Your application should now show as "Authorized" with selected scopes
+
+---
+
+## Step 5: Configure Your MCP Server
+
+### Copy and Edit `.env` File
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` with your Auth0 settings:
+
+```bash
+# =============================================================================
+# REQUIRED: Server Configuration
+# =============================================================================
+
+# ⚠️ MUST match Auth0 API Identifier from Step 2 EXACTLY
+RESOURCE_URI=https://mcplocal
+
+# Your Auth0 domain from Step 3 (with https://)
+AUTH_SERVER_URL=https://dev-abc123.us.auth0.com
+
+# =============================================================================
+# OPTIONAL: Token Configuration
+# =============================================================================
+
+# Must match RESOURCE_URI
+TOKEN_AUDIENCE=https://mcplocal
+
+# Auth0 domain with trailing slash!
+TOKEN_ISSUER=https://dev-abc123.us.auth0.com/
+```
+
+**⚠️ Important:**
+- Replace `dev-abc123` with YOUR actual Auth0 domain
+- `RESOURCE_URI` must match Auth0 API Identifier **EXACTLY** (case-sensitive!)
+- `TOKEN_ISSUER` must have trailing slash `/`
+
+---
+
+## Step 6: Start Your MCP Server
+
+```bash
+npm install
+npm run dev
+```
+
+**Expected Output:**
+```
+🚀 OAuth discovery server running at http://localhost:3005
+NITRO_LOG::{"level":"info","message":"OAuthModule: Running in STDIO mode, starting DiscoveryHttpServer on port 3005"}
+NITRO_LOG::{"level":"info","message":"🔐 OAuth 2.1 enabled"}
+NITRO_LOG::{"level":"info","message":"   Resource URI: https://mcplocal"}
+NITRO_LOG::{"level":"info","message":"   Auth Servers: https://dev-abc123.us.auth0.com"}
+🚀 Server started successfully (DUAL: STDIO + HTTP)
+📡 MCP Protocol: STDIO (for Studio/Claude)
+🌐 OAuth Metadata: HTTP (port 3005)
+```
+
+**✅ Success!** Your server is running in DUAL mode:
+- **STDIO**: For MCP protocol communication (tools, chat)
+- **HTTP (3005)**: For OAuth metadata and discovery in dev mode
+
+---
+
+## Step 7: Test OAuth Flow in NitroStack Studio
+
+### Open Studio
+
+Navigate to **http://localhost:3000** in your browser
+
+### 7.1 Discover OAuth Server
+
+1. Go to **Auth** → **OAuth 2.1** tab
+2. In the **"1. Discover Server Auth"** section:
+   ```
+   Server URL: http://localhost:3005
+   ```
+   **Note:** Port 3005 in dev mode (discovery server)
+
+3. Click **"Discover Auth Config"**
+
+**Expected Result:**
+```
+✅ Discovery successful!
+
+Resource: https://mcplocal
+Authorization Servers: https://dev-abc123.us.auth0.com
+Scopes: read, write, admin
+```
+
+**✅ In Console, you should see:**
+```
+🎯 Setting audience parameter: https://mcplocal
+```
+
+**⚠️ This is CRITICAL!** The audience parameter tells Auth0 to issue a proper JWT access token for your API.
+
+### 7.2 Enter Client Credentials
+
+1. Scroll to **"2a. Use Existing Client"** section
+2. Enter your credentials from Step 3:
+   ```
+   Client ID: [Your Auth0 Client ID]
+   Client Secret: [Your Auth0 Client Secret]
+   ```
+3. Click **"Save Client Credentials"**
+
+**Expected Result:**
+```
+✅ Client credentials saved!
+```
+
+### 7.3 Start OAuth Flow
+
+1. Scroll to **"3. Start OAuth Flow"** section
+2. Click **"Start Authorization Flow"**
+
+**What Happens:**
+1. ✅ You're redirected to Auth0 login page
+2. ✅ Login with your Auth0 account (or test user)
+3. ✅ You're asked to authorize the application
+4. ✅ After authorization, you're redirected back to Studio
+5. ✅ Studio exchanges the code for a JWT token
+6. ✅ Token is automatically saved!
+
+**Expected Result:**
+```
+✅ Authorization successful! Redirecting...
+```
+
+### 7.4 Verify Token Type (Debug Check)
+
+**In your MCP server logs, you should see:**
+```
+[DEBUG] Token header: {"alg":"RS256","typ":"at+jwt","kid":"..."}
+[DEBUG] Decoded payload: SUCCESS
+[DEBUG] Payload audience: https://mcplocal
+[DEBUG] Expected audience: https://mcplocal
+```
+
+**✅ Perfect!** You're getting **RS256 JWT tokens** (not encrypted JWE tokens)
+
+**❌ If you see this instead:**
+```
+[DEBUG] Token header: {"alg":"dir","enc":"A256GCM",...}
+[ERROR] Received JWE (encrypted) token instead of JWT!
+```
+
+**Fix:** Go back to Step 3 and disable ID Token Encryption in Application settings
+
+### 7.5 Test Protected Tools
+
+1. Go to **Tools** tab
+2. Try a protected tool (e.g., `get_user_profile`, `list_resources`)
+3. Click **"Execute"**
+
+**Expected Result:**
+```json
+{
+  "success": true,
+  "user": {
+    "sub": "auth0|xxx",
+    "scopes": ["read", "write", "admin"],
+    "clientId": "..."
+  }
+}
+```
+
+**🎉 Congratulations!** Your OAuth 2.1 server is fully working!
+
+---
+
+## 🔍 How It Works
+
+### Dual Transport Architecture
+
+NitroStack automatically runs **two transports simultaneously** when OAuth is enabled:
+
+```
+Development Mode:
+┌─────────────────────────────────────┐
+│   Your OAuth 2.1 MCP Server         │
+├─────────────────────────────────────┤
+│                                     │
+│  📡 STDIO Transport                 │
+│  ├─ MCP Protocol (tools, chat)      │
+│  ├─ Connected to Studio/Claude      │
+│  └─ stdin/stdout communication      │
+│                                     │
+│  🌐 DiscoveryHttpServer (Port 3005) │
+│  ├─ OAuth Metadata Endpoints        │
+│  ├─ /.well-known/oauth-protected-   │
+│  │   resource                       │
+│  ├─ /auth/callback                  │
+│  └─ Discovery & Token Validation    │
+│                                     │
+└─────────────────────────────────────┘
+
+Production Mode:
+┌─────────────────────────────────────┐
+│   Your OAuth 2.1 MCP Server         │
+├─────────────────────────────────────┤
+│                                     │
+│  🌐 HttpServerTransport (Port 3000) │
+│  ├─ MCP Protocol (SSE)              │
+│  ├─ OAuth Metadata Endpoints        │
+│  ├─ /.well-known/oauth-protected-   │
+│  │   resource                       │
+│  ├─ /auth/callback                  │
+│  └─ All-in-one HTTP server          │
+│                                     │
+└─────────────────────────────────────┘
+```
+
+### OAuth Flow Sequence
+
+```
+1. Studio → Discover     → Your MCP Server (HTTP :3005 in dev)
+                          ↓
+                      Returns OAuth metadata
+                      (includes resource URI for audience)
+                          ↓
+2. Studio → Authorize    → Auth0 Login Page
+   (with audience param)  ↓
+                      User logs in
+                          ↓
+3. Auth0 → Redirect      → Studio Callback (/auth/callback)
+                          ↓
+4. Studio → Exchange     → Auth0 Token Endpoint
+   (code for token)       ↓
+                      Receives RS256 JWT access token
+                      (NOT encrypted JWE token!)
+                          ↓
+5. Studio → Execute Tool → Your MCP Server (STDIO)
+           (with JWT)    ↓
+                      Tool validates token & executes
+```
+
+**Key Point:** Studio now automatically includes the `audience` parameter when starting the OAuth flow, which ensures Auth0 issues proper JWT tokens.
+
+---
+
+## 🚨 Troubleshooting
+
+### Issue: "Received JWE (encrypted) token instead of JWT!"
+
+**Symptoms:**
+```
+[DEBUG] Token header: {"alg":"dir","enc":"A256GCM",...}
+[ERROR] Received JWE (encrypted) token instead of JWT!
+```
+
+**Root Cause:** One of these:
+1. ID Token Encryption is enabled in Application settings
+2. Application type is wrong (SPA instead of Regular Web App)
+3. Audience parameter not being sent (fixed in latest Studio version)
+
+**Fix:**
+1. Go to Applications → Your Application → Settings → Advanced Settings
+2. Click **"ID Token"** tab
+3. Ensure **"ID Token Encryption"** is **Disabled** or **None**
+4. Click **"OAuth"** tab
+5. Ensure **"OIDC Conformant"** is **ON**
+6. **Save Changes**
+7. Clear Studio's saved token and re-authorize
+
+### Issue: "Application doesn't show in API's Machine to Machine tab"
+
+**Root Cause:** Application type is "Single Page Application" instead of "Regular Web Application"
+
+**Fix:**
+1. Delete the current application
+2. Create a new one with type **"Regular Web Application"**
+3. Follow Step 3 again
+
+### Issue: "Token audience mismatch"
+
+**Symptoms:**
+```
+OAuth token validation failed: Token audience mismatch. 
+Expected: https://mcplocal, Got: https://dev-abc123.us.auth0.com/api/v2/
+```
+
+**Root Cause:** `RESOURCE_URI` in `.env` doesn't match Auth0 API Identifier
+
+**Fix:**
+1. In Auth0: Applications → APIs → Your API → Settings → **Identifier**
+2. Copy the exact identifier (e.g., `https://mcplocal`)
+3. In `.env`: Set `RESOURCE_URI` to match **EXACTLY** (case-sensitive)
+4. In `.env`: Set `TOKEN_AUDIENCE` to match **EXACTLY**
+5. Restart your MCP server
+
+### Issue: "Discovery failed" or "Cannot read properties of undefined"
+
+**Root Cause:** Server URL is incorrect or server isn't running
+
+**Fix:**
+1. Verify server is running: Check for "🚀 OAuth discovery server running" in logs
+2. Check URL is exactly: `http://localhost:3005` (dev mode)
+3. Test metadata endpoint:
+   ```bash
+   curl http://localhost:3005/.well-known/oauth-protected-resource
+   ```
+   Should return:
+   ```json
+   {
+     "resource": "https://mcplocal",
+     "authorization_servers": ["https://dev-abc123.us.auth0.com"],
+     "scopes_supported": ["read", "write", "admin"]
+   }
+   ```
+
+### Issue: "Invalid token issuer"
+
+**Root Cause:** `TOKEN_ISSUER` doesn't match token's `iss` claim
+
+**Fix:**
+1. Check Auth0 domain in dashboard
+2. Add `https://` prefix
+3. Add trailing `/` 
+4. Example: `https://dev-abc123.us.auth0.com/` (note the slash!)
+
+### Issue: "Insufficient scope"
+
+**Root Cause:** Token doesn't have required scopes for the tool
+
+**Fix:**
+1. In Auth0: Applications → APIs → Your API → Machine to Machine Applications
+2. Find your application and ensure it's **Authorized**
+3. Click the dropdown and **select all required scopes**
+4. Click **"Update"**
+5. In Studio: Clear the saved token and re-authorize
+6. New token will have updated scopes
+
+### Issue: "Port 3005 already in use"
+
+**Root Cause:** Previous server instance still running
+
+**Fix:**
+```bash
+# Kill process on port 3005
+lsof -ti :3005 | xargs kill -9
+
+# Restart server
+npm run dev
+```
+
+---
+
+## 🌐 Other OAuth Providers
+
+### Okta
+
+```bash
+RESOURCE_URI=https://mcp.yourapp.com
+AUTH_SERVER_URL=https://your-domain.okta.com/oauth2/default
+TOKEN_AUDIENCE=api://mcp.yourapp.com
+TOKEN_ISSUER=https://your-domain.okta.com/oauth2/default
+```
+
+### Keycloak
+
+```bash
+RESOURCE_URI=https://mcp.yourapp.com
+AUTH_SERVER_URL=https://keycloak.yourapp.com/realms/your-realm
+TOKEN_AUDIENCE=mcp-server
+TOKEN_ISSUER=https://keycloak.yourapp.com/realms/your-realm
+```
+
+### Azure AD / Entra ID
+
+```bash
+RESOURCE_URI=https://mcp.yourapp.com
+AUTH_SERVER_URL=https://login.microsoftonline.com/YOUR-TENANT-ID/v2.0
+TOKEN_AUDIENCE=api://YOUR-APP-ID
+TOKEN_ISSUER=https://login.microsoftonline.com/YOUR-TENANT-ID/v2.0
+```
+
+---
+
+## 📚 Learn More
+
+- [MCP OAuth Specification](https://modelcontextprotocol.io/specification/draft/basic/authorization)
+- [OAuth 2.1 Draft](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-13)
+- [RFC 8707 - Resource Indicators](https://datatracker.ietf.org/doc/html/rfc8707)
+- [RFC 9728 - Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728)
+- [OpenAI Apps SDK - Auth](https://developers.openai.com/apps-sdk/build/auth)
+
+---
+
+## ✅ Pre-Flight Checklist
+
+Before asking for help, verify:
+
+- [ ] Auth0 API created with **RS256** signing algorithm
+- [ ] Auth0 API **JWT Profile** set to **RFC 9068**
+- [ ] Auth0 Application type is **"Regular Web Application"** (not SPA or M2M)
+- [ ] Application has correct **callback URLs** (`http://localhost:3005/auth/callback`)
+- [ ] Application **Grant Types** include "Authorization Code" and "Refresh Token"
+- [ ] Application **ID Token Encryption** is **DISABLED**
+- [ ] Application is **Authorized** to access the API (Machine to Machine Applications tab)
+- [ ] Required **scopes** are granted to the application
+- [ ] `.env` file has `RESOURCE_URI` matching Auth0 API Identifier **EXACTLY**
+- [ ] `.env` file has `TOKEN_ISSUER` with **trailing slash** `/`
+- [ ] Server starts successfully (check logs for "🚀 OAuth discovery server running")
+- [ ] Discovery endpoint is accessible: `curl http://localhost:3005/.well-known/oauth-protected-resource`
+- [ ] Discovery works in Studio (shows resource, auth servers, scopes)
+- [ ] Client credentials saved in Studio
+- [ ] OAuth flow completes successfully
+- [ ] Server logs show **RS256 JWT tokens** (not JWE encrypted tokens)
+- [ ] JWT token stored in Studio (check Auth tab)
+- [ ] Protected tools execute successfully
+
+**If all checkboxes are ✅ and it still doesn't work,** check the troubleshooting section above!
+
+---
+
+## 🎓 What We Learned (Common Pitfalls)
+
+1. **Application Type Matters:** Must be "Regular Web Application", not SPA or M2M
+2. **Audience Parameter is Critical:** Without it, Auth0 returns encrypted tokens (fixed in Studio)
+3. **API Identifier Must Match:** `RESOURCE_URI` must **exactly** match Auth0 API Identifier
+4. **Encryption Must Be Disabled:** ID Token encryption breaks JWT validation
+5. **Trailing Slash Matters:** `TOKEN_ISSUER` must have trailing `/` for Auth0
+6. **Authorization Required:** Application must be explicitly authorized to access the API
+7. **Port Awareness:** Dev mode uses 3005, prod mode uses 3000
+
+---
+
+**Happy coding! 🚀**
+
+If you have issues, check the troubleshooting section above. Most problems are solved by verifying the checklist!

--- a/sample-apps/concord-governance-agent/README.md
+++ b/sample-apps/concord-governance-agent/README.md
@@ -1,0 +1,146 @@
+# Concord — self-driving DevOps with a conscience
+
+> Most "AI DevOps" demos are chatbots wearing a hard hat. Concord actually runs the pipeline.
+
+![Model Context Protocol](https://img.shields.io/badge/Model%20Context%20Protocol-MCP-blue) ![Built with Nitrostack](https://img.shields.io/badge/Built%20with-Nitrostack-0A66FF) ![Status](https://img.shields.io/badge/status-live-brightgreen)
+
+**Concord** is an [MCP (Model Context Protocol)](https://nitrostack.ai) server that gives AI assistants — Claude, Cursor, ChatGPT, or any MCP-compatible client — real authority over cloud infrastructure governance: DevOps, SecOps, and FinOps, unified into one decision layer. Built and deployed on [Nitrostack](https://nitrostack.ai).
+
+**Team:** The Pixel Pirates — Amrita University MCP Hackathon 2026
+
+## Table of Contents
+
+- [Overview](#overview)
+- [What is MCP?](#what-is-mcp)
+- [Features](#features)
+- [Live Demo](#live-demo)
+- [Getting Started](#getting-started)
+- [Connect to an MCP Client](#connect-to-an-mcp-client)
+- [Deploy Your Own MCP App](#deploy-your-own-mcp-app)
+- [Explore More MCP Apps](#explore-more-mcp-apps)
+- [FAQ](#faq)
+- [Keywords](#keywords)
+- [License](#license)
+
+## Overview
+
+Concord runs the pipeline — commit, build, cost-check, canary deploy, monitor, loop — with nobody touching it. It watches five clusters across three regions, live security threats, and real department budgets at the same time, and it doesn't just react, it does the math first: what does halting this cluster actually cost, whose contract does it break, whose budget goes negative. If the answer crosses a hard line, it refuses to act — even fully autonomous, it won't drain a team's budget below its safety floor. Everything else, it just handles.
+
+When a human does need to step in, it hands over a real briefing — financial exposure, conflict type, a live AI-generated root-cause chain — with an SLA clock ticking, not a wall of logs to decode.
+
+Every decision, human or machine, gets hash-chained into a tamper-evident audit trail. The same governance brain runs two ways: a live autonomous web dashboard, and this MCP server — any AI client can call the exact same tools, rules, and receipts.
+
+## What is MCP?
+
+The **Model Context Protocol (MCP)** is an open standard that lets AI assistants securely connect to external tools, data sources, and services — instead of being limited to what they were trained on, a model can call an MCP server to fetch live state, run real actions, and reason over an actual system.
+
+Concord is one such server. Learn more about building and shipping MCP apps at [nitrostack.ai](https://nitrostack.ai).
+
+## Features
+
+- 🧠 **Autonomous governance loop** — commit → build → cost-check → canary deploy → monitor → incident → root-cause → remediate → resolved, running continuously with no human trigger
+- 💰 **Real financial math, not vibes** — every proposed action gets an hourly cost estimate, SLA penalty exposure, and budget-runway impact before it's approved
+- 🚧 **Hard guardrails** — the agent will refuse to breach a department's budget floor even when fully autonomous
+- 🔍 **Live AI root-cause analysis** — `get_root_cause_analysis` generates a real causality chain via Groq's Llama 3.3 70B, not a canned template
+- 🚀 **GitOps-style canary deploys** — `deploy_canary` progressively shifts traffic 10% → 100% with automatic rollback on error-rate/latency spikes
+- 🔐 **Tamper-evident audit trail** — every approve/deny decision is SHA-256 hash-chained; `verify_audit_chain` proves nothing's been altered
+- ⚙️ **Dynamic rule engine** — 7 governance rules (contract penalties, budget floors, duplicate actions, canary conflicts, weather risk) evaluated per action, not hardcoded per tool
+- 🔌 **MCP-native** — 15 tools, 5 resources, 1 prompt template, callable from any MCP-compatible client
+
+## Live Demo
+
+🚀 **Live MCP endpoint:** https://nitro-6a5-the-pixel-pirates-amrita-university-amritapuri-campus.app.nitrocloud.ai
+
+Point your MCP client at the endpoint above to try it instantly. Ask it to `get_state_summary`, or `halt_deployment_pipeline` on a cluster and watch it surface the real conflict and cost before it acts.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 18+
+- A free [Groq API key](https://console.groq.com) (no credit card needed) — powers the live root-cause analysis
+- An MCP-compatible client (Claude Desktop, Cursor, NitroStudio, etc.)
+
+### Installation
+
+```bash
+git clone https://github.com/RuthiKode/concord-governance-agent.git
+cd concord-governance-agent/my-mcp-server
+npm install
+```
+
+### Configuration
+
+Copy the example environment file and add your Groq API key:
+
+```bash
+cp .env.example .env
+```
+
+```env
+GROQ_API_KEY=your_groq_api_key_here
+GROQ_MODEL=llama-3.3-70b-versatile
+```
+
+### Run
+
+```bash
+npx nitrostack-cli dev
+```
+
+## Connect to an MCP Client
+
+Add this server to your MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "concord-governance-server": {
+      "url": "https://nitro-6a5-the-pixel-pirates-amrita-university-amritapuri-campus.app.nitrocloud.ai"
+    }
+  }
+}
+```
+
+Restart your client — 15 governance tools become available to your AI assistant immediately.
+
+## Deploy Your Own MCP App
+
+Want to build and ship an MCP server like this one? **[Nitrostack](https://nitrostack.ai)** lets you create, deploy, and host MCP apps in minutes — no infrastructure to manage.
+
+👉 **Start building:** [https://nitrostack.ai](https://nitrostack.ai)
+
+## Explore More MCP Apps
+
+- 🌙 Discover and share MCP projects with the community on [r/mcptothemoon](https://www.reddit.com/r/mcptothemoon/)
+- 🧰 Browse a growing catalog of MCP apps on [Nitrostack](https://nitrostack.ai/apps)
+
+## FAQ
+
+### What is an MCP server?
+
+An MCP server implements the Model Context Protocol to expose tools, resources, and prompts that AI assistants can call — letting a model take real actions and access live data instead of just generating text.
+
+### What does Concord actually do?
+
+It governs cloud infrastructure autonomously — deploying, monitoring, and responding to incidents across DevOps, SecOps, and FinOps — while calculating real financial exposure before every high-risk action and refusing to breach hard budget guardrails, even without a human in the loop.
+
+### Which AI clients does this work with?
+
+Any MCP-compatible client, including Claude Desktop, Cursor, and NitroStudio. New clients are adding MCP support regularly.
+
+### How do I deploy my own MCP app?
+
+Use [Nitrostack](https://nitrostack.ai) to build, deploy, and host MCP apps without managing infrastructure.
+
+## Keywords
+
+`Open Innovation` · `MCP` · `Model Context Protocol` · `MCP server` · `AIOps` · `GitOps` · `FinOps` · `cloud governance` · `autonomous agent` · `cyber security` · `AI tools` · `AI agents` · `Claude MCP` · `Nitrostack` · `deploy MCP server`
+
+## License
+
+MIT © 2026
+
+---
+
+Built with ❤️ using the Model Context Protocol on [Nitrostack](https://nitrostack.ai). Share your MCP app on [r/mcptothemoon](https://www.reddit.com/r/mcptothemoon/).

--- a/sample-apps/concord-governance-agent/package-lock.json
+++ b/sample-apps/concord-governance-agent/package-lock.json
@@ -1,0 +1,4009 @@
+{
+  "name": "my-mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "my-mcp-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "@duffel/api": "^4.21.0",
+        "@modelcontextprotocol/ext-apps": ">=0.1.0",
+        "@nitrostack/core": "^1.0.13",
+        "axios": "^1.7.9",
+        "date-fns": "^4.1.0",
+        "dotenv": "^16.3.1",
+        "zod": "^3.22.4"
+      },
+      "devDependencies": {
+        "@nitrostack/cli": "^1.0.14",
+        "@types/node": "^22.10.0",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@duffel/api": {
+      "version": "4.28.0",
+      "resolved": "https://registry.npmjs.org/@duffel/api/-/api-4.28.0.tgz",
+      "integrity": "sha512-KhKYunG6r/8eD4GFp3dIHYB2bMWAlvB2/8qrKwlLBm0sZKWSg1VsC5CFy9TAt5XuaWUQ01+pjUfYpOAGh7Z+QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "18.0.0",
+        "@types/node-fetch": "2.6.13",
+        "node-fetch": "2.7.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@duffel/api/node_modules/@types/node": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.4.tgz",
+      "integrity": "sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@nitrostack/cli": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@nitrostack/cli/-/cli-1.0.14.tgz",
+      "integrity": "sha512-aZf+59ybqFVU+YtOagnCywpIY+kENkRgsRh5HgOC2d2iRiCxfdAyEf+ookQekpR9JxSNtr0GRwhkc8yA/lAhTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "chokidar": "^3.6.0",
+        "commander": "^12.1.0",
+        "esbuild": "^0.24.0",
+        "fs-extra": "^11.3.2",
+        "inquirer": "^9.3.7",
+        "open": "^10.1.0",
+        "ora": "^8.1.1",
+        "posthog-node": "^5.21.2"
+      },
+      "bin": {
+        "cli": "dist/index.js",
+        "nitrostack-cli": "dist/index.js"
+      }
+    },
+    "node_modules/@nitrostack/core": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@nitrostack/core/-/core-1.0.13.tgz",
+      "integrity": "sha512-cmQqqioxvhvOmASlAAwzFMnFWDcvlrEP47v455UraeZqhrZvm8Jr7ePo2GtpSir4t7OA6uIKhRpVb5XeLDjM5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.4",
+        "bcryptjs": "^2.4.3",
+        "cors": "^2.8.5",
+        "dotenv": "^17.2.3",
+        "express": "^4.21.2",
+        "jose": "^6.1.0",
+        "jsonwebtoken": "^9.0.2",
+        "reflect-metadata": "^0.2.1",
+        "uuid": "^11.0.5",
+        "winston": "^3.17.0",
+        "ws": "^8.18.3",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/@nitrostack/core/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/@nitrostack/core/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/@nitrostack/core/node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.43.1.tgz",
+      "integrity": "sha512-hGM8f5sp3we6Em/RQHXbmyYm554hUx9+9jhf92ZQgDS4/xW72KHyZiO9wcFye+qAx2cJAOhOCDIznmO1FV8IbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.396.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.397.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.397.0.tgz",
+      "integrity": "sha512-Pa7FtsBo3V0XrhY4y8Xquwp8U07syuZ2IGQdlsRyxhz0yejQLceFjI58UssCXE5zDCDj3km5l7H3ufD6rHChCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/inquirer": {
+      "version": "9.3.8",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.8.tgz",
+      "integrity": "sha512-pFGGdaHrmRKMh4WoDDSowddgjT1Vkl90atobmTeSmcPGdYiwikch/m/Ef5wRaiamHejtw0cUUMMerzDUXCci2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/external-editor": "^1.0.2",
+        "@inquirer/figures": "^1.0.3",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "1.0.0",
+        "ora": "^5.4.1",
+        "run-async": "^3.0.0",
+        "rxjs": "^7.8.1",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.45.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.45.2.tgz",
+      "integrity": "sha512-QhHw/xL0ntMG/DzqA/qdiKu8JY8ChK5Obm8m1nMJor5sjJ7+pfVJSx1yAynC7iUAJfJ9V+OhBNhDCyi5IFWC0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.43.1"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/sample-apps/concord-governance-agent/package.json
+++ b/sample-apps/concord-governance-agent/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "my-mcp-server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "my-mcp-server MCP server",
+  "scripts": {
+    "dev": "nitrostack-cli dev",
+    "build": "nitrostack-cli build",
+    "start": "npm run build && nitrostack-cli start",
+    "start:prod": "nitrostack-cli start",
+    "upgrade": "nitrostack-cli upgrade",
+    "install:all": "nitrostack-cli install",
+    "widget": "npm --prefix src/widgets"
+  },
+  "dependencies": {
+    "@nitrostack/core": "^1.0.13",
+    "zod": "^3.22.4",
+    "dotenv": "^16.3.1",
+    "@duffel/api": "^4.21.0",
+    "axios": "^1.7.9",
+    "date-fns": "^4.1.0",
+    "@modelcontextprotocol/ext-apps": ">=0.1.0"
+  },
+  "devDependencies": {
+    "@nitrostack/cli": "^1.0.14",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.3.3"
+  },
+  "author": "NitroStudio",
+  "nitrostack": {
+    "skillsVersion": "1.0.0"
+  }
+}

--- a/sample-apps/concord-governance-agent/src/app.module.ts
+++ b/sample-apps/concord-governance-agent/src/app.module.ts
@@ -1,0 +1,26 @@
+import { McpApp, Module, ConfigModule } from '@nitrostack/core';
+import { ConcordModule } from './modules/concord/concord.module.js';
+import { SystemHealthCheck } from './health/system.health.js';
+
+@McpApp({
+  module: AppModule,
+  server: {
+    name: 'concord-governance-server',
+    version: '1.0.0'
+  },
+  logging: {
+    level: 'info'
+  }
+})
+@Module({
+  name: 'app',
+  description: 'Concord — cross-departmental governance agent (DevOps / SecOps / FinOps) with human-in-the-loop approval',
+  imports: [
+    ConfigModule.forRoot(),
+    ConcordModule
+  ],
+  providers: [
+    SystemHealthCheck
+  ]
+})
+export class AppModule {}

--- a/sample-apps/concord-governance-agent/src/guards/oauth.guard.ts
+++ b/sample-apps/concord-governance-agent/src/guards/oauth.guard.ts
@@ -1,0 +1,145 @@
+import { Guard, ExecutionContext, OAuthModule, OAuthTokenPayload } from '@nitrostack/core';
+
+/**
+ * OAuth Guard
+ * 
+ * Validates OAuth 2.1 access tokens according to MCP specification.
+ * 
+ * Performs:
+ * - Token validation (introspection or JWT validation)
+ * - Audience binding (RFC 8707) - CRITICAL for security
+ * - Scope validation
+ * - Expiration checking
+ * 
+ * Compatible with:
+ * - OpenAI Apps SDK
+ * - Any RFC-compliant OAuth 2.1 provider
+ * 
+ * Usage:
+ * ```typescript
+ * @Tool({
+ *   name: 'protected_resource',
+ *   description: 'A protected tool'
+ * })
+ * @UseGuards(OAuthGuard)
+ * async protectedTool() {
+ *   // Only accessible with valid OAuth token
+ * }
+ * ```
+ */
+export class OAuthGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Extract token from metadata (sent by Studio or OAuth client)
+    const authHeader = context.metadata?.authorization as string;
+    const metaToken = context.metadata?._oauth || context.metadata?.token;
+    
+    let token: string | null = null;
+    
+    // Try Bearer token format first
+    if (authHeader?.startsWith('Bearer ')) {
+      token = authHeader.substring(7);
+    } else if (metaToken) {
+      token = metaToken as string;
+    }
+
+    // Enforcement gate: when OAuth is not required (OAUTH_REQUIRED not "true"),
+    // do not reject. Best-effort: if a valid token happens to be present, attach
+    // its identity; otherwise allow the request through unauthenticated.
+    if (!OAuthModule.isAuthRequired()) {
+      if (token) {
+        const result = await OAuthModule.validateToken(token);
+        if (result.valid) {
+          const payload = result.payload as OAuthTokenPayload;
+          context.auth = {
+            subject: payload.sub,
+            scopes: this.extractScopes(payload),
+            clientId: payload.client_id,
+            tokenPayload: payload,
+          };
+        }
+      }
+      return true;
+    }
+    
+    if (!token) {
+      throw new Error(
+        'OAuth token required. Please authenticate in Studio (Auth → OAuth 2.1 tab) ' +
+        'or provide token in Authorization header: "Bearer <token>"'
+      );
+    }
+    
+    // Validate token using OAuthModule
+    const result = await OAuthModule.validateToken(token);
+    
+    if (!result.valid) {
+      throw new Error(`OAuth token validation failed: ${result.error}`);
+    }
+    
+    // Extract scopes from token payload
+    const payload = result.payload as OAuthTokenPayload;
+    const scopes = this.extractScopes(payload);
+    
+    // Populate context.auth with OAuth token information
+    context.auth = {
+      subject: payload.sub,
+      scopes: scopes,
+      clientId: payload.client_id,
+      tokenPayload: payload,
+    };
+    
+    return true;
+  }
+  
+  /**
+   * Extract scopes from token payload
+   * Handles both "scope" (space-separated string) and "scopes" (array) formats
+   */
+  private extractScopes(payload: OAuthTokenPayload): string[] {
+    if (payload.scopes && Array.isArray(payload.scopes)) {
+      return payload.scopes;
+    }
+    
+    if (payload.scope && typeof payload.scope === 'string') {
+      return payload.scope.split(' ').filter(s => s.length > 0);
+    }
+    
+    return [];
+  }
+}
+
+/**
+ * Scope Guard
+ * 
+ * Validates that the OAuth token has required scopes.
+ * Use this in addition to OAuthGuard for fine-grained access control.
+ * 
+ * Usage:
+ * ```typescript
+ * @Tool({ name: 'admin_action' })
+ * @UseGuards(OAuthGuard, createScopeGuard(['admin', 'write']))
+ * async adminAction() {
+ *   // Requires OAuth token with 'admin' AND 'write' scopes
+ * }
+ * ```
+ */
+export function createScopeGuard(requiredScopes: string[]): new () => Guard {
+  return class ScopeGuard implements Guard {
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+      const userScopes = context.auth?.scopes || [];
+      
+      const missingScopes = requiredScopes.filter(
+        scope => !userScopes.includes(scope)
+      );
+      
+      if (missingScopes.length > 0) {
+        throw new Error(
+          `Insufficient scope. Required: ${requiredScopes.join(', ')}. ` +
+          `Missing: ${missingScopes.join(', ')}`
+        );
+      }
+      
+      return true;
+    }
+  };
+}
+

--- a/sample-apps/concord-governance-agent/src/health/system.health.ts
+++ b/sample-apps/concord-governance-agent/src/health/system.health.ts
@@ -1,0 +1,55 @@
+import { HealthCheck, HealthCheckInterface, HealthCheckResult } from '@nitrostack/core';
+
+/**
+ * System Health Check
+ * 
+ * Monitors system resources and uptime
+ */
+@HealthCheck({ 
+  name: 'system', 
+  description: 'System resource and uptime check',
+  interval: 30 // Check every 30 seconds
+})
+export class SystemHealthCheck implements HealthCheckInterface {
+  private startTime: number;
+
+  constructor() {
+    this.startTime = Date.now();
+  }
+
+  async check(): Promise<HealthCheckResult> {
+    try {
+      const memoryUsage = process.memoryUsage();
+      const uptime = Date.now() - this.startTime;
+      const uptimeSeconds = Math.floor(uptime / 1000);
+      
+      // Convert memory to MB
+      const memoryUsedMB = Math.round(memoryUsage.heapUsed / 1024 / 1024);
+      const memoryTotalMB = Math.round(memoryUsage.heapTotal / 1024 / 1024);
+      
+      // Consider unhealthy if memory usage is > 90%
+      const memoryPercent = (memoryUsage.heapUsed / memoryUsage.heapTotal) * 100;
+      const isHealthy = memoryPercent < 90;
+      
+      return {
+        status: isHealthy ? 'up' : 'degraded',
+        message: isHealthy 
+          ? 'System is healthy' 
+          : 'High memory usage detected',
+        details: {
+          uptime: `${uptimeSeconds}s`,
+          memory: `${memoryUsedMB}MB / ${memoryTotalMB}MB (${Math.round(memoryPercent)}%)`,
+          pid: process.pid,
+          nodeVersion: process.version,
+        },
+      };
+    } catch (error: any) {
+      return {
+        status: 'down',
+        message: 'System health check failed',
+        details: error.message,
+      };
+    }
+  }
+}
+

--- a/sample-apps/concord-governance-agent/src/index.ts
+++ b/sample-apps/concord-governance-agent/src/index.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Calculator MCP Server with OAuth 2.1 Authentication
+ * 
+ * Main entry point for the MCP server.
+ * Uses the @McpApp decorator pattern for clean, NestJS-style architecture.
+ * 
+ * OAuth 2.1 Compliance:
+ * - MCP Specification: https://modelcontextprotocol.io/specification/draft/basic/authorization
+ * - OpenAI Apps SDK: https://developers.openai.com/apps-sdk/build/auth
+ * - RFC 9728 - Protected Resource Metadata
+ * - RFC 8707 - Resource Indicators (Token Audience Binding)
+ * 
+ * Transport Configuration:
+ * - Development (NODE_ENV=development): STDIO only
+ * - Production (NODE_ENV=production): Dual transport (STDIO + HTTP SSE)
+ * - With OAuth: Dual mode (STDIO + HTTP for metadata endpoints)
+ */
+
+import 'dotenv/config';
+import { McpApplicationFactory } from '@nitrostack/core';
+import { AppModule } from './app.module.js';
+
+/**
+ * Bootstrap the application
+ */
+async function bootstrap() {
+  try {
+    console.error('🔐 Starting Calculator MCP Server with OAuth 2.1...\\n');
+
+    // Validate required environment variables for OAuth, set defaults if missing
+    if (!process.env.RESOURCE_URI || !process.env.AUTH_SERVER_URL) {
+      console.error('⚠️  Warning: Missing RESOURCE_URI or AUTH_SERVER_URL environment variables.');
+      console.error('   Defaulting to local test endpoints. Copy .env.example to .env to configure.\n');
+      process.env.RESOURCE_URI = process.env.RESOURCE_URI || 'http://localhost:3000';
+      process.env.AUTH_SERVER_URL = process.env.AUTH_SERVER_URL || 'http://localhost:8080/auth';
+    }
+
+    // Create the MCP application
+    const server = await McpApplicationFactory.create(AppModule);
+
+    const authEnforced = process.env.OAUTH_REQUIRED === 'true';
+    console.error('✅ OAuth 2.1 Module configured');
+    console.error(`   Resource URI: ${process.env.RESOURCE_URI}`);
+    console.error(`   Auth Server: ${process.env.AUTH_SERVER_URL}`);
+    console.error(`   Scopes: read, write, admin`);
+    console.error(`   Audience: ${process.env.TOKEN_AUDIENCE || process.env.RESOURCE_URI}`);
+    console.error(`   Enforcement: ${authEnforced ? 'ON (OAUTH_REQUIRED=true)' : 'OFF (dev mode — set OAUTH_REQUIRED=true to enforce)'}\\n`);
+
+    // Start the server
+    await server.start();
+
+  } catch (error) {
+    console.error('❌ Failed to start server:', error);
+    console.error('\\n💡 Check your OAuth configuration in .env\\n');
+    process.exit(1);
+  }
+}
+
+// Start the application
+bootstrap();

--- a/sample-apps/concord-governance-agent/src/modules/concord/aiops/rca-engine.ts
+++ b/sample-apps/concord-governance-agent/src/modules/concord/aiops/rca-engine.ts
@@ -1,0 +1,95 @@
+import { AppState, Threat } from '../../../state/state.js';
+
+export interface RcaChainStep {
+  node: string;
+  event: string;
+  severity: string;
+}
+
+export interface RcaResult {
+  chain: RcaChainStep[];
+  root_cause: string;
+  recommended_action: string;
+}
+
+const FALLBACK_CHAINS: Record<string, (node: string) => RcaChainStep[]> = {
+  low: (node) => [
+    { node, event: 'Unpatched dependency detected', severity: 'low' },
+    { node: 'API Gateway', event: 'Elevated error rate on dependent endpoints', severity: 'medium' },
+    { node: 'Monitoring', event: 'SLA window at risk — anomaly alert triggered', severity: 'medium' }
+  ],
+  medium: (node) => [
+    { node, event: 'Malicious payload detected', severity: 'medium' },
+    { node: 'Service Mesh', event: 'Lateral movement attempt — mTLS blocking', severity: 'high' },
+    { node: 'Auth Service', event: 'Token validation error spike', severity: 'high' },
+    { node: 'API Gateway', event: '5xx responses rising — user impact imminent', severity: 'high' }
+  ],
+  high: (node) => [
+    { node, event: 'Active exploit executing', severity: 'high' },
+    { node: 'Service Mesh', event: 'East-west traffic anomaly — possible data exfiltration', severity: 'critical' },
+    { node: 'Database Layer', event: 'Unauthorized read queries from compromised node', severity: 'critical' },
+    { node: 'Perimeter', event: 'Egress to unknown IP — C2 callback suspected', severity: 'critical' }
+  ],
+  critical: (node) => [
+    { node, event: 'Ransomware payload executing', severity: 'critical' },
+    { node: 'Storage Layer', event: 'File encryption in progress — backups at risk', severity: 'critical' },
+    { node: 'Service Mesh', event: 'All outbound traffic rerouted through malicious proxy', severity: 'critical' },
+    { node: 'Recovery Systems', event: 'Backup access attempted — RTO/RPO objectives threatened', severity: 'critical' }
+  ]
+};
+
+function buildFallbackRCA(threat: Threat): RcaResult {
+  const fn = FALLBACK_CHAINS[threat.severity] || FALLBACK_CHAINS.medium;
+  return {
+    chain: fn(threat.affected_node),
+    root_cause: `${threat.description} on ${threat.affected_node} — triggered by unresolved CVE in the dependency chain`,
+    recommended_action: `isolate_compromised_node:${threat.affected_node}`
+  };
+}
+
+export async function generateRCA(threat: Threat, state: AppState): Promise<RcaResult> {
+  const apiKey = process.env.GROQ_API_KEY;
+  const model = process.env.GROQ_MODEL || 'llama-3.3-70b-versatile';
+  if (!apiKey) return buildFallbackRCA(threat);
+
+  const clusters = state.devops.clusters.map(c => `${c.id}:${c.status}`).join(', ');
+  const otherThreats = state.secops.threats.filter(t => t.id !== threat.id).map(t => `${t.id}(${t.severity})`).join(', ') || 'none';
+
+  const prompt = `You are an AIOps root cause analysis engine for a cloud infrastructure governance platform.
+
+Incident:
+- Threat ID: ${threat.id}
+- Severity: ${threat.severity}
+- Description: ${threat.description}
+- Affected node: ${threat.affected_node}
+- Cluster states: ${clusters}
+- Other active threats: ${otherThreats}
+
+Return ONLY a JSON object (no other text) showing the causality chain:
+{
+  "chain": [
+    { "node": "node_name", "event": "what happened here", "severity": "critical|high|medium|low" }
+  ],
+  "root_cause": "One sentence root cause",
+  "recommended_action": "governance action to take"
+}
+
+Include 3-4 chain steps showing how the failure propagated through the system.`;
+
+  try {
+    const res = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ model, messages: [{ role: 'user', content: prompt }], max_tokens: 400, temperature: 0.3 })
+    });
+    const data: any = await res.json();
+    const content = data.choices?.[0]?.message?.content?.trim();
+    if (!content) throw new Error('empty response');
+    const match = content.match(/\{[\s\S]*\}/);
+    if (!match) throw new Error('no JSON in response');
+    return JSON.parse(match[0]);
+  } catch (err: any) {
+    console.error('[rca] Groq call failed, using fallback:', err.message);
+    return buildFallbackRCA(threat);
+  }
+}

--- a/sample-apps/concord-governance-agent/src/modules/concord/audit/hash-chain.ts
+++ b/sample-apps/concord-governance-agent/src/modules/concord/audit/hash-chain.ts
@@ -1,0 +1,60 @@
+import { createHash } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const AUDIT_FILE = path.join(process.cwd(), 'audit-chain.jsonl');
+
+export interface AuditEntry {
+  tool: string;
+  params: Record<string, unknown>;
+  decision: string;
+  conflict: unknown;
+  role: string;
+  ts: string;
+  prev_hash?: string;
+  hash?: string;
+}
+
+function computeHash(entry: Omit<AuditEntry, 'hash'>, prevHash: string): string {
+  const payload = JSON.stringify({ ...entry, prev_hash: prevHash });
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+function readAllEntries(): AuditEntry[] {
+  if (!fs.existsSync(AUDIT_FILE)) return [];
+  const lines = fs.readFileSync(AUDIT_FILE, 'utf8').trim().split('\n').filter(Boolean);
+  return lines.map(l => JSON.parse(l));
+}
+
+export function writeAuditEntry(entryData: Omit<AuditEntry, 'hash' | 'prev_hash'>): AuditEntry {
+  const entries = readAllEntries();
+  const last = entries[entries.length - 1];
+  const prevHash = last?.hash ?? '0'.repeat(64);
+  const hash = computeHash(entryData, prevHash);
+  const fullEntry: AuditEntry = { ...entryData, prev_hash: prevHash, hash };
+  fs.appendFileSync(AUDIT_FILE, JSON.stringify(fullEntry) + '\n');
+  return fullEntry;
+}
+
+export function getAuditHistory(limit = 100): AuditEntry[] {
+  return readAllEntries().reverse().slice(0, limit);
+}
+
+export function verifyChain(): { valid: boolean; count: number; broken_at?: string } {
+  const entries = readAllEntries();
+  if (entries.length === 0) return { valid: true, count: 0 };
+
+  let prevHash = '0'.repeat(64);
+  for (const entry of entries) {
+    if (entry.prev_hash !== prevHash) {
+      return { valid: false, broken_at: entry.ts, count: entries.length };
+    }
+    const { hash, prev_hash, ...data } = entry;
+    const recomputed = computeHash(data, prevHash);
+    if (recomputed !== hash) {
+      return { valid: false, broken_at: entry.ts, count: entries.length };
+    }
+    prevHash = hash!;
+  }
+  return { valid: true, count: entries.length };
+}

--- a/sample-apps/concord-governance-agent/src/modules/concord/canary-engine.ts
+++ b/sample-apps/concord-governance-agent/src/modules/concord/canary-engine.ts
@@ -1,0 +1,65 @@
+import { getState, updateDeployment, removeDeployment } from '../../state/state.js';
+
+const TRAFFIC_STEPS = [10, 25, 50, 75, 100];
+const STEP_INTERVAL = 8000; // 8 seconds per step
+const activeTimers = new Map<string, NodeJS.Timeout>();
+
+function simulateMetrics() {
+  const spike = Math.random() < 0.10;
+  return {
+    error_rate: spike ? 2.5 + Math.random() * 3 : Math.random() * 1.0,
+    latency_p99: spike ? 850 + Math.random() * 300 : 150 + Math.random() * 350
+  };
+}
+
+export function startCanary(deploymentId: string) {
+  let stepIndex = 0;
+
+  const tick = () => {
+    const state = getState();
+    const dep = state.devops.deployments.find(d => d.id === deploymentId);
+    if (!dep || dep.status !== 'active') {
+      activeTimers.delete(deploymentId);
+      return;
+    }
+
+    const metrics = simulateMetrics();
+    const shouldRollback = metrics.error_rate > 2.0 || metrics.latency_p99 > 800;
+
+    if (shouldRollback) {
+      updateDeployment(deploymentId, { status: 'rolled_back', traffic_pct: 0, metrics });
+      activeTimers.delete(deploymentId);
+      setTimeout(() => removeDeployment(deploymentId), 12000);
+      return;
+    }
+
+    const newTrafficPct = TRAFFIC_STEPS[stepIndex] ?? 100;
+    stepIndex++;
+    const isComplete = stepIndex >= TRAFFIC_STEPS.length;
+
+    updateDeployment(deploymentId, {
+      traffic_pct: newTrafficPct,
+      metrics,
+      phase: `Step ${stepIndex}/${TRAFFIC_STEPS.length}`,
+      status: isComplete ? 'complete' : 'active'
+    });
+
+    if (isComplete) {
+      activeTimers.delete(deploymentId);
+      setTimeout(() => removeDeployment(deploymentId), 15000);
+    } else {
+      const timerId = setTimeout(tick, STEP_INTERVAL);
+      activeTimers.set(deploymentId, timerId);
+    }
+  };
+
+  const timerId = setTimeout(tick, STEP_INTERVAL);
+  activeTimers.set(deploymentId, timerId);
+}
+
+export function stopCanary(deploymentId: string) {
+  if (activeTimers.has(deploymentId)) {
+    clearTimeout(activeTimers.get(deploymentId));
+    activeTimers.delete(deploymentId);
+  }
+}

--- a/sample-apps/concord-governance-agent/src/modules/concord/concord.module.ts
+++ b/sample-apps/concord-governance-agent/src/modules/concord/concord.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nitrostack/core';
+import { ConcordTools } from './concord.tools.js';
+import { ConcordResources } from './concord.resources.js';
+import { ConcordPrompts } from './concord.prompts.js';
+
+@Module({
+  name: 'concord',
+  description: 'Cross-departmental governance agent — DevOps, SecOps, and FinOps with human-in-the-loop approval for high-risk actions.',
+  controllers: [ConcordTools, ConcordResources, ConcordPrompts]
+})
+export class ConcordModule {}

--- a/sample-apps/concord-governance-agent/src/modules/concord/concord.prompts.ts
+++ b/sample-apps/concord-governance-agent/src/modules/concord/concord.prompts.ts
@@ -1,0 +1,43 @@
+import { PromptDecorator as Prompt, ExecutionContext } from '@nitrostack/core';
+import { getState } from '../../state/state.js';
+
+export class ConcordPrompts {
+  @Prompt({
+    name: 'incident_briefing_template',
+    description: 'Generates a structured governance briefing for a proposed high-risk action, including cross-domain context and any detected conflicts.',
+    arguments: [
+      { name: 'role',        description: 'IAM role of the requester',            required: true  },
+      { name: 'tool_name',   description: 'Name of the high-risk tool proposed',  required: true  },
+      { name: 'params',      description: 'JSON-encoded parameters for the tool', required: true  },
+      { name: 'conflict',    description: 'JSON-encoded conflict object or null', required: false }
+    ]
+  })
+  async incidentBriefing(args: { role: string; tool_name: string; params: string; conflict?: string }, ctx: ExecutionContext) {
+    const params  = JSON.parse(args.params  || '{}');
+    const conflict = args.conflict ? JSON.parse(args.conflict) : null;
+    const state   = getState();
+
+    const devopsSummary = state.devops.clusters.map(c => `${c.id}: ${c.status}`).join(', ');
+    const secSummary    = state.secops.threats.map(t => `${t.id}(${t.severity})`).join(', ') || 'none';
+    const finSummary    = state.finops.ledgers.map(l => `${l.department}: ₹${l.budget.toLocaleString()}`).join(', ');
+
+    let briefing = `Requested by: ${args.role}\nAction: ${args.tool_name}(${JSON.stringify(params)})\n\n`;
+    briefing    += `Relevant state:\n`;
+    briefing    += `- DevOps clusters: ${devopsSummary}\n`;
+    briefing    += `- SecOps threats: ${secSummary}\n`;
+    briefing    += `- FinOps budgets: ${finSummary}\n`;
+
+    if (conflict?.has_conflict) {
+      briefing += `\n⚠️  Conflict detected: ${conflict.message}`;
+    }
+
+    return {
+      messages: [
+        {
+          role: 'user' as const,
+          content: `You are Concord, a cross-departmental governance agent. Review this proposed action and provide your assessment:\n\n${briefing}`
+        }
+      ]
+    };
+  }
+}

--- a/sample-apps/concord-governance-agent/src/modules/concord/concord.resources.ts
+++ b/sample-apps/concord-governance-agent/src/modules/concord/concord.resources.ts
@@ -1,0 +1,89 @@
+import { ResourceDecorator as Resource, ExecutionContext } from '@nitrostack/core';
+import { getDevops, getSecops, getFinops, getIam, getState } from '../../state/state.js';
+
+export class ConcordResources {
+  @Resource({
+    uri: 'devops://kubernetes/live-clusters.json',
+    name: 'Live Kubernetes Clusters',
+    description: 'Real-time status of all production Kubernetes clusters including deployment queues and active services.',
+    mimeType: 'application/json'
+  })
+  async getLiveClusters(ctx: ExecutionContext) {
+    const data = getDevops();
+    return {
+      contents: [{
+        uri: 'devops://kubernetes/live-clusters.json',
+        mimeType: 'application/json',
+        text: JSON.stringify(data, null, 2)
+      }]
+    };
+  }
+
+  @Resource({
+    uri: 'secops://network/threat-intel.json',
+    name: 'Network Threat Intelligence',
+    description: 'Active threat signals, severity levels, and affected nodes from the security operations center.',
+    mimeType: 'application/json'
+  })
+  async getThreatIntel(ctx: ExecutionContext) {
+    const data = getSecops();
+    return {
+      contents: [{
+        uri: 'secops://network/threat-intel.json',
+        mimeType: 'application/json',
+        text: JSON.stringify(data, null, 2)
+      }]
+    };
+  }
+
+  @Resource({
+    uri: 'finops://erp/department-ledgers.json',
+    name: 'Department Financial Ledgers',
+    description: 'Budget allocations, burn rates, reserve floors, and active customer contracts across all departments.',
+    mimeType: 'application/json'
+  })
+  async getDepartmentLedgers(ctx: ExecutionContext) {
+    const data = getFinops();
+    return {
+      contents: [{
+        uri: 'finops://erp/department-ledgers.json',
+        mimeType: 'application/json',
+        text: JSON.stringify(data, null, 2)
+      }]
+    };
+  }
+
+  @Resource({
+    uri: 'iam://directory/active-session.json',
+    name: 'Active IAM Session',
+    description: 'Currently authenticated user role and identity for authorization checks.',
+    mimeType: 'application/json'
+  })
+  async getActiveSession(ctx: ExecutionContext) {
+    const data = getIam();
+    return {
+      contents: [{
+        uri: 'iam://directory/active-session.json',
+        mimeType: 'application/json',
+        text: JSON.stringify(data, null, 2)
+      }]
+    };
+  }
+
+  @Resource({
+    uri: 'weather://live-risk.json',
+    name: 'Weather Risk Signal',
+    description: 'Live weather risk signal for the Chennai data centre region. Elevated risk (thunderstorm / high wind) affects operational decisions for PROD-01.',
+    mimeType: 'application/json'
+  })
+  async getWeatherRisk(ctx: ExecutionContext) {
+    const data = getState().weather;
+    return {
+      contents: [{
+        uri: 'weather://live-risk.json',
+        mimeType: 'application/json',
+        text: JSON.stringify(data, null, 2)
+      }]
+    };
+  }
+}

--- a/sample-apps/concord-governance-agent/src/modules/concord/concord.tools.ts
+++ b/sample-apps/concord-governance-agent/src/modules/concord/concord.tools.ts
@@ -1,0 +1,399 @@
+import { ToolDecorator as Tool, Widget, ExecutionContext, z } from '@nitrostack/core';
+import {
+  getState, getIam,
+  haltCluster, reallocateCapital, prioritizeBranch, isolateNode,
+  addPendingAction, removePendingAction, getPendingAction,
+  addDeployment, updateDeployment,
+  PendingAction, ConflictResult
+} from '../../state/state.js';
+import { runConflictCheck, listRules } from './rules/rule-registry.js';
+import './rules/governance-rules.js'; // side-effect: registers all rules
+import { estimateCost, formatCostSection } from './finops/cost-estimator.js';
+import { generateRCA } from './aiops/rca-engine.js';
+import { startCanary } from './canary-engine.js';
+import { writeAuditEntry, getAuditHistory, verifyChain } from './audit/hash-chain.js';
+
+const CLUSTER_IDS = ['PROD-01', 'PROD-02', 'STAGING-01', 'PROD-03', 'EU-WEST-01'] as const;
+
+function buildBriefing(toolName: string, params: Record<string, unknown>, conflict: ConflictResult | null): string {
+  const role = getIam().active_session.role;
+  const state = getState();
+  let text = `Requested by: ${role}\nAction: ${toolName}(${JSON.stringify(params)})\n`;
+  if (conflict?.has_conflict) {
+    text += `\n⚠️  Conflict detected: ${conflict.message}`;
+  }
+  const cost = estimateCost(toolName, params, state);
+  text += formatCostSection(cost);
+  return text;
+}
+
+function makePendingAction(toolName: string, params: Record<string, unknown>, conflict: ConflictResult | null): PendingAction {
+  return {
+    id: `action-${Date.now()}`,
+    tool_name: toolName,
+    params,
+    briefing_text: buildBriefing(toolName, params, conflict),
+    conflict,
+    timestamp: new Date().toISOString()
+  };
+}
+
+export class ConcordTools {
+  // ── High-risk tools ─────────────────────────────────────────────────────────
+
+  @Tool({
+    name: 'halt_deployment_pipeline',
+    description: 'Halts a CI/CD deployment pipeline for a given cluster. HIGH RISK — queued for human approval. Always read finops://erp/department-ledgers.json first to check for active contracts on this cluster.',
+    inputSchema: z.object({
+      cluster_id:    z.enum(CLUSTER_IDS).describe('Target cluster'),
+      severity_flag: z.enum(['low', 'medium', 'critical']).describe('Reason severity')
+    })
+  })
+  async haltDeploymentPipeline(input: { cluster_id: string; severity_flag: string }, ctx: ExecutionContext) {
+    const conflict = await runConflictCheck('halt_deployment_pipeline', input, getState());
+    const action = makePendingAction('halt_deployment_pipeline', input as Record<string, unknown>, conflict);
+    addPendingAction(action);
+
+    ctx.logger.info('halt_deployment_pipeline queued for approval', { id: action.id, conflict: !!conflict });
+
+    return {
+      status: 'pending_approval',
+      action_id: action.id,
+      briefing: action.briefing_text,
+      conflict: action.conflict,
+      message: `Action queued. Call approve_action("${action.id}") to execute or deny_action("${action.id}") to cancel.`
+    };
+  }
+
+  @Tool({
+    name: 'reallocate_capital',
+    description: 'Shifts budget between department ledgers. HIGH RISK — queued for human approval. Check the source department floor before proposing.',
+    inputSchema: z.object({
+      source_dept:   z.enum(['Engineering', 'Security', 'UI/Design']).describe('Source department'),
+      target_dept:   z.enum(['Engineering', 'Security', 'UI/Design']).describe('Target department'),
+      amount:        z.number().min(0).describe('Amount in INR to transfer'),
+      justification: z.string().min(10).describe('Business justification')
+    })
+  })
+  async reallocateCapital(input: { source_dept: string; target_dept: string; amount: number; justification: string }, ctx: ExecutionContext) {
+    const conflict = await runConflictCheck('reallocate_capital', input, getState());
+    const action = makePendingAction('reallocate_capital', input as Record<string, unknown>, conflict);
+    addPendingAction(action);
+
+    ctx.logger.info('reallocate_capital queued for approval', { id: action.id, conflict: !!conflict });
+
+    return {
+      status: 'pending_approval',
+      action_id: action.id,
+      briefing: action.briefing_text,
+      conflict: action.conflict,
+      message: `Action queued. Call approve_action("${action.id}") to execute or deny_action("${action.id}") to cancel.`
+    };
+  }
+
+  @Tool({
+    name: 'prioritize_engineering_branch',
+    description: 'Escalates a codebase branch for immediate compute priority and human review. HIGH RISK — queued for human approval.',
+    inputSchema: z.object({
+      branch_id:     z.string().describe('Git branch identifier'),
+      urgency_level: z.enum(['normal', 'high', 'critical']).describe('Escalation urgency')
+    })
+  })
+  async prioritizeEngineeringBranch(input: { branch_id: string; urgency_level: string }, ctx: ExecutionContext) {
+    const conflict = await runConflictCheck('prioritize_engineering_branch', input, getState());
+    const action = makePendingAction('prioritize_engineering_branch', input as Record<string, unknown>, conflict);
+    addPendingAction(action);
+
+    return {
+      status: 'pending_approval',
+      action_id: action.id,
+      briefing: action.briefing_text,
+      conflict: action.conflict,
+      message: `Action queued. Call approve_action("${action.id}") to execute or deny_action("${action.id}") to cancel.`
+    };
+  }
+
+  @Tool({
+    name: 'isolate_compromised_node',
+    description: 'Quarantines a network node suspected of compromise. HIGH RISK — queued for human approval. Confirm the node is not serving live traffic first.',
+    inputSchema: z.object({
+      node_id: z.string().describe('Node or cluster ID to isolate')
+    })
+  })
+  async isolateCompromisedNode(input: { node_id: string }, ctx: ExecutionContext) {
+    const conflict = await runConflictCheck('isolate_compromised_node', input, getState());
+    const action = makePendingAction('isolate_compromised_node', input as Record<string, unknown>, conflict);
+    addPendingAction(action);
+
+    return {
+      status: 'pending_approval',
+      action_id: action.id,
+      briefing: action.briefing_text,
+      conflict: action.conflict,
+      message: `Action queued. Call approve_action("${action.id}") to execute or deny_action("${action.id}") to cancel.`
+    };
+  }
+
+  @Tool({
+    name: 'deploy_canary',
+    description: 'Initiates a progressive canary deployment for a microservice using Argo Rollouts-style traffic splitting. HIGH RISK — queued for human approval. Automatically advances traffic from 10% → 100% in steps, with metric-driven auto-rollback if error_rate > 2% or latency_p99 > 800ms. Poll get_deployment_status to see progress.',
+    inputSchema: z.object({
+      service_id: z.string().describe('Service name to deploy (e.g. payments-service)'),
+      cluster_id: z.enum(CLUSTER_IDS).describe('Target cluster'),
+      image_tag:  z.string().describe('Docker image tag to deploy (e.g. v2.1.0)'),
+      strategy:   z.enum(['canary', 'blue_green']).default('canary').describe('Deployment strategy')
+    })
+  })
+  async deployCanary(input: { service_id: string; cluster_id: string; image_tag: string; strategy?: string }, ctx: ExecutionContext) {
+    const conflict = await runConflictCheck('deploy_canary', input, getState());
+    const action = makePendingAction('deploy_canary', input as Record<string, unknown>, conflict);
+    addPendingAction(action);
+
+    return {
+      status: 'pending_approval',
+      action_id: action.id,
+      briefing: action.briefing_text,
+      conflict: action.conflict,
+      message: `Action queued. Call approve_action("${action.id}") to execute or deny_action("${action.id}") to cancel.`
+    };
+  }
+
+  // ── Approval tools ───────────────────────────────────────────────────────────
+
+  @Tool({
+    name: 'approve_action',
+    description: 'Approve a queued high-risk action and execute it against live state. Use the action_id returned by the originating tool call.',
+    inputSchema: z.object({
+      action_id: z.string().describe('The action_id returned by the high-risk tool call')
+    })
+  })
+  async approveAction(input: { action_id: string }, ctx: ExecutionContext) {
+    const action = getPendingAction(input.action_id);
+    if (!action) return { status: 'error', message: `No pending action found with id ${input.action_id}` };
+
+    const { tool_name, params } = action;
+    let deploymentId: string | undefined;
+
+    switch (tool_name) {
+      case 'halt_deployment_pipeline':
+        haltCluster(params.cluster_id as string);
+        break;
+      case 'reallocate_capital':
+        reallocateCapital(params.source_dept as string, params.target_dept as string, params.amount as number);
+        break;
+      case 'prioritize_engineering_branch':
+        prioritizeBranch(params.branch_id as string, params.urgency_level as string);
+        break;
+      case 'isolate_compromised_node':
+        isolateNode(params.node_id as string);
+        break;
+      case 'deploy_canary':
+        deploymentId = `dep-${Date.now()}`;
+        addDeployment({
+          id: deploymentId,
+          service_id: params.service_id as string,
+          cluster_id: params.cluster_id as string,
+          image_tag: params.image_tag as string,
+          strategy: (params.strategy as string) || 'canary',
+          traffic_pct: 0,
+          phase: 'Starting',
+          metrics: { error_rate: 0, latency_p99: 0 },
+          status: 'active',
+          started_at: new Date().toISOString()
+        });
+        startCanary(deploymentId);
+        break;
+    }
+
+    removePendingAction(input.action_id);
+
+    const entry = writeAuditEntry({
+      tool: tool_name,
+      params,
+      decision: 'approved',
+      conflict: action.conflict,
+      role: getIam().active_session.role,
+      ts: new Date().toISOString()
+    });
+
+    ctx.logger.info('Action approved and executed', { action_id: input.action_id, tool: tool_name });
+
+    return {
+      status: 'executed',
+      tool: tool_name,
+      params,
+      deployment_id: deploymentId,
+      audit_hash: entry.hash,
+      message: `${tool_name} executed successfully. State has been updated.`
+    };
+  }
+
+  @Tool({
+    name: 'deny_action',
+    description: 'Deny and discard a queued high-risk action without executing it.',
+    inputSchema: z.object({
+      action_id: z.string().describe('The action_id to cancel'),
+      reason:    z.string().optional().describe('Optional reason for denial')
+    })
+  })
+  async denyAction(input: { action_id: string; reason?: string }, ctx: ExecutionContext) {
+    const action = getPendingAction(input.action_id);
+    if (!action) return { status: 'error', message: `No pending action found with id ${input.action_id}` };
+
+    removePendingAction(input.action_id);
+
+    const entry = writeAuditEntry({
+      tool: action.tool_name,
+      params: action.params,
+      decision: 'denied',
+      conflict: action.conflict,
+      role: getIam().active_session.role,
+      ts: new Date().toISOString()
+    });
+
+    ctx.logger.info('Action denied', { action_id: input.action_id, reason: input.reason });
+
+    return {
+      status: 'denied',
+      tool: action.tool_name,
+      reason: input.reason || 'No reason provided',
+      audit_hash: entry.hash,
+      message: `${action.tool_name} was denied and will not be executed.`
+    };
+  }
+
+  // ── State inspection ─────────────────────────────────────────────────────────
+
+  @Widget('governance-dashboard')
+  @Tool({
+    name: 'get_pending_actions',
+    description: 'List all actions currently queued for human approval.',
+    inputSchema: z.object({})
+  })
+  async getPendingActions(_input: Record<string, never>, ctx: ExecutionContext) {
+    const state = getState();
+    return {
+      pending_count: state.pending_actions.length,
+      actions: state.pending_actions.map(a => ({
+        id: a.id,
+        tool_name: a.tool_name,
+        has_conflict: a.conflict?.has_conflict ?? false,
+        timestamp: a.timestamp
+      }))
+    };
+  }
+
+  @Tool({
+    name: 'get_state_summary',
+    description: 'Returns a full cross-domain governance snapshot in one call: cluster health, active threats, isolated nodes, budget positions, contracts, deployments, pending actions count, and weather risk. Use this instead of calling all 5 resources individually when you need a complete situational overview.',
+    inputSchema: z.object({})
+  })
+  async getStateSummary(_input: Record<string, never>, ctx: ExecutionContext) {
+    const s = getState();
+    return {
+      clusters:          s.devops.clusters,
+      deployments:       s.devops.deployments,
+      prioritized_branches: s.devops.clusters.flatMap(c => c.prioritized_branches ?? []),
+      threats:           s.secops.threats,
+      isolated_nodes:    s.secops.isolated_nodes ?? [],
+      budgets:           s.finops.ledgers,
+      contracts:         s.finops.contracts,
+      weather_risk:      s.weather?.risk_signal ?? 'unknown',
+      weather_condition: s.weather?.condition ?? null,
+      pending_approvals: s.pending_actions.length,
+      active_role:       s.iam.active_session.role
+    };
+  }
+
+  @Tool({
+    name: 'get_deployment_status',
+    description: 'Returns all active/recent canary deployments and their live traffic-split progress and metrics. Poll this after approving a deploy_canary action to watch the rollout advance.',
+    inputSchema: z.object({})
+  })
+  async getDeploymentStatus(_input: Record<string, never>, ctx: ExecutionContext) {
+    const s = getState();
+    return { deployments: s.devops.deployments };
+  }
+
+  @Tool({
+    name: 'get_root_cause_analysis',
+    description: 'Generates an AIOps root-cause causality chain for an active threat, showing how the failure propagated through the system and a recommended remediation action.',
+    inputSchema: z.object({
+      threat_id: z.string().describe('The threat ID from get_state_summary or secops://network/threat-intel.json')
+    })
+  })
+  async getRootCauseAnalysis(input: { threat_id: string }, ctx: ExecutionContext) {
+    const state = getState();
+    const threat = state.secops.threats.find(t => t.id === input.threat_id);
+    if (!threat) return { status: 'error', message: `No threat found with id ${input.threat_id}` };
+
+    const rca = await generateRCA(threat, state);
+    return { status: 'ok', threat_id: input.threat_id, ...rca };
+  }
+
+  @Tool({
+    name: 'get_rules',
+    description: 'Lists the currently registered governance conflict-detection rules, in priority order.',
+    inputSchema: z.object({})
+  })
+  async getRules(_input: Record<string, never>, ctx: ExecutionContext) {
+    return { rules: listRules() };
+  }
+
+  @Tool({
+    name: 'simulate_incident',
+    description: 'Seeds a realistic incident scenario into state for demonstration purposes. Use this to quickly set up a compelling governance scenario from a clean state. incident_type: "ransomware" | "budget_crisis" | "deployment_conflict".',
+    inputSchema: z.object({
+      incident_type: z.enum(['ransomware', 'budget_crisis', 'deployment_conflict']).describe('The scenario to inject into state')
+    })
+  })
+  async simulateIncident(input: { incident_type: string }, ctx: ExecutionContext) {
+    const s = getState();
+    if (input.incident_type === 'ransomware') {
+      s.secops.threats.push({
+        id: 'THR-CRIT-01',
+        severity: 'critical',
+        description: 'Ransomware beacon detected on SEC-NODE-03. Lateral movement in progress.',
+        affected_node: 'SEC-NODE-03'
+      });
+      s.devops.clusters[0].queue_length += 5;
+      ctx.logger.info('Ransomware scenario seeded');
+      return { seeded: 'ransomware', message: 'Critical threat THR-CRIT-01 added to SecOps. SEC-NODE-03 at risk. PROD-01 queue pressure increased.' };
+    }
+    if (input.incident_type === 'budget_crisis') {
+      const eng = s.finops.ledgers.find(l => l.department === 'Engineering');
+      if (eng) { eng.budget = Math.max(eng.floor + 10000, eng.budget * 0.22); }
+      ctx.logger.info('Budget crisis scenario seeded');
+      return { seeded: 'budget_crisis', message: 'Engineering budget dropped to near-floor. Reallocations will now trigger conflicts.' };
+    }
+    if (input.incident_type === 'deployment_conflict') {
+      s.devops.clusters[0].queue_length = 12;
+      s.devops.clusters[0].active_deployments.push('billing-service-v2', 'auth-service-v3');
+      ctx.logger.info('Deployment conflict scenario seeded');
+      return { seeded: 'deployment_conflict', message: 'PROD-01 queue depth at 12, active deployments added. Halting now carries maximum disruption.' };
+    }
+    return { error: 'Unknown incident_type' };
+  }
+
+  @Tool({
+    name: 'get_audit_log',
+    description: 'Returns the last N entries from the tamper-evident hash-chained governance audit log — all approve/deny decisions made through the human-in-the-loop flow.',
+    inputSchema: z.object({
+      limit: z.number().min(1).max(100).default(20).optional().describe('Number of recent entries to return')
+    })
+  })
+  async getAuditLog(input: { limit?: number }, ctx: ExecutionContext) {
+    const limit = input.limit ?? 20;
+    const entries = getAuditHistory(limit);
+    return { entries, total: entries.length };
+  }
+
+  @Tool({
+    name: 'verify_audit_chain',
+    description: 'Recomputes the SHA-256 hash chain over the entire audit log and confirms no entry has been tampered with.',
+    inputSchema: z.object({})
+  })
+  async verifyAuditChain(_input: Record<string, never>, ctx: ExecutionContext) {
+    return verifyChain();
+  }
+}

--- a/sample-apps/concord-governance-agent/src/modules/concord/finops/cost-estimator.ts
+++ b/sample-apps/concord-governance-agent/src/modules/concord/finops/cost-estimator.ts
@@ -1,0 +1,69 @@
+import { AppState } from '../../../state/state.js';
+
+export interface CostEstimate {
+  hourly_impact_inr: number;
+  risk_label: string;
+  sla_exposure_inr?: number;
+  sla_customer?: string;
+  hours_remaining?: number;
+  rightsizing_savings_monthly?: number;
+  src_runway_months?: number;
+  tgt_runway_months?: number;
+  note?: string;
+}
+
+export function estimateCost(toolName: string, params: Record<string, any>, state: AppState): CostEstimate | null {
+  const { devops, secops, finops } = state;
+  const engLedger = finops.ledgers.find(l => l.department === 'Engineering');
+  const hourlyBurn = engLedger ? Math.round(engLedger.burn_rate / (30 * 24)) : 0;
+
+  if (toolName === 'halt_deployment_pipeline') {
+    const contract = finops.contracts.find(c => c.cluster_id === params.cluster_id);
+    const result: CostEstimate = { hourly_impact_inr: hourlyBurn, risk_label: 'HIGH' };
+    if (contract) {
+      result.sla_exposure_inr = contract.penalty_clause_inr;
+      result.sla_customer = contract.customer;
+      result.hours_remaining = Math.max(0, Math.round((new Date(contract.deadline).getTime() - Date.now()) / 3600000));
+    }
+    result.rightsizing_savings_monthly = Math.round(hourlyBurn * 24 * 30 * 0.40);
+    return result;
+  }
+
+  if (toolName === 'reallocate_capital') {
+    const src = finops.ledgers.find(l => l.department === params.source_dept);
+    const tgt = finops.ledgers.find(l => l.department === params.target_dept);
+    const srcRunway = src ? Math.floor((src.budget - params.amount - src.floor) / src.burn_rate) : 0;
+    const tgtRunway = tgt ? Math.floor((tgt.budget + params.amount - tgt.floor) / tgt.burn_rate) : 0;
+    return { hourly_impact_inr: 0, src_runway_months: srcRunway, tgt_runway_months: tgtRunway, risk_label: srcRunway < 3 ? 'HIGH' : 'MEDIUM' };
+  }
+
+  if (toolName === 'deploy_canary') {
+    return { hourly_impact_inr: Math.round(hourlyBurn * 0.15), risk_label: 'LOW', note: 'Canary overhead ~15% during progressive rollout (~8 min)' };
+  }
+
+  if (toolName === 'isolate_compromised_node') {
+    const threat = secops.threats.find(t => t.affected_node === params.node_id);
+    return {
+      hourly_impact_inr: devops.clusters.find(c => c.id === params.node_id) ? hourlyBurn : 0,
+      risk_label: threat?.severity === 'critical' ? 'CRITICAL' : 'HIGH',
+      note: 'Traffic disruption during isolation. Restored on threat clearance.'
+    };
+  }
+
+  return null;
+}
+
+export function formatCostSection(cost: CostEstimate | null): string {
+  if (!cost) return '';
+  const lines = ['\nFINANCIAL IMPACT:'];
+  if (cost.hourly_impact_inr > 0) lines.push(`  Cost impact: ₹${cost.hourly_impact_inr.toLocaleString('en-IN')}/hr`);
+  if (cost.sla_exposure_inr) lines.push(`  SLA exposure: ₹${cost.sla_exposure_inr.toLocaleString('en-IN')} (${cost.sla_customer}, ${cost.hours_remaining}h remaining)`);
+  if (cost.rightsizing_savings_monthly) lines.push(`  Rightsizing opportunity: ₹${cost.rightsizing_savings_monthly.toLocaleString('en-IN')}/mo (cluster over-provisioned ~40%)`);
+  if (cost.src_runway_months !== undefined) {
+    lines.push(`  Source dept runway after reallocation: ${cost.src_runway_months}mo`);
+    lines.push(`  Target dept runway after reallocation: ${cost.tgt_runway_months}mo`);
+  }
+  if (cost.note) lines.push(`  Note: ${cost.note}`);
+  lines.push(`  Risk classification: ${cost.risk_label}`);
+  return lines.join('\n');
+}

--- a/sample-apps/concord-governance-agent/src/modules/concord/rules/governance-rules.ts
+++ b/sample-apps/concord-governance-agent/src/modules/concord/rules/governance-rules.ts
@@ -1,0 +1,126 @@
+import { registerRule } from './rule-registry.js';
+
+// ── Rule: Contract Penalty on Halt ────────────────────────────────────────────
+registerRule({
+  id: 'contract-penalty',
+  toolName: 'halt_deployment_pipeline',
+  priority: 100,
+  check(params, state) {
+    const contract = state.finops.contracts.find(c => c.cluster_id === params.cluster_id);
+    if (!contract) return null;
+    return {
+      has_conflict: true,
+      conflict_type: 'contract_penalty',
+      message: `Halting ${params.cluster_id} affects an active order for ${contract.customer}. Contractual penalty for missed deadline: ₹${contract.penalty_clause_inr.toLocaleString()}. Deadline: ${contract.deadline}.`
+    };
+  }
+});
+
+// ── Rule: Cross-Tool Double-Halt (same cluster already queued) ────────────────
+registerRule({
+  id: 'cross-tool-double-halt',
+  toolName: 'halt_deployment_pipeline',
+  priority: 90,
+  check(params, state) {
+    const alreadyQueued = state.pending_actions.some(
+      a => a.tool_name === 'halt_deployment_pipeline' && (a.params as any).cluster_id === params.cluster_id
+    );
+    if (!alreadyQueued) return null;
+    return {
+      has_conflict: true,
+      conflict_type: 'duplicate_halt',
+      message: `A halt for ${params.cluster_id} is already pending human approval. Approving this second request before the first resolves may cause a double-halt event.`
+    };
+  }
+});
+
+// ── Rule: Canary In Progress (halt blocked while canary active) ───────────────
+registerRule({
+  id: 'canary-in-progress',
+  toolName: 'halt_deployment_pipeline',
+  priority: 95,
+  check(params, state) {
+    const activeCanary = state.devops.deployments.find(
+      d => d.cluster_id === params.cluster_id && d.status === 'active'
+    );
+    if (!activeCanary) return null;
+    return {
+      has_conflict: true,
+      conflict_type: 'canary_in_progress',
+      message: `A canary deployment of ${activeCanary.service_id} v${activeCanary.image_tag} is currently progressing on ${params.cluster_id} (${activeCanary.traffic_pct}% traffic). Halting now will abort the rollout and may leave traffic in an inconsistent split.`
+    };
+  }
+});
+
+// ── Rule: Budget Floor Violation on Reallocation ──────────────────────────────
+registerRule({
+  id: 'budget-floor',
+  toolName: 'reallocate_capital',
+  priority: 100,
+  check(params, state) {
+    const ledger = state.finops.ledgers.find(l => l.department === params.source_dept);
+    if (!ledger) return null;
+    const remaining = ledger.budget - params.amount;
+    if (remaining < ledger.floor) {
+      return {
+        has_conflict: true,
+        conflict_type: 'budget_floor',
+        message: `Reallocating ₹${params.amount.toLocaleString()} from ${params.source_dept} would drop their budget to ₹${remaining.toLocaleString()}, below their minimum reserve floor of ₹${ledger.floor.toLocaleString()}.`
+      };
+    }
+    return null;
+  }
+});
+
+// ── Rule: Unknown Isolation Target ────────────────────────────────────────────
+registerRule({
+  id: 'unknown-isolation-target',
+  toolName: 'isolate_compromised_node',
+  priority: 100,
+  check(params, state) {
+    const inRegistry = state.secops.threats.some(t => t.affected_node === params.node_id);
+    if (inRegistry) return null;
+    return {
+      has_conflict: true,
+      conflict_type: 'unknown_isolation_target',
+      message: `Node "${params.node_id}" does not appear in the current threat registry. Isolating an unknown node may disrupt live traffic unexpectedly — confirm the target is correct.`
+    };
+  }
+});
+
+// ── Rule: Compute Budget Low on Critical Branch Prioritization ────────────────
+registerRule({
+  id: 'compute-budget-low',
+  toolName: 'prioritize_engineering_branch',
+  priority: 100,
+  check(params, state) {
+    if (params.urgency_level !== 'critical') return null;
+    const eng = state.finops.ledgers.find(l => l.department === 'Engineering');
+    if (!eng) return null;
+    const headroom = ((eng.budget - eng.floor) / eng.floor) * 100;
+    if (headroom < 20) {
+      return {
+        has_conflict: true,
+        conflict_type: 'compute_budget_low',
+        message: `Critical compute priority escalation for branch "${params.branch_id}" may incur burst infrastructure costs. Engineering budget is only ₹${(eng.budget - eng.floor).toLocaleString()} above floor (${headroom.toFixed(0)}% headroom). Approval will authorize unplanned spend.`
+      };
+    }
+    return null;
+  }
+});
+
+// ── Rule: Weather Context Augmentation (wildcard — all tools) ────────────────
+registerRule({
+  id: 'weather-context',
+  toolName: '*',
+  priority: 50,
+  check(params, state) {
+    if (state.weather?.risk_signal !== 'elevated') return null;
+    const condition = state.weather.condition || 'severe conditions';
+    return {
+      has_conflict: true,
+      conflict_type: 'weather_risk',
+      message: `⚠️  Weather risk is ELEVATED in the Chennai DC region (${condition}) — physical operational risk is heightened. Consider whether this action should be deferred until conditions normalise.`
+    };
+  }
+});

--- a/sample-apps/concord-governance-agent/src/modules/concord/rules/rule-registry.ts
+++ b/sample-apps/concord-governance-agent/src/modules/concord/rules/rule-registry.ts
@@ -1,0 +1,28 @@
+import { AppState, ConflictResult } from '../../../state/state.js';
+
+export interface Rule {
+  id: string;
+  toolName: string;
+  priority: number;
+  check: (params: Record<string, any>, state: AppState) => ConflictResult | null | Promise<ConflictResult | null>;
+}
+
+const rules: Rule[] = [];
+
+export function registerRule(rule: Rule) {
+  rules.push(rule);
+  rules.sort((a, b) => b.priority - a.priority);
+}
+
+export async function runConflictCheck(toolName: string, params: Record<string, any>, state: AppState): Promise<ConflictResult | null> {
+  const applicable = rules.filter(r => r.toolName === toolName || r.toolName === '*');
+  for (const rule of applicable) {
+    const result = await rule.check(params, state);
+    if (result?.has_conflict) return result;
+  }
+  return null;
+}
+
+export function listRules() {
+  return rules.map(r => ({ id: r.id, toolName: r.toolName, priority: r.priority }));
+}

--- a/sample-apps/concord-governance-agent/src/modules/flights/booking.tools.ts
+++ b/sample-apps/concord-governance-agent/src/modules/flights/booking.tools.ts
@@ -1,0 +1,324 @@
+import { ToolDecorator as Tool, Widget, ExecutionContext, z, UseGuards, Injectable } from '@nitrostack/core';
+import { OAuthGuard } from '../../guards/oauth.guard.js';
+import { DuffelService } from '../../services/duffel.service.js';
+
+// Note: Using explicit deps for ESM compatibility
+@Injectable({ deps: [DuffelService] })
+export class BookingTools {
+    constructor(private duffelService: DuffelService) { }
+
+    @Tool({
+        name: 'create_order',
+        description: 'Create a flight order with hold (no payment required). IMPORTANT: Before calling this tool, you MUST collect passenger information from the user. Ask for: full name (first and last), title (Mr/Ms/Mrs/Miss/Dr), gender (M/F), date of birth (YYYY-MM-DD), email, and phone number with country code. The order will be held for later payment.',
+        inputSchema: z.object({
+            offerId: z.string().describe('The offer ID to book'),
+            passengers: z.string().describe('JSON string containing array of passenger objects. Each passenger must have: title (mr/ms/mrs/miss/dr), givenName (first name), familyName (last name), gender (M/F), bornOn (YYYY-MM-DD), email, phoneNumber. Example: \'[{"title":"mr","givenName":"John","familyName":"Doe","gender":"M","bornOn":"1990-01-15","email":"john@example.com","phoneNumber":"+1234567890"}]\'')
+        }),
+        examples: {
+            request: {
+                offerId: 'off_123456',
+                passengers: '[{"title":"mr","givenName":"John","familyName":"Doe","gender":"M","bornOn":"1990-01-15","email":"john.doe@example.com","phoneNumber":"+1234567890"}]'
+            },
+            response: {
+                orderId: 'ord_123456',
+                status: 'held',
+                totalAmount: '450.00',
+                totalCurrency: 'USD',
+                expiresAt: '2024-03-01T12:00:00Z',
+                passengers: [],
+                slices: [],
+                message: 'Order created and held successfully.'
+            }
+        }
+    })
+    @UseGuards(OAuthGuard)
+    @Widget('order-summary')
+    async createOrder(input: any, ctx: ExecutionContext) {
+        ctx.logger.info('Creating flight order (hold)', {
+            user: ctx.auth?.subject,
+            offerId: input.offerId
+        });
+
+        // Validate and parse passengers
+        let passengersArray;
+        try {
+            if (typeof input.passengers === 'string') {
+                // Try to parse the JSON string
+                // Handle both regular JSON and double-encoded JSON
+                let passengerStr = input.passengers;
+
+                // If the string starts with escaped quotes, it might be double-encoded
+                if (passengerStr.startsWith('\\"') || passengerStr.includes('\\"')) {
+                    // Remove escape characters
+                    passengerStr = passengerStr.replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+                }
+
+                passengersArray = JSON.parse(passengerStr);
+            } else if (Array.isArray(input.passengers)) {
+                passengersArray = input.passengers;
+            } else {
+                throw new Error('Passengers must be a JSON string or array');
+            }
+        } catch (error: any) {
+            ctx.logger.error('Failed to parse passengers', {
+                input: input.passengers,
+                error: error.message
+            });
+            throw new Error(`Invalid passengers format: ${error.message}. Expected JSON string like '[{"title":"mr","givenName":"John","familyName":"Doe","gender":"M","bornOn":"1990-01-15","email":"john@example.com","phoneNumber":"+1234567890"}]'`);
+        }
+
+        if (!passengersArray || !Array.isArray(passengersArray) || passengersArray.length === 0) {
+            throw new Error('At least one passenger is required to create an order');
+        }
+
+        // Transform passengers to Duffel format
+        // Pass inline passenger data - Duffel will create passenger records automatically
+        const passengers = passengersArray.map((pax: any) => ({
+            title: pax.title,
+            given_name: pax.givenName,
+            family_name: pax.familyName,
+            gender: pax.gender,
+            born_on: pax.bornOn,
+            email: pax.email,
+            phone_number: pax.phoneNumber
+        }));
+
+        const orderParams: any = {
+            selectedOffers: [input.offerId],
+            passengers,
+            type: 'hold' // Always create hold orders
+        };
+
+        const order = await this.duffelService.createOrder(orderParams);
+
+        ctx.logger.info('Order created successfully', {
+            user: ctx.auth?.subject,
+            orderId: order.id,
+            status: 'held'
+        });
+
+        return {
+            orderId: order.id,
+            status: 'held',
+            totalAmount: order.total_amount,
+            totalCurrency: order.total_currency,
+            expiresAt: (order as any).expires_at,
+            bookingReference: order.booking_reference,
+            passengers: order.passengers.map((pax: any) => ({
+                id: pax.id,
+                name: `${pax.given_name} ${pax.family_name}`,
+                type: pax.type
+            })),
+            slices: order.slices.map((slice: any) => ({
+                origin: slice.origin.iata_code,
+                destination: slice.destination.iata_code,
+                departureTime: slice.segments[0].departing_at,
+                arrivalTime: slice.segments[slice.segments.length - 1].arriving_at
+            })),
+            message: 'Order created and held successfully.'
+        };
+    }
+
+
+
+    @Tool({
+        name: 'get_order_details',
+        description: 'Get detailed information about an order',
+        inputSchema: z.object({
+            orderId: z.string().describe('The order ID')
+        }),
+        examples: {
+            request: {
+                orderId: 'ord_123456'
+            },
+            response: {
+                orderId: 'ord_123456',
+                status: 'confirmed',
+                bookingReference: 'ABC123',
+                totalAmount: '450.00',
+                totalCurrency: 'USD',
+                passengers: [],
+                slices: []
+            }
+        }
+    })
+    @UseGuards(OAuthGuard)
+    @Widget('order-summary')
+    async getOrderDetails(input: any, ctx: ExecutionContext) {
+        ctx.logger.info('Getting order details', {
+            user: ctx.auth?.subject,
+            orderId: input.orderId
+        });
+
+        const order = await this.duffelService.getOrder(input.orderId);
+
+        return {
+            orderId: order.id,
+            status: (order as any).status || 'confirmed',
+            bookingReference: order.booking_reference,
+            totalAmount: order.total_amount,
+            totalCurrency: order.total_currency,
+            createdAt: order.created_at,
+            expiresAt: (order as any).expires_at,
+            passengers: order.passengers.map((pax: any) => ({
+                id: pax.id,
+                name: `${pax.given_name} ${pax.family_name}`,
+                type: pax.type,
+                email: pax.email,
+                phoneNumber: pax.phone_number
+            })),
+            slices: order.slices.map((slice: any) => ({
+                id: slice.id,
+                origin: {
+                    code: slice.origin.iata_code,
+                    name: slice.origin.name,
+                    city: slice.origin.city_name
+                },
+                destination: {
+                    code: slice.destination.iata_code,
+                    name: slice.destination.name,
+                    city: slice.destination.city_name
+                },
+                duration: slice.duration,
+                segments: slice.segments.map((seg: any) => ({
+                    id: seg.id,
+                    origin: seg.origin.iata_code,
+                    destination: seg.destination.iata_code,
+                    departingAt: seg.departing_at,
+                    arrivingAt: seg.arriving_at,
+                    airline: seg.marketing_carrier.name,
+                    flightNumber: seg.marketing_carrier_flight_number,
+                    aircraft: seg.aircraft?.name
+                }))
+            }))
+        };
+    }
+
+    @Tool({
+        name: 'get_seat_map',
+        description: 'Get available seats for a flight offer to allow seat selection',
+        inputSchema: z.object({
+            offerId: z.string().describe('The offer ID to get seats for')
+        }),
+        examples: {
+            request: {
+                offerId: 'off_123456'
+            },
+            response: {
+                offerId: 'off_123456',
+                cabins: [
+                    {
+                        cabinClass: 'economy',
+                        rows: [
+                            {
+                                rowNumber: 10,
+                                seats: [
+                                    {
+                                        id: 'seat_10a',
+                                        column: 'A',
+                                        available: true,
+                                        price: '25.00',
+                                        currency: 'USD',
+                                        type: 'window'
+                                    },
+                                    {
+                                        id: 'seat_10b',
+                                        column: 'B',
+                                        available: true,
+                                        price: '0',
+                                        currency: 'USD',
+                                        type: 'middle'
+                                    },
+                                    {
+                                        id: 'seat_10c',
+                                        column: 'C',
+                                        available: true,
+                                        price: '15.00',
+                                        currency: 'USD',
+                                        type: 'aisle'
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                message: 'Select your preferred seats from the available options'
+            }
+        }
+    })
+    @UseGuards(OAuthGuard)
+    @Widget('seat-selection')
+    async getSeatMap(input: any, ctx: ExecutionContext) {
+        ctx.logger.info('Getting seat map', {
+            user: ctx.auth?.subject,
+            offerId: input.offerId
+        });
+
+        const seatMaps = await this.duffelService.getSeatsForOffer(input.offerId);
+
+        return {
+            offerId: input.offerId,
+            cabins: seatMaps.map((cabin: any) => ({
+                cabinClass: cabin.cabin_class,
+                rows: cabin.rows.map((row: any) => ({
+                    rowNumber: row.row_number,
+                    seats: row.sections.flatMap((section: any) =>
+                        section.elements.filter((el: any) => el.type === 'seat').map((seat: any) => ({
+                            id: seat.id,
+                            column: seat.designator,
+                            available: seat.available_services?.length > 0,
+                            price: seat.available_services?.[0]?.total_amount,
+                            currency: seat.available_services?.[0]?.total_currency,
+                            type: seat.disclosures?.join(', ') || 'standard'
+                        }))
+                    )
+                }))
+            })),
+            message: 'Select your preferred seats from the available options'
+        };
+    }
+
+    @Tool({
+        name: 'cancel_order',
+        description: 'Cancel a flight order and request refund if applicable',
+        inputSchema: z.object({
+            orderId: z.string().describe('The order ID to cancel')
+        }),
+        examples: {
+            request: {
+                orderId: 'ord_123456'
+            },
+            response: {
+                orderId: 'ord_123456',
+                cancellationId: 'ocr_123456',
+                status: 'cancelled',
+                refundAmount: '450.00',
+                refundCurrency: 'USD',
+                confirmedAt: '2024-03-01T12:00:00Z',
+                message: 'Order cancelled. Refund of USD 450.00 will be processed.'
+            }
+        }
+    })
+    @UseGuards(OAuthGuard)
+    @Widget('order-cancellation')
+    async cancelOrder(input: any, ctx: ExecutionContext) {
+        ctx.logger.info('Cancelling order', {
+            user: ctx.auth?.subject,
+            orderId: input.orderId
+        });
+
+        const cancellation = await this.duffelService.cancelOrder(input.orderId);
+
+        return {
+            orderId: input.orderId,
+            cancellationId: cancellation.id,
+            status: 'cancelled',
+            refundAmount: cancellation.refund_amount,
+            refundCurrency: cancellation.refund_currency,
+            confirmedAt: cancellation.confirmed_at,
+            message: cancellation.refund_amount
+                ? `Order cancelled. Refund of ${cancellation.refund_currency} ${cancellation.refund_amount} will be processed.`
+                : 'Order cancelled. No refund available for this booking.'
+        };
+    }
+}

--- a/sample-apps/concord-governance-agent/src/modules/flights/flights.module.ts
+++ b/sample-apps/concord-governance-agent/src/modules/flights/flights.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nitrostack/core';
+import { FlightTools } from './flights.tools.js';
+import { BookingTools } from './booking.tools.js';
+import { FlightPrompts } from './flights.prompts.js';
+import { FlightResources } from './flights.resources.js';
+import { DuffelService } from '../../services/duffel.service.js';
+
+@Module({
+    name: 'flights',
+    description: 'Professional flight search and booking system powered by Duffel API',
+    controllers: [FlightTools, BookingTools, FlightPrompts, FlightResources],
+    providers: [DuffelService]
+})
+export class FlightsModule { }

--- a/sample-apps/concord-governance-agent/src/modules/flights/flights.prompts.ts
+++ b/sample-apps/concord-governance-agent/src/modules/flights/flights.prompts.ts
@@ -1,0 +1,247 @@
+import { PromptDecorator as Prompt, ExecutionContext, Injectable } from '@nitrostack/core';
+import { DuffelService } from '../../services/duffel.service.js';
+
+// Note: Using explicit deps for ESM compatibility
+@Injectable({ deps: [DuffelService] })
+export class FlightPrompts {
+    constructor(private duffelService: DuffelService) { }
+
+    @Prompt({
+        name: 'flight_search_assistant',
+        description: 'An AI assistant specialized in helping users search for flights, understand flight options, and make booking decisions.',
+        arguments: [
+            {
+                name: 'userQuery',
+                description: 'The user\'s flight search query or question',
+                required: true
+            },
+            {
+                name: 'context',
+                description: 'Optional context including previous searches and selected offers',
+                required: false
+            }
+        ]
+    })
+    async flightSearchAssistant(input: any, ctx: ExecutionContext) {
+        const systemPrompt = `You are a professional flight booking assistant with expertise in helping travelers find flight information.
+
+⚠️ CRITICAL: Only do what the user specifically asks. Do NOT assume additional steps.
+
+Your capabilities:
+- Search for airports using search_airports tool
+- Search for flights using the search_flights tool
+- Get detailed flight information using get_flight_details tool
+- Help book flights when explicitly requested
+
+**IMPORTANT RULES:**
+1. If user asks about airports, ONLY search airports - do NOT search for flights
+2. If user asks about flights, ONLY search flights - do NOT automatically book
+3. If user asks to book, ONLY then proceed with booking workflow
+4. NEVER chain operations unless user explicitly requests it
+
+**EXAMPLES:**
+- "show me airports in London" → search_airports("London") → show results → STOP
+- "find flights from NYC to LAX" → search_flights → show results → STOP
+- "book this flight" → THEN start booking workflow
+
+BOOKING WORKFLOW (only when user explicitly wants to book):
+1. FIRST, collect ALL passenger information (name, title, gender, date of birth, email, phone)
+2. THEN, call create_order tool with complete passenger details
+⚠️ NEVER call create_order without collecting passenger information first!
+⚠️ All bookings are automatically held - no payment is required at booking time
+
+Current user query: ${input.userQuery}
+
+${input.context?.previousSearches?.length ? `Previous searches in this conversation:\n${JSON.stringify(input.context.previousSearches, null, 2)}` : ''}
+
+Respond to EXACTLY what the user asked - nothing more.`;
+
+        return {
+            role: 'assistant',
+            content: systemPrompt
+        };
+    }
+
+    @Prompt({
+        name: 'flight_comparison',
+        description: 'Compare multiple flight offers and provide recommendations based on various factors.',
+        arguments: [
+            {
+                name: 'offerIds',
+                description: 'Flight offer IDs to compare (2-5 offers)',
+                required: true
+            },
+            {
+                name: 'priorities',
+                description: 'User priorities for comparison (price, duration, stops, airline, departure_time, flexibility)',
+                required: false
+            }
+        ]
+    })
+    async flightComparison(input: any, ctx: ExecutionContext) {
+        let ids: string[] = [];
+        if (Array.isArray(input.offerIds)) {
+            ids = input.offerIds;
+        } else if (typeof input.offerIds === 'string') {
+            const trimmed = input.offerIds.trim();
+            if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+                try {
+                    const parsed = JSON.parse(trimmed);
+                    ids = Array.isArray(parsed) ? parsed : [parsed];
+                } catch {
+                    ids = trimmed.split(',').map((s: string) => s.trim());
+                }
+            } else {
+                ids = trimmed.split(',').map((s: string) => s.trim());
+            }
+        }
+        ids = ids.filter(Boolean);
+
+        const offers = await Promise.all(
+            ids.map((id: string) => this.duffelService.getOffer(id))
+        );
+
+        const comparisonData = offers.map((offer: any) => {
+            const outbound = offer.slices[0];
+            return {
+                offerId: offer.id,
+                price: `${offer.total_amount} ${offer.total_currency}`,
+                airline: outbound.segments[0].marketing_carrier.name,
+                duration: outbound.duration,
+                stops: outbound.segments.length - 1,
+                departureTime: outbound.segments[0].departing_at,
+                arrivalTime: outbound.segments[outbound.segments.length - 1].arriving_at,
+                refundable: offer.conditions?.refund_before_departure?.allowed || false,
+                changeable: offer.conditions?.change_before_departure?.allowed || false
+            };
+        });
+
+        const priorities = input.priorities || ['price', 'duration', 'stops'];
+
+        const prompt = `Compare these flight options and provide a recommendation:
+
+${JSON.stringify(comparisonData, null, 2)}
+
+User priorities: ${priorities.join(', ')}
+
+Provide:
+1. A clear comparison of the key differences
+2. Pros and cons of each option
+3. Your recommendation based on the user's priorities
+4. Any important considerations (layover times, airline reputation, flexibility, etc.)`;
+
+        return {
+            role: 'assistant',
+            content: prompt
+        };
+    }
+
+    @Prompt({
+        name: 'travel_tips',
+        description: 'Provide travel tips and advice for a specific route and travel dates.',
+        arguments: [
+            {
+                name: 'origin',
+                description: 'Origin airport code',
+                required: true
+            },
+            {
+                name: 'destination',
+                description: 'Destination airport code',
+                required: true
+            },
+            {
+                name: 'departureDate',
+                description: 'Departure date',
+                required: true
+            },
+            {
+                name: 'tripType',
+                description: 'Type of trip: business, leisure, or family',
+                required: false
+            }
+        ]
+    })
+    async travelTips(input: any, ctx: ExecutionContext) {
+        const prompt = `Provide helpful travel tips for a trip from ${input.origin} to ${input.destination} departing on ${input.departureDate}.
+
+Include advice on:
+1. Best time to book for this route
+2. Typical weather at destination during this time
+3. Airport tips (check-in, security, lounges)
+4. Baggage recommendations
+5. Connection considerations if applicable
+6. Time zone differences and jet lag tips
+${input.tripType ? `7. Specific tips for ${input.tripType} travel` : ''}
+
+Be concise but informative.`;
+
+        return {
+            role: 'assistant',
+            content: prompt
+        };
+    }
+
+    @Prompt({
+        name: 'booking_assistant',
+        description: 'Guide users through the flight booking process, collecting all necessary passenger information before creating an order.',
+        arguments: [
+            {
+                name: 'offerId',
+                description: 'The flight offer ID the user wants to book',
+                required: true
+            },
+            {
+                name: 'passengerCount',
+                description: 'Number of passengers (default: 1)',
+                required: false
+            }
+        ]
+    })
+    async bookingAssistant(input: any, ctx: ExecutionContext) {
+        const passengerCount = input.passengerCount || 1;
+
+        const prompt = `You are helping the user book flight offer: ${input.offerId}
+
+IMPORTANT BOOKING WORKFLOW:
+Before you can create the order, you MUST collect the following information for ${passengerCount} passenger(s):
+
+For EACH passenger, ask for:
+1. **Title**: Mr, Ms, Mrs, Miss, or Dr
+2. **Full Name**: First name and last name (as it appears on their passport/ID)
+3. **Gender**: Male (M) or Female (F)
+4. **Date of Birth**: In YYYY-MM-DD format (e.g., 1990-01-15)
+5. **Email Address**: For booking confirmation
+6. **Phone Number**: With country code (e.g., +1234567890)
+
+COLLECTION STRATEGY:
+- Ask for all information in a friendly, conversational way
+- You can ask for multiple fields at once to make it efficient
+- Validate the format (especially date of birth and email)
+- Confirm all details with the user before proceeding
+
+EXAMPLE QUESTIONS:
+"Great! To complete your booking, I'll need some passenger details. Could you please provide:
+- Full name (first and last)
+- Title (Mr/Ms/Mrs/Miss/Dr)
+- Date of birth (YYYY-MM-DD)
+- Gender (M/F)
+- Email address
+- Phone number with country code"
+
+BOOKING PROCESS:
+Once you have ALL passenger information:
+- Call create_order with the offer ID and passenger details
+- The booking will be automatically held (no payment required)
+- The user will receive booking confirmation with expiration details
+- Payment can be completed later before the hold expires
+
+DO NOT ask for payment details - all bookings are held by default.
+ALWAYS inform the user that their booking is held and they have time to complete payment.`;
+
+        return {
+            role: 'assistant',
+            content: prompt
+        };
+    }
+}

--- a/sample-apps/concord-governance-agent/src/modules/flights/flights.resources.ts
+++ b/sample-apps/concord-governance-agent/src/modules/flights/flights.resources.ts
@@ -1,0 +1,216 @@
+import { ResourceDecorator as Resource, ExecutionContext, z, Injectable } from '@nitrostack/core';
+import { DuffelService } from '../../services/duffel.service.js';
+
+// Note: Using explicit deps for ESM compatibility
+@Injectable({ deps: [DuffelService] })
+export class FlightResources {
+    constructor(private duffelService: DuffelService) { }
+
+    @Resource({
+        uri: 'flight://search-history',
+        name: 'Flight Search History',
+        description: 'Access to recent flight searches and their results',
+        mimeType: 'application/json'
+    })
+    async getSearchHistory(ctx: ExecutionContext) {
+        // In a real implementation, this would fetch from a database
+        // For now, return a template structure
+        return {
+            searches: [],
+            message: 'Search history will be stored here after performing searches'
+        };
+    }
+
+    @Resource({
+        uri: 'flight://popular-routes',
+        name: 'Popular Flight Routes',
+        description: 'Information about popular flight routes and typical pricing',
+        mimeType: 'application/json'
+    })
+    async getPopularRoutes(ctx: ExecutionContext) {
+        return {
+            routes: [
+                {
+                    route: 'JFK → LAX',
+                    description: 'New York to Los Angeles',
+                    averageDuration: '6h 30m',
+                    typicalPrice: '$200-400',
+                    airlines: ['American Airlines', 'Delta', 'JetBlue', 'United']
+                },
+                {
+                    route: 'LHR → JFK',
+                    description: 'London to New York',
+                    averageDuration: '8h 00m',
+                    typicalPrice: '$400-800',
+                    airlines: ['British Airways', 'American Airlines', 'Virgin Atlantic']
+                },
+                {
+                    route: 'SFO → NRT',
+                    description: 'San Francisco to Tokyo',
+                    averageDuration: '11h 30m',
+                    typicalPrice: '$600-1200',
+                    airlines: ['United', 'ANA', 'Japan Airlines']
+                },
+                {
+                    route: 'DXB → LHR',
+                    description: 'Dubai to London',
+                    averageDuration: '7h 30m',
+                    typicalPrice: '$400-900',
+                    airlines: ['Emirates', 'British Airways']
+                }
+            ],
+            note: 'Prices are approximate and vary by season, booking time, and availability'
+        };
+    }
+
+    @Resource({
+        uri: 'flight://booking-guide',
+        name: 'Flight Booking Guide',
+        description: 'Comprehensive guide on how to search and book flights',
+        mimeType: 'text/markdown'
+    })
+    async getBookingGuide(ctx: ExecutionContext) {
+        return `# Flight Booking Guide
+
+## How to Search for Flights
+
+### 1. Prepare Your Information
+- **Origin & Destination**: Use 3-letter IATA airport codes (e.g., JFK, LAX)
+  - Use \`search_airports\` tool if you don't know the code
+- **Dates**: Provide dates in YYYY-MM-DD format
+- **Passengers**: Specify number of adults, children, and infants
+- **Cabin Class**: Choose from economy, premium_economy, business, or first
+
+### 2. Use the Search Tool
+\`\`\`
+search_flights({
+  origin: "JFK",
+  destination: "LAX",
+  departureDate: "2024-03-15",
+  returnDate: "2024-03-22",
+  adults: 2,
+  cabinClass: "economy"
+})
+\`\`\`
+
+### 3. Review Results
+- Compare prices, airlines, and flight times
+- Check number of stops and total duration
+- Review baggage allowance and fare conditions
+
+### 4. Get Detailed Information
+Use \`get_flight_details\` with an offer ID to see:
+- Complete itinerary with all segments
+- Baggage allowance per passenger
+- Refund and change policies
+- Payment requirements
+
+## Tips for Best Results
+
+### Flexible Dates
+- Search multiple date combinations
+- Weekday flights are often cheaper than weekends
+- Avoid major holidays and peak seasons
+
+### Direct vs. Connecting Flights
+- Use \`maxConnections: 0\` for direct flights only
+- Connecting flights are usually cheaper but take longer
+- Consider layover duration and airport
+
+### Cabin Class Selection
+- **Economy**: Most affordable, basic amenities
+- **Premium Economy**: More legroom and better service
+- **Business**: Lie-flat seats, premium dining, lounge access
+- **First**: Ultimate luxury, private suites, concierge service
+
+### Booking Timing
+- Book 2-3 months in advance for domestic flights
+- Book 3-6 months in advance for international flights
+- Last-minute deals exist but are risky
+
+## Understanding Fare Conditions
+
+### Refundable vs. Non-Refundable
+- **Refundable**: Can cancel and get money back (usually more expensive)
+- **Non-Refundable**: No refund if cancelled (cheaper)
+
+### Change Policies
+- Some fares allow changes with a fee
+- Others don't allow any changes
+- Check \`conditions\` in flight details
+
+### Baggage Allowance
+- **Carry-on**: Usually 1 bag + 1 personal item
+- **Checked**: Varies by airline and fare class
+- International flights typically include checked bags
+
+## Booking Process
+
+### Hold Orders
+- All bookings are automatically held (no payment required at booking time)
+- Price is guaranteed until the hold expires
+- You'll receive an expiration time when booking
+
+### Passenger Information Required
+- Full legal name (as on passport/ID)
+- Date of birth
+- Gender
+- Passport details for international flights
+
+## After Booking
+
+### Confirmation
+- You'll receive a booking reference
+- Save confirmation email
+- Check-in opens 24 hours before departure
+
+### Manage Your Booking
+- Add seat selections
+- Purchase extra baggage
+- Add special meals or assistance
+- Update passenger information
+
+## Need Help?
+
+Use the \`flight_search_assistant\` prompt for personalized assistance with:
+- Finding the best flights for your needs
+- Understanding complex itineraries
+- Comparing different options
+- Making booking decisions
+`;
+    }
+
+    @Resource({
+        uri: 'flight://airline-codes',
+        name: 'Airline Codes Reference',
+        description: 'Common airline IATA codes and names',
+        mimeType: 'application/json'
+    })
+    async getAirlineCodes(ctx: ExecutionContext) {
+        try {
+            const airlines = await this.duffelService.getAirlines();
+            return {
+                airlines: airlines.slice(0, 50).map((airline: any) => ({
+                    iataCode: airline.iata_code,
+                    name: airline.name
+                })),
+                note: 'Showing top 50 airlines. More available through Duffel API.'
+            };
+        } catch (error) {
+            // Return common airlines if API call fails
+            return {
+                airlines: [
+                    { iataCode: 'AA', name: 'American Airlines' },
+                    { iataCode: 'DL', name: 'Delta Air Lines' },
+                    { iataCode: 'UA', name: 'United Airlines' },
+                    { iataCode: 'BA', name: 'British Airways' },
+                    { iataCode: 'LH', name: 'Lufthansa' },
+                    { iataCode: 'AF', name: 'Air France' },
+                    { iataCode: 'EK', name: 'Emirates' },
+                    { iataCode: 'QR', name: 'Qatar Airways' }
+                ],
+                note: 'Common airlines. Use search_airports tool for complete list.'
+            };
+        }
+    }
+}

--- a/sample-apps/concord-governance-agent/src/modules/flights/flights.tools.ts
+++ b/sample-apps/concord-governance-agent/src/modules/flights/flights.tools.ts
@@ -1,0 +1,458 @@
+import { ToolDecorator as Tool, Widget, ExecutionContext, z, UseGuards, Injectable } from '@nitrostack/core';
+import { OAuthGuard } from '../../guards/oauth.guard.js';
+import { DuffelService } from '../../services/duffel.service.js';
+import { format } from 'date-fns';
+
+// Note: Using explicit deps for ESM compatibility
+@Injectable({ deps: [DuffelService] })
+export class FlightTools {
+    constructor(private duffelService: DuffelService) { }
+
+    @Tool({
+        name: 'search_flights',
+        description: 'Search for flight offers based on origin, destination, dates, and preferences. Returns available flight options with pricing and details.',
+        inputSchema: z.object({
+            origin: z.string().length(3).describe('Origin airport IATA code (e.g., "JFK", "LHR")'),
+            destination: z.string().length(3).describe('Destination airport IATA code (e.g., "LAX", "CDG")'),
+            departureDate: z.string().describe('Departure date in YYYY-MM-DD format'),
+            returnDate: z.string().optional().describe('Return date in YYYY-MM-DD format for round trip'),
+            adults: z.number().min(1).max(9).default(1).describe('Number of adult passengers (18+)'),
+            children: z.number().min(0).max(9).default(0).describe('Number of child passengers (2-17)'),
+            infants: z.number().min(0).max(9).default(0).describe('Number of infant passengers (under 2)'),
+            cabinClass: z.enum(['economy', 'premium_economy', 'business', 'first']).default('economy').describe('Preferred cabin class'),
+            maxConnections: z.number().min(0).max(3).optional().describe('Maximum number of connections (0 for direct flights only)'),
+            departureTimeFrom: z.string().optional().describe('Earliest departure time in HH:MM format'),
+            departureTimeTo: z.string().optional().describe('Latest departure time in HH:MM format')
+        }),
+        examples: {
+            request: {
+                origin: 'JFK',
+                destination: 'LAX',
+                departureDate: '2024-03-15',
+                returnDate: '2024-03-22',
+                adults: 2,
+                cabinClass: 'economy'
+            },
+            response: {
+                requestId: 'orq_123456',
+                searchParams: {
+                    origin: 'JFK',
+                    destination: 'LAX',
+                    departureDate: '2024-03-15',
+                    returnDate: '2024-03-22',
+                    passengers: {
+                        adults: 2,
+                        children: 0,
+                        infants: 0
+                    },
+                    cabinClass: 'economy'
+                },
+                totalOffers: 15,
+                offers: [
+                    {
+                        id: 'off_123456',
+                        totalAmount: '450.00',
+                        totalCurrency: 'USD',
+                        expiresAt: '2024-03-01T12:00:00Z',
+                        outbound: {
+                            origin: 'JFK',
+                            destination: 'LAX',
+                            departureTime: '2024-03-15T08:00:00Z',
+                            arrivalTime: '2024-03-15T14:30:00Z',
+                            duration: 'PT6H30M',
+                            stops: 0,
+                            airline: 'American Airlines',
+                            flightNumber: 'AA123',
+                            segments: []
+                        },
+                        return: {
+                            origin: 'LAX',
+                            destination: 'JFK',
+                            departureTime: '2024-03-22T16:00:00Z',
+                            arrivalTime: '2024-03-23T00:30:00Z',
+                            duration: 'PT5H30M',
+                            stops: 0,
+                            airline: 'American Airlines',
+                            flightNumber: 'AA456',
+                            segments: []
+                        },
+                        fareType: 'Domestic',
+                        refundable: false,
+                        changeable: true
+                    }
+                ],
+                message: 'Found 15 flight options. Showing top 10 results.'
+            }
+        }
+    })
+    @UseGuards(OAuthGuard)
+    @Widget('flight-search-results')
+    async searchFlights(input: any, ctx: ExecutionContext) {
+        ctx.logger.info('Searching for flights', {
+            user: ctx.auth?.subject,
+            origin: input.origin,
+            destination: input.destination,
+            departureDate: input.departureDate
+        });
+
+        // Ensure we have passenger counts with defaults
+        const adults = input.adults || 1;
+        const children = input.children || 0;
+        const infants = input.infants || 0;
+
+        // Build passengers array
+        const passengers: any[] = [];
+        for (let i = 0; i < adults; i++) {
+            passengers.push({ type: 'adult' });
+        }
+        for (let i = 0; i < children; i++) {
+            passengers.push({ type: 'child', age: 12 }); // Default age for children
+        }
+        for (let i = 0; i < infants; i++) {
+            passengers.push({ type: 'infant_without_seat' });
+        }
+
+        // Build time filters if provided
+        const departureTime = input.departureTimeFrom && input.departureTimeTo
+            ? { from: input.departureTimeFrom, to: input.departureTimeTo }
+            : undefined;
+
+        ctx.logger.info('Calling Duffel service with passengers:', {
+            passengersCount: passengers.length,
+            passengers: passengers,
+            adults: adults,
+            children: children,
+            infants: infants
+        });
+
+        const result = await this.duffelService.searchFlights({
+            origin: input.origin.toUpperCase(),
+            destination: input.destination.toUpperCase(),
+            departureDate: input.departureDate,
+            returnDate: input.returnDate,
+            passengers,
+            cabinClass: input.cabinClass,
+            maxConnections: input.maxConnections,
+            departureTime
+        });
+
+        // Transform offers for better presentation
+        const offers = result.offers.map((offer: any) => {
+            const outboundSlice = offer.slices[0];
+            const returnSlice = offer.slices[1];
+
+            return {
+                id: offer.id,
+                totalAmount: offer.total_amount,
+                totalCurrency: offer.total_currency,
+                expiresAt: offer.expires_at,
+
+                // Outbound flight details
+                outbound: {
+                    origin: outboundSlice.origin.iata_code,
+                    destination: outboundSlice.destination.iata_code,
+                    departureTime: outboundSlice.segments[0].departing_at,
+                    arrivalTime: outboundSlice.segments[outboundSlice.segments.length - 1].arriving_at,
+                    duration: outboundSlice.duration,
+                    stops: outboundSlice.segments.length - 1,
+                    airline: outboundSlice.segments[0].marketing_carrier.name,
+                    flightNumber: outboundSlice.segments[0].marketing_carrier_flight_number,
+                    segments: outboundSlice.segments.map((seg: any) => ({
+                        origin: seg.origin.iata_code,
+                        destination: seg.destination.iata_code,
+                        departingAt: seg.departing_at,
+                        arrivingAt: seg.arriving_at,
+                        airline: seg.marketing_carrier.name,
+                        flightNumber: seg.marketing_carrier_flight_number,
+                        aircraft: seg.aircraft?.name
+                    }))
+                },
+
+                // Return flight details (if round trip)
+                ...(returnSlice && {
+                    return: {
+                        origin: returnSlice.origin.iata_code,
+                        destination: returnSlice.destination.iata_code,
+                        departureTime: returnSlice.segments[0].departing_at,
+                        arrivalTime: returnSlice.segments[returnSlice.segments.length - 1].arriving_at,
+                        duration: returnSlice.duration,
+                        stops: returnSlice.segments.length - 1,
+                        airline: returnSlice.segments[0].marketing_carrier.name,
+                        flightNumber: returnSlice.segments[0].marketing_carrier_flight_number,
+                        segments: returnSlice.segments.map((seg: any) => ({
+                            origin: seg.origin.iata_code,
+                            destination: seg.destination.iata_code,
+                            departingAt: seg.departing_at,
+                            arrivingAt: seg.arriving_at,
+                            airline: seg.marketing_carrier.name,
+                            flightNumber: seg.marketing_carrier_flight_number,
+                            aircraft: seg.aircraft?.name
+                        }))
+                    }
+                }),
+
+                // Fare details
+                fareType: offer.passenger_identity_documents_required ? 'International' : 'Domestic',
+                refundable: offer.conditions?.refund_before_departure?.allowed || false,
+                changeable: offer.conditions?.change_before_departure?.allowed || false
+            };
+        });
+
+        ctx.logger.info('Flight search completed', {
+            user: ctx.auth?.subject,
+            offersFound: offers.length
+        });
+
+        return {
+            requestId: result.id,
+            searchParams: {
+                origin: input.origin.toUpperCase(),
+                destination: input.destination.toUpperCase(),
+                departureDate: input.departureDate,
+                returnDate: input.returnDate,
+                passengers: {
+                    adults: adults,
+                    children: children,
+                    infants: infants
+                },
+                cabinClass: input.cabinClass
+            },
+            totalOffers: offers.length,
+            offers: offers.slice(0, 10), // Return top 10 offers
+            message: `Found ${offers.length} flight options. Showing top 10 results.`
+        };
+    }
+
+    @Tool({
+        name: 'get_flight_details',
+        description: 'Get detailed information about a specific flight offer including baggage allowance, fare conditions, and seat availability.',
+        inputSchema: z.object({
+            offerId: z.string().describe('The offer ID from search results')
+        }),
+        examples: {
+            request: {
+                offerId: 'off_123456'
+            },
+            response: {
+                id: 'off_123456',
+                totalAmount: '450.00',
+                totalCurrency: 'USD',
+                expiresAt: '2024-03-01T12:00:00Z',
+                slices: [
+                    {
+                        origin: {
+                            code: 'JFK',
+                            name: 'John F. Kennedy International Airport',
+                            city: 'New York'
+                        },
+                        destination: {
+                            code: 'LAX',
+                            name: 'Los Angeles International Airport',
+                            city: 'Los Angeles'
+                        },
+                        duration: 'PT6H30M',
+                        segments: [
+                            {
+                                id: 'seg_123',
+                                origin: 'JFK',
+                                destination: 'LAX',
+                                departingAt: '2024-03-15T08:00:00Z',
+                                arrivingAt: '2024-03-15T14:30:00Z',
+                                duration: 'PT6H30M',
+                                airline: {
+                                    name: 'American Airlines',
+                                    code: 'AA',
+                                    flightNumber: '123'
+                                },
+                                aircraft: 'Boeing 777-300ER'
+                            }
+                        ]
+                    }
+                ],
+                passengers: [
+                    {
+                        id: 'pas_123',
+                        type: 'adult',
+                        fareType: 'economy',
+                        baggageAllowance: [
+                            {
+                                type: 'checked',
+                                quantity: 1
+                            },
+                            {
+                                type: 'carry_on',
+                                quantity: 1
+                            }
+                        ]
+                    }
+                ],
+                conditions: {
+                    refundBeforeDeparture: {
+                        allowed: false
+                    },
+                    changeBeforeDeparture: {
+                        allowed: true,
+                        penaltyAmount: '75.00',
+                        penaltyCurrency: 'USD'
+                    }
+                },
+                paymentRequirements: {
+                    requiresInstantPayment: true,
+                    priceGuaranteeExpiresAt: '2024-03-01T12:00:00Z'
+                }
+            }
+        }
+    })
+    @UseGuards(OAuthGuard)
+    @Widget('flight-details')
+    async getFlightDetails(input: any, ctx: ExecutionContext) {
+        ctx.logger.info('Getting flight details', {
+            user: ctx.auth?.subject,
+            offerId: input.offerId
+        });
+
+        const offer = await this.duffelService.getOffer(input.offerId);
+
+        return {
+            id: offer.id,
+            totalAmount: offer.total_amount,
+            totalCurrency: offer.total_currency,
+            expiresAt: offer.expires_at,
+
+            slices: offer.slices.map((slice: any) => ({
+                origin: {
+                    code: slice.origin.iata_code,
+                    name: slice.origin.name,
+                    city: slice.origin.city_name
+                },
+                destination: {
+                    code: slice.destination.iata_code,
+                    name: slice.destination.name,
+                    city: slice.destination.city_name
+                },
+                duration: slice.duration,
+                segments: slice.segments.map((seg: any) => ({
+                    id: seg.id,
+                    origin: seg.origin.iata_code,
+                    destination: seg.destination.iata_code,
+                    departingAt: seg.departing_at,
+                    arrivingAt: seg.arriving_at,
+                    duration: seg.duration,
+                    airline: {
+                        name: seg.marketing_carrier.name,
+                        code: seg.marketing_carrier.iata_code,
+                        flightNumber: seg.marketing_carrier_flight_number
+                    },
+                    aircraft: seg.aircraft?.name,
+                    operatingCarrier: seg.operating_carrier?.name,
+                    distance: seg.distance
+                }))
+            })),
+
+            passengers: offer.passengers.map((pax: any) => ({
+                id: pax.id,
+                type: pax.type,
+                fareType: pax.fare_type,
+                baggageAllowance: pax.baggages?.map((bag: any) => ({
+                    type: bag.type,
+                    quantity: bag.quantity
+                }))
+            })),
+
+            conditions: {
+                refundBeforeDeparture: {
+                    allowed: offer.conditions?.refund_before_departure?.allowed || false,
+                    penaltyAmount: offer.conditions?.refund_before_departure?.penalty_amount,
+                    penaltyCurrency: offer.conditions?.refund_before_departure?.penalty_currency
+                },
+                changeBeforeDeparture: {
+                    allowed: offer.conditions?.change_before_departure?.allowed || false,
+                    penaltyAmount: offer.conditions?.change_before_departure?.penalty_amount,
+                    penaltyCurrency: offer.conditions?.change_before_departure?.penalty_currency
+                }
+            },
+
+            paymentRequirements: {
+                requiresInstantPayment: offer.payment_requirements?.requires_instant_payment,
+                priceGuaranteeExpiresAt: offer.payment_requirements?.price_guarantee_expires_at,
+                paymentRequiredBy: offer.payment_requirements?.payment_required_by
+            }
+        };
+    }
+
+    @Tool({
+        name: 'search_airports',
+        description: 'Search for airports by city name or airport code. Useful for finding IATA codes.',
+        inputSchema: z.object({
+            query: z.string().min(2).describe('City name or airport code to search for')
+        }),
+        examples: {
+            request: {
+                query: 'London'
+            },
+            response: {
+                query: 'London',
+                results: [
+                    {
+                        id: 'arp_lhr_gb',
+                        name: 'Heathrow Airport',
+                        iataCode: 'LHR',
+                        icaoCode: 'EGLL',
+                        cityName: 'London',
+                        type: 'airport',
+                        latitude: 51.4700,
+                        longitude: -0.4543,
+                        timeZone: 'Europe/London'
+                    },
+                    {
+                        id: 'arp_lgw_gb',
+                        name: 'Gatwick Airport',
+                        iataCode: 'LGW',
+                        icaoCode: 'EGKK',
+                        cityName: 'London',
+                        type: 'airport',
+                        latitude: 51.1537,
+                        longitude: -0.1821,
+                        timeZone: 'Europe/London'
+                    },
+                    {
+                        id: 'arp_stn_gb',
+                        name: 'Stansted Airport',
+                        iataCode: 'STN',
+                        icaoCode: 'EGSS',
+                        cityName: 'London',
+                        type: 'airport',
+                        latitude: 51.8860,
+                        longitude: 0.2389,
+                        timeZone: 'Europe/London'
+                    }
+                ]
+            }
+        }
+    })
+    @UseGuards(OAuthGuard)
+    @Widget('airport-search')
+    async searchAirports(input: any, ctx: ExecutionContext) {
+        ctx.logger.info('Searching airports', {
+            user: ctx.auth?.subject,
+            query: input.query
+        });
+
+        const places = await this.duffelService.searchAirports(input.query);
+
+        return {
+            query: input.query,
+            results: places.slice(0, 10).map((place: any) => ({
+                id: place.id,
+                name: place.name,
+                iataCode: place.iata_code,
+                icaoCode: place.icao_code,
+                cityName: place.city_name,
+                type: place.type,
+                latitude: place.latitude,
+                longitude: place.longitude,
+                timeZone: place.time_zone
+            }))
+        };
+    }
+}

--- a/sample-apps/concord-governance-agent/src/services/duffel.service.ts
+++ b/sample-apps/concord-governance-agent/src/services/duffel.service.ts
@@ -1,0 +1,287 @@
+import { Duffel } from '@duffel/api';
+import { Injectable } from '@nitrostack/core';
+
+/**
+ * Duffel API Service
+ * 
+ * Handles all interactions with the Duffel API for flight search and booking.
+ * Implements best practices from Duffel documentation.
+ */
+@Injectable()
+export class DuffelService {
+    private duffel: Duffel;
+
+    constructor() {
+        let apiKey = process.env.DUFFEL_API_KEY;
+        if (!apiKey) {
+            console.error('⚠️  Warning: DUFFEL_API_KEY environment variable is missing.');
+            console.error('   Running with a dummy key for testing/dry-run mode.\n');
+            apiKey = 'duffel_test_dummy_key';
+        }
+
+        this.duffel = new Duffel({
+            token: apiKey
+        });
+    }
+
+    /**
+     * Search for flights using offer requests
+     * 
+     * @param params Search parameters
+     * @returns Flight offers
+     */
+    async searchFlights(params: {
+        origin: string;
+        destination: string;
+        departureDate: string;
+        returnDate?: string;
+        passengers: Array<{ type: 'adult' } | { type: 'child'; age: number } | { type: 'infant_without_seat' }>;
+        cabinClass?: 'economy' | 'premium_economy' | 'business' | 'first';
+        maxConnections?: number;
+        departureTime?: { from: string; to: string };
+        arrivalTime?: { from: string; to: string };
+    }) {
+        try {
+            const slices: any[] = [
+                {
+                    origin: params.origin,
+                    destination: params.destination,
+                    departure_date: params.departureDate,
+                    ...(params.departureTime && { departure_time: params.departureTime }),
+                    ...(params.arrivalTime && { arrival_time: params.arrivalTime })
+                }
+            ];
+
+            // Add return slice if round trip
+            if (params.returnDate) {
+                slices.push({
+                    origin: params.destination,
+                    destination: params.origin,
+                    departure_date: params.returnDate
+                });
+            }
+
+            const offerRequest = await this.duffel.offerRequests.create({
+                slices,
+                passengers: params.passengers as any,
+                cabin_class: params.cabinClass,
+                max_connections: params.maxConnections as 0 | 1 | 2 | undefined,
+                return_offers: true
+            });
+
+            return {
+                id: offerRequest.data.id,
+                offers: offerRequest.data.offers || [],
+                passengers: offerRequest.data.passengers,
+                slices: offerRequest.data.slices
+            };
+        } catch (error: any) {
+            throw new Error(`Flight search failed: ${error.message || JSON.stringify(error.errors || error)}`);
+        }
+    }
+
+    /**
+     * Get a specific offer by ID
+     */
+    async getOffer(offerId: string) {
+        try {
+            const offer = await this.duffel.offers.get(offerId);
+            return offer.data;
+        } catch (error: any) {
+            throw new Error(`Failed to get offer: ${error.message}`);
+        }
+    }
+
+    /**
+     * Get available seats for an offer
+     */
+    async getAvailableSeats(offerId: string) {
+        try {
+            const seatMaps = await this.duffel.seatMaps.get({ offer_id: offerId });
+            return seatMaps.data;
+        } catch (error: any) {
+            throw new Error(`Failed to get seat maps: ${error.message}`);
+        }
+    }
+
+
+    /**
+     * Generate a simple UUID-like identifier
+     */
+    private generateId(): string {
+        return 'pas_' + Date.now().toString(36) + Math.random().toString(36).substr(2, 9);
+    }
+
+    /**
+     * Create an order (book a flight) with optional hold
+     * This creates a new offer request with passenger details to get passenger IDs,
+     * then uses those IDs to create the order
+     */
+    async createOrder(params: {
+        selectedOffers: string[];
+        passengers: Array<{
+            title: 'mr' | 'ms' | 'mrs' | 'miss' | 'dr';
+            given_name: string;
+            family_name: string;
+            gender: 'M' | 'F';
+            born_on: string;
+            email: string;
+            phone_number: string;
+        }>;
+    }) {
+        try {
+            // Step 1: Get the offer to extract flight details
+            const offer = await this.duffel.offers.get(params.selectedOffers[0]);
+            const offerData = offer.data;
+
+            // Step 2: Create a new offer request with passenger details to get passenger IDs
+            const offerRequest = await this.duffel.offerRequests.create({
+                slices: offerData.slices.map((slice: any) => ({
+                    origin: slice.origin.iata_code,
+                    destination: slice.destination.iata_code,
+                    departure_date: slice.segments[0].departing_at.split('T')[0]
+                })),
+                passengers: params.passengers.map(p => ({
+                    type: 'adult', // Simplified - you can enhance this based on age
+                    given_name: p.given_name,
+                    family_name: p.family_name,
+                    title: p.title,
+                    gender: p.gender.toLowerCase() as 'm' | 'f',
+                    born_on: p.born_on,
+                    email: p.email,
+                    phone_number: p.phone_number
+                })),
+                cabin_class: (offerData as any).cabin_class || 'economy',
+                return_offers: true  // We need offers to be returned!
+            } as any);
+
+            const passengerIds = offerRequest.data.passengers.map((p: any) => p.id);
+
+            // Step 3: Create order using passenger IDs from the NEW offer request
+            // We need to use an offer from THIS offer request, not the original one
+            const newOfferId = (offerRequest.data as any).offers?.[0]?.id;
+
+            if (!newOfferId) {
+                throw new Error('No offers returned from offer request with passenger details');
+            }
+
+            const orderData: any = {
+                selected_offers: [newOfferId],  // Use offer from the NEW request
+                passengers: passengerIds.map((id: string, index: number) => ({
+                    id: id,
+                    ...params.passengers[index],
+                    gender: params.passengers[index].gender.toLowerCase()
+                })),
+                type: 'hold'  // Always create hold orders
+            };
+
+            const order = await this.duffel.orders.create(orderData);
+            return order.data;
+        } catch (error: any) {
+            // Log detailed error information
+            const errorDetails = {
+                message: error.message,
+                errors: error.errors,
+                response: error.response?.data,
+                status: error.response?.status
+            };
+            console.error('Duffel order creation failed:', JSON.stringify(errorDetails, null, 2));
+
+            throw new Error(`Failed to create order: ${error.message || JSON.stringify(error.errors || error.response?.data || error)}`);
+        }
+    }
+
+
+
+    /**
+     * Get available seats for an offer
+     */
+    async getSeatsForOffer(offerId: string) {
+        try {
+            const seatMaps = await this.duffel.seatMaps.get({ offer_id: offerId });
+            return seatMaps.data;
+        } catch (error: any) {
+            throw new Error(`Failed to get seats: ${error.message || JSON.stringify(error.errors || error)}`);
+        }
+    }
+
+    /**
+     * Create order change request for seats
+     */
+    async createOrderChangeForSeats(orderId: string) {
+        try {
+            const changeRequest = await this.duffel.orderChangeRequests.create({
+                order_id: orderId
+            } as any);
+            return changeRequest.data;
+        } catch (error: any) {
+            throw new Error(`Failed to create order change: ${error.message || JSON.stringify(error.errors || error)}`);
+        }
+    }
+
+    /**
+     * Get available services (baggage, seats) for an order
+     */
+    async getAvailableServices(orderId: string) {
+        try {
+            const services = await this.duffel.orderChangeRequests.create({
+                order_id: orderId
+            } as any);
+            return services.data;
+        } catch (error: any) {
+            throw new Error(`Failed to get available services: ${error.message || JSON.stringify(error.errors || error)}`);
+        }
+    }
+
+    /**
+     * Get order details
+     */
+    async getOrder(orderId: string) {
+        try {
+            const order = await this.duffel.orders.get(orderId);
+            return order.data;
+        } catch (error: any) {
+            throw new Error(`Failed to get order: ${error.message}`);
+        }
+    }
+
+    /**
+     * Cancel an order
+     */
+    async cancelOrder(orderId: string) {
+        try {
+            const cancellation = await this.duffel.orderCancellations.create({
+                order_id: orderId
+            });
+            return cancellation.data;
+        } catch (error: any) {
+            throw new Error(`Failed to cancel order: ${error.message}`);
+        }
+    }
+
+    /**
+     * Search for airports by query
+     */
+    async searchAirports(query: string) {
+        try {
+            const suggestions = await this.duffel.suggestions.list({
+                query: query
+            });
+            return suggestions.data;
+        } catch (error: any) {
+            throw new Error(`Failed to search airports: ${error.message}`);
+        }
+    }
+
+    /**
+     * Get airlines list
+     */
+    async getAirlines() {
+        try {
+            const airlines = await this.duffel.airlines.list();
+            return airlines.data;
+        } catch (error: any) {
+            throw new Error(`Failed to get airlines: ${error.message}`);
+        }
+    }
+}

--- a/sample-apps/concord-governance-agent/src/state/state.ts
+++ b/sample-apps/concord-governance-agent/src/state/state.ts
@@ -1,0 +1,155 @@
+export interface Cluster {
+  id: string;
+  region: string;
+  status: 'healthy' | 'halted' | 'isolated';
+  queue_length: number;
+  active_deployments: string[];
+  prioritized_branches?: Array<{ branch_id: string; urgency_level: string; prioritized_at: string }>;
+}
+
+export interface Threat {
+  id: string;
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  description: string;
+  affected_node: string;
+}
+
+export interface Ledger {
+  department: string;
+  budget: number;
+  burn_rate: number;
+  floor: number;
+}
+
+export interface Contract {
+  cluster_id: string;
+  customer: string;
+  penalty_clause_inr: number;
+  deadline: string;
+}
+
+export interface PendingAction {
+  id: string;
+  tool_name: string;
+  params: Record<string, unknown>;
+  briefing_text: string;
+  conflict: ConflictResult | null;
+  timestamp: string;
+}
+
+export interface ConflictResult {
+  has_conflict: boolean;
+  conflict_type: string;
+  message: string;
+}
+
+export interface DeploymentMetrics {
+  error_rate: number;
+  latency_p99: number;
+}
+
+export interface Deployment {
+  id: string;
+  service_id: string;
+  cluster_id: string;
+  image_tag: string;
+  strategy: string;
+  traffic_pct: number;
+  phase: string;
+  metrics: DeploymentMetrics;
+  status: 'active' | 'complete' | 'rolled_back';
+  started_at: string;
+}
+
+export interface AppState {
+  devops: { clusters: Cluster[]; deployments: Deployment[] };
+  secops: { threats: Threat[]; isolated_nodes?: Array<{ node_id: string; isolated_at: string }> };
+  finops: { ledgers: Ledger[]; contracts: Contract[] };
+  iam: { active_session: { role: string; name: string } };
+  weather: { last_fetched: string | null; risk_signal: string | null; condition?: string };
+  pending_actions: PendingAction[];
+}
+
+const state: AppState = {
+  devops: {
+    clusters: [
+      { id: 'PROD-01',    region: 'Chennai DC',   status: 'healthy', queue_length: 2, active_deployments: ['payments-service', 'checkout-service'] },
+      { id: 'PROD-02',    region: 'Chennai DC',   status: 'healthy', queue_length: 0, active_deployments: ['api-gateway', 'auth-service'] },
+      { id: 'STAGING-01', region: 'Chennai DC',   status: 'healthy', queue_length: 0, active_deployments: ['canary-staging'] },
+      { id: 'PROD-03',    region: 'Mumbai DC',    status: 'healthy', queue_length: 1, active_deployments: ['inventory-service', 'search-service'] },
+      { id: 'EU-WEST-01', region: 'Frankfurt DC', status: 'healthy', queue_length: 0, active_deployments: ['eu-gateway', 'gdpr-compliance-service'] }
+    ],
+    deployments: []
+  },
+  secops: {
+    threats: [
+      { id: 'THR-01', severity: 'low',    description: 'Unpatched dependency in staging',              affected_node: 'PROD-02' },
+      { id: 'THR-02', severity: 'medium', description: 'Anomalous outbound traffic from search-service', affected_node: 'PROD-03' }
+    ]
+  },
+  finops: {
+    ledgers: [
+      { department: 'Engineering', budget: 500000, burn_rate: 12000, floor: 100000 },
+      { department: 'Security',    budget: 150000, burn_rate: 8000,  floor: 20000  },
+      { department: 'UI/Design',   budget: 80000,  burn_rate: 3000,  floor: 10000  }
+    ],
+    contracts: [
+      { cluster_id: 'PROD-01', customer: 'Acme Corp', penalty_clause_inr: 40000, deadline: '2026-07-18T18:00:00Z' }
+    ]
+  },
+  iam: { active_session: { role: 'CISO', name: 'Demo User' } },
+  weather: { last_fetched: null, risk_signal: null },
+  pending_actions: []
+};
+
+export const getState  = () => state;
+export const getDevops = () => state.devops;
+export const getSecops = () => state.secops;
+export const getFinops = () => state.finops;
+export const getIam    = () => state.iam;
+export const getWeather = () => state.weather;
+
+export function setWeather(data: { condition: string; risk: string }) {
+  state.weather = { risk_signal: data.risk, condition: data.condition, last_fetched: new Date().toISOString() };
+}
+
+export function haltCluster(clusterId: string) {
+  const c = state.devops.clusters.find(c => c.id === clusterId);
+  if (c) { c.status = 'halted'; c.active_deployments = []; }
+}
+
+export function reallocateCapital(sourceDept: string, targetDept: string, amount: number) {
+  const src = state.finops.ledgers.find(l => l.department === sourceDept);
+  const tgt = state.finops.ledgers.find(l => l.department === targetDept);
+  if (src && tgt) { src.budget -= amount; tgt.budget += amount; }
+}
+
+export function prioritizeBranch(branchId: string, urgencyLevel: string) {
+  state.devops.clusters.forEach(c => {
+    if (!c.prioritized_branches) c.prioritized_branches = [];
+    c.prioritized_branches.push({ branch_id: branchId, urgency_level: urgencyLevel, prioritized_at: new Date().toISOString() });
+  });
+}
+
+export function isolateNode(nodeId: string) {
+  state.devops.clusters.forEach(c => { if (c.id === nodeId) c.status = 'isolated'; });
+  if (!state.secops.isolated_nodes) state.secops.isolated_nodes = [];
+  const alreadyIsolated = state.secops.isolated_nodes.some(n => n.node_id === nodeId);
+  if (!alreadyIsolated) {
+    state.secops.isolated_nodes.push({ node_id: nodeId, isolated_at: new Date().toISOString() });
+  }
+}
+
+export function addPendingAction(action: PendingAction) { state.pending_actions.push(action); }
+export function removePendingAction(id: string) { state.pending_actions = state.pending_actions.filter(a => a.id !== id); }
+export function getPendingAction(id: string) { return state.pending_actions.find(a => a.id === id); }
+
+export function addDeployment(dep: Deployment) { state.devops.deployments.push(dep); }
+export function updateDeployment(id: string, patch: Partial<Deployment>) {
+  const dep = state.devops.deployments.find(d => d.id === id);
+  if (dep) Object.assign(dep, patch);
+}
+export function removeDeployment(id: string) {
+  state.devops.deployments = state.devops.deployments.filter(d => d.id !== id);
+}
+export function getDeployment(id: string) { return state.devops.deployments.find(d => d.id === id); }

--- a/sample-apps/concord-governance-agent/src/widgets/app/globals.css
+++ b/sample-apps/concord-governance-agent/src/widgets/app/globals.css
@@ -1,0 +1,167 @@
+/* Nitrocloud Widget Styles - Professional Theme */
+
+:root {
+  /* Professional Color Palette */
+  --primary: #3B82F6;
+  --primary-hover: #2563EB;
+  --secondary: #6B7280;
+  --secondary-hover: #4B5563;
+
+  --success: #10B981;
+  --warning: #F59E0B;
+  --error: #EF4444;
+  --info: #3B82F6;
+
+  /* Light Theme */
+  --bg-primary: #FFFFFF;
+  --bg-secondary: #F9FAFB;
+  --bg-tertiary: #F3F4F6;
+  --bg-elevated: #FFFFFF;
+
+  --text-primary: #111827;
+  --text-secondary: #6B7280;
+  --text-muted: #9CA3AF;
+
+  --border-color: #E5E7EB;
+  --border-hover: #D1D5DB;
+
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+}
+
+.dark {
+  /* Dark Theme */
+  --bg-primary: #111827;
+  --bg-secondary: #1F2937;
+  --bg-tertiary: #374151;
+  --bg-elevated: #1F2937;
+
+  --text-primary: #F9FAFB;
+  --text-secondary: #D1D5DB;
+  --text-muted: #9CA3AF;
+
+  --border-color: #374151;
+  --border-hover: #4B5563;
+
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.5);
+}
+
+/* Reset */
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Card Styles */
+.card {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 16px;
+  transition: all 0.2s ease;
+  box-shadow: var(--shadow-sm);
+}
+
+.card:hover {
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-md);
+}
+
+/* Button Styles */
+.btn-primary {
+  background: var(--primary);
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 14px;
+}
+
+.btn-primary:hover {
+  background: var(--primary-hover);
+  box-shadow: var(--shadow-md);
+}
+
+.btn-secondary {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  padding: 10px 20px;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 14px;
+}
+
+.btn-secondary:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--border-hover);
+}
+
+/* Badge Styles */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.badge-success {
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--success);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+}
+
+.badge-warning {
+  background: rgba(245, 158, 11, 0.1);
+  color: var(--warning);
+  border: 1px solid rgba(245, 158, 11, 0.2);
+}
+
+.badge-error {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--error);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+}
+
+.badge-info {
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--info);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.dark .badge-success {
+  background: rgba(16, 185, 129, 0.2);
+  color: #6EE7B7;
+}
+
+.dark .badge-warning {
+  background: rgba(245, 158, 11, 0.2);
+  color: #FCD34D;
+}
+
+.dark .badge-error {
+  background: rgba(239, 68, 68, 0.2);
+  color: #FCA5A5;
+}
+
+.dark .badge-info {
+  background: rgba(59, 130, 246, 0.2);
+  color: #93C5FD;
+}

--- a/sample-apps/concord-governance-agent/src/widgets/app/governance-dashboard/page.tsx
+++ b/sample-apps/concord-governance-agent/src/widgets/app/governance-dashboard/page.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useWidgetSDK, useTheme } from '@nitrostack/widgets';
+
+interface PendingAction {
+  id: string;
+  tool_name: string;
+  has_conflict: boolean;
+  timestamp: string;
+}
+
+interface GovernanceData {
+  pending_count: number;
+  actions: PendingAction[];
+}
+
+function Badge({ label, color }: { label: string; color: string }) {
+  return (
+    <span style={{
+      display: 'inline-block',
+      padding: '2px 8px',
+      borderRadius: '9999px',
+      fontSize: '11px',
+      fontWeight: 700,
+      background: color === 'green' ? '#14532d' : color === 'red' ? '#7f1d1d' : color === 'amber' ? '#78350f' : '#1e3a5f',
+      color: color === 'green' ? '#86efac' : color === 'red' ? '#fca5a5' : color === 'amber' ? '#fcd34d' : '#93c5fd',
+    }}>
+      {label}
+    </span>
+  );
+}
+
+function ToolLabel({ name }: { name: string }) {
+  const map: Record<string, string> = {
+    halt_deployment_pipeline: 'Halt Deployment',
+    reallocate_capital: 'Reallocate Budget',
+    prioritize_engineering_branch: 'Prioritize Branch',
+    isolate_compromised_node: 'Isolate Node',
+  };
+  return <span>{map[name] ?? name}</span>;
+}
+
+export default function GovernanceDashboard() {
+  const { getToolOutput, callTool } = useWidgetSDK();
+  const theme = useTheme();
+  const data = getToolOutput<GovernanceData>();
+  const isDark = theme === 'dark';
+
+  const bg   = isDark ? '#020617' : '#ffffff';
+  const card = isDark ? '#0f172a' : '#f8fafc';
+  const bdr  = isDark ? '#1e293b' : '#e2e8f0';
+  const txt  = isDark ? '#f1f5f9' : '#0f172a';
+  const muted = isDark ? '#94a3b8' : '#64748b';
+
+  const handleApprove = async (id: string) => {
+    try { await callTool('approve_action', { action_id: id }); } catch {}
+  };
+  const handleDeny = async (id: string) => {
+    try { await callTool('deny_action', { action_id: id }); } catch {}
+  };
+
+  const pendingCount = data?.pending_count ?? 0;
+  const actions: PendingAction[] = data?.actions ?? [];
+
+  return (
+    <div style={{ padding: '16px', background: bg, color: txt, fontFamily: 'system-ui, sans-serif', minHeight: '100%' }}>
+      {/* Header */}
+      <div style={{ marginBottom: '16px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div>
+          <div style={{ fontSize: '16px', fontWeight: 700, letterSpacing: '-0.01em' }}>Concord</div>
+          <div style={{ fontSize: '11px', color: muted, marginTop: '2px' }}>cross-departmental governance agent</div>
+        </div>
+        <div style={{
+          background: pendingCount > 0 ? '#7f1d1d' : '#14532d',
+          color: pendingCount > 0 ? '#fca5a5' : '#86efac',
+          borderRadius: '9999px',
+          padding: '4px 12px',
+          fontSize: '13px',
+          fontWeight: 700,
+        }}>
+          {pendingCount} pending
+        </div>
+      </div>
+
+      {/* Pending actions */}
+      {actions.length === 0 ? (
+        <div style={{
+          background: card,
+          border: `1px solid ${bdr}`,
+          borderRadius: '12px',
+          padding: '32px',
+          textAlign: 'center',
+          color: muted,
+          fontSize: '13px',
+        }}>
+          <div style={{ fontSize: '32px', marginBottom: '8px' }}>✅</div>
+          No actions pending approval
+        </div>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
+          {actions.map(a => (
+            <div key={a.id} style={{
+              background: card,
+              border: `1px solid ${a.has_conflict ? '#78350f' : bdr}`,
+              borderLeft: `4px solid ${a.has_conflict ? '#f59e0b' : '#6366f1'}`,
+              borderRadius: '12px',
+              padding: '14px 16px',
+            }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', flexWrap: 'wrap', gap: '8px' }}>
+                <div>
+                  <div style={{ fontWeight: 600, fontSize: '13px' }}>
+                    <ToolLabel name={a.tool_name} />
+                  </div>
+                  <div style={{ fontSize: '11px', color: muted, marginTop: '4px', fontFamily: 'monospace' }}>
+                    {a.id}
+                  </div>
+                </div>
+                <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+                  {a.has_conflict && <Badge label="⚠ CONFLICT" color="amber" />}
+                  <Badge label="AWAITING" color="blue" />
+                </div>
+              </div>
+
+              <div style={{ marginTop: '12px', display: 'flex', gap: '8px' }}>
+                <button
+                  onClick={() => handleApprove(a.id)}
+                  style={{
+                    flex: 1,
+                    padding: '7px',
+                    background: '#14532d',
+                    color: '#86efac',
+                    border: 'none',
+                    borderRadius: '8px',
+                    cursor: 'pointer',
+                    fontWeight: 600,
+                    fontSize: '12px',
+                  }}
+                >
+                  ✓ Approve
+                </button>
+                <button
+                  onClick={() => handleDeny(a.id)}
+                  style={{
+                    flex: 1,
+                    padding: '7px',
+                    background: '#7f1d1d',
+                    color: '#fca5a5',
+                    border: 'none',
+                    borderRadius: '8px',
+                    cursor: 'pointer',
+                    fontWeight: 600,
+                    fontSize: '12px',
+                  }}
+                >
+                  ✗ Deny
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Footer hint */}
+      <div style={{ marginTop: '16px', fontSize: '10px', color: muted, textAlign: 'center' }}>
+        Powered by Nitrostack · Human-in-the-loop governance
+      </div>
+    </div>
+  );
+}

--- a/sample-apps/concord-governance-agent/src/widgets/app/layout.tsx
+++ b/sample-apps/concord-governance-agent/src/widgets/app/layout.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { WidgetLayout } from '@nitrostack/widgets';
+import './globals.css';
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, padding: 0, fontFamily: 'system-ui, sans-serif' }}>
+        <WidgetLayout>{children}</WidgetLayout>
+      </body>
+    </html>
+  );
+}

--- a/sample-apps/concord-governance-agent/src/widgets/next-env.d.ts
+++ b/sample-apps/concord-governance-agent/src/widgets/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/sample-apps/concord-governance-agent/src/widgets/next.config.js
+++ b/sample-apps/concord-governance-agent/src/widgets/next.config.js
@@ -1,0 +1,45 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['nitrostack'],
+  
+  // Static export for production builds
+  ...(process.env.NODE_ENV === 'production' && {
+    output: 'export',
+    distDir: 'out',
+    images: {
+      unoptimized: true,
+    },
+  }),
+  
+  // Development optimizations to prevent cache corruption
+  ...(process.env.NODE_ENV === 'development' && {
+    // Use memory cache instead of filesystem cache in dev to avoid stale chunks
+    webpack: (config, { isServer }) => {
+      // Disable persistent caching in development to prevent chunk reference errors
+      if (config.cache && config.cache.type === 'filesystem') {
+        config.cache = {
+          type: 'memory',
+        };
+      }
+      
+      // Improve cache busting for new files
+      if (!isServer) {
+        config.cache = false; // Disable cache completely on client in dev
+      }
+      
+      return config;
+    },
+    
+    // Disable build activity indicator which can cause issues
+    devIndicators: {
+      buildActivity: false,
+      buildActivityPosition: 'bottom-right',
+    },
+    
+    // Faster dev server
+    compress: false,
+  }),
+};
+
+export default nextConfig;

--- a/sample-apps/concord-governance-agent/src/widgets/package-lock.json
+++ b/sample-apps/concord-governance-agent/src/widgets/package-lock.json
@@ -1,0 +1,2643 @@
+{
+  "name": "flight-booking-widgets",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "flight-booking-widgets",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0",
+        "@nitrostack/core": "^1.0.13",
+        "@nitrostack/widgets": "^1.0.8",
+        "next": "^14.2.5",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20",
+        "@types/react": "^18",
+        "@types/react-dom": "^18",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.4.tgz",
+      "integrity": "sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.33.tgz",
+      "integrity": "sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nitrostack/core": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@nitrostack/core/-/core-1.0.13.tgz",
+      "integrity": "sha512-cmQqqioxvhvOmASlAAwzFMnFWDcvlrEP47v455UraeZqhrZvm8Jr7ePo2GtpSir4t7OA6uIKhRpVb5XeLDjM5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.4",
+        "bcryptjs": "^2.4.3",
+        "cors": "^2.8.5",
+        "dotenv": "^17.2.3",
+        "express": "^4.21.2",
+        "jose": "^6.1.0",
+        "jsonwebtoken": "^9.0.2",
+        "reflect-metadata": "^0.2.1",
+        "uuid": "^11.0.5",
+        "winston": "^3.17.0",
+        "ws": "^8.18.3",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0"
+      }
+    },
+    "node_modules/@nitrostack/widgets": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@nitrostack/widgets/-/widgets-1.0.8.tgz",
+      "integrity": "sha512-/E8MAgOp/rYOyRNydzamxsJAhsBp7Q9A8LYB7m+kqy+o0ubLBsU7rb1EIaIg8JX8KPdxfchxqwo0HxzUWRsYDg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0",
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
+      "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001757",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001757.tgz",
+      "integrity": "sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.33.tgz",
+      "integrity": "sha512-GiKHLsD00t4ACm1p00VgrI0rUFAC9cRDGReKyERlM57aeEZkOQGcZTpIbsGn0b562FTPJWmYfKwplfO9EaT6ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.33",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/sample-apps/concord-governance-agent/src/widgets/package.json
+++ b/sample-apps/concord-governance-agent/src/widgets/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "flight-booking-widgets",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3001 --port 3001",
+    "build": "next build",
+    "start": "next start -p 3001"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/ext-apps": ">=0.1.0",
+    "@nitrostack/core": "^1.0.13",
+    "@nitrostack/widgets": "^1.0.8",
+    "next": "^14.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "typescript": "^5"
+  }
+}

--- a/sample-apps/concord-governance-agent/src/widgets/tsconfig.json
+++ b/sample-apps/concord-governance-agent/src/widgets/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}
+

--- a/sample-apps/concord-governance-agent/src/widgets/widget-manifest.json
+++ b/sample-apps/concord-governance-agent/src/widgets/widget-manifest.json
@@ -1,0 +1,43 @@
+{
+  "version": "1.0.0",
+  "widgets": [
+    {
+      "uri": "/governance-dashboard",
+      "name": "Governance Dashboard",
+      "description": "Live view of pending high-risk actions awaiting human approval, with approve/deny controls.",
+      "examples": [
+        {
+          "name": "Pending Halt with Conflict",
+          "description": "Shows a queued halt action that has a contract conflict",
+          "data": {
+            "pending_count": 1,
+            "actions": [
+              {
+                "id": "action-1784284250426",
+                "tool_name": "halt_deployment_pipeline",
+                "has_conflict": true,
+                "timestamp": "2025-07-17T10:00:00.000Z"
+              }
+            ]
+          }
+        },
+        {
+          "name": "No Pending Actions",
+          "description": "Clean state — all actions resolved",
+          "data": {
+            "pending_count": 0,
+            "actions": []
+          }
+        }
+      ],
+      "tags": [
+        "governance",
+        "devops",
+        "secops",
+        "finops",
+        "approval"
+      ]
+    }
+  ],
+  "generatedAt": "2025-07-17T00:00:00.000Z"
+}

--- a/sample-apps/concord-governance-agent/tsconfig.json
+++ b/sample-apps/concord-governance-agent/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022"],
+    "moduleResolution": "node",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/widgets"]
+}
+


### PR DESCRIPTION
## Description

Adds Concord as a sample MCP app — an autonomous governance agent for cloud infrastructure that unifies DevOps, SecOps, and FinOps decision-making into one agent. Built for the Amrita University MCP Hackathon 2026 (Open Innovation track).

## Type of Change

- [x] feat: New feature

## Related Issues

N/A — new sample app contribution, not tied to an existing issue.

## Changes Made

- Added `sample-apps/concord-governance-agent/` — a full Nitrostack MCP server with 15 tools, 5 resources, 1 prompt
- Autonomous governance loop: commit → build → cost-check → canary deploy → monitor → incident → root-cause → remediate
- Dynamic rule engine (7 governance rules) with hard budget-floor guardrails
- SHA-256 hash-chained audit trail (tamper-evident, verifiable via `verify_audit_chain`)
- Live AI root-cause analysis via Groq (`get_root_cause_analysis`)
- GitOps-style canary deployment tool with automatic rollback

## Testing

- [ ] `npm run lint`
- [ ] `npm test`
- [x] Manual testing performed — all 15 tools verified via direct MCP JSON-RPC calls (initialize, tool listing, and end-to-end tool execution including approve/deny flows, canary progression, and audit chain verification)

No lint/test scripts exist for this sample app specifically; it was verified by running the server (`npx nitrostack-cli dev`) and exercising the tools directly.

## Screenshots / Recordings

Live deployed instance: https://nitro-6a5-the-pixel-pirates-amrita-university-amritapuri-campus.app.nitrocloud.ai

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [ ] I have added/updated tests where appropriate
- [x] I have updated docs where appropriate
- [x] I have kept this PR focused and scoped
- [ ] I have used conventional commits