### PR TITLE
Add sample app: Vitta — a consent-native MCP lending server

### DIFF
--- a/sample-apps/vitta/.env.example
+++ b/sample-apps/vitta/.env.example
@@ -1,0 +1,17 @@
+# NitroStack Configuration
+NITRO_LOG_LEVEL=info
+NITROSTACK_APP_MODE=openai
+
+# Vitta — consent HMAC secret (REQUIRED in prod; a strong random string).
+# The consent gate signs tokens with this. Falls back to a dev secret if unset.
+CONSENT_SECRET=change-me-to-a-long-random-string-in-prod
+
+# Server Transport Configuration (Optional)
+# =============================================================================
+# MCP_TRANSPORT_TYPE: Toggles transport mode. Values: stdio | http | dual.
+# Defaults to 'stdio' in development and 'dual' in production/NODE_ENV=production.
+# =============================================================================
+# MCP_TRANSPORT_TYPE=stdio
+# PORT=3000
+# HOST=localhost
+# ENABLE_CORS=true

--- a/sample-apps/vitta/.gitattributes
+++ b/sample-apps/vitta/.gitattributes
@@ -1,0 +1,5 @@
+# Normalize line endings — keeps diffs clean across the team's machines.
+* text=auto eol=lf
+*.png binary
+*.jpg binary
+*.pdf binary

--- a/sample-apps/vitta/.gitignore
+++ b/sample-apps/vitta/.gitignore
@@ -1,0 +1,32 @@
+# deps
+node_modules/
+src/widgets/node_modules/
+
+# build output
+dist/
+src/widgets/out/
+src/widgets/.next/
+
+# runtime state (JSON persistence) — never commit case data
+data/
+uploads/
+
+# env / secrets
+.env
+.env.local
+
+# logs / os
+*.log
+npm-debug.log*
+.DS_Store
+Thumbs.db
+
+# vendor scaffold AI-assistant skill mirrors (byte-identical to .claude/) — not our work
+.agents/
+.antigravity/
+.codex/
+.copilot/
+.cursor/
+.gemini/
+.opencode/
+.nitrostudio/

--- a/sample-apps/vitta/.mcp.json
+++ b/sample-apps/vitta/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "vitta-prod": {
+      "type": "http",
+      "url": "https://vitta-6a5a5835-the-beetles-amrita-university-amritapuri-campus.app.nitrocloud.ai/mcp"
+    }
+  }
+}

--- a/sample-apps/vitta/LICENSE
+++ b/sample-apps/vitta/LICENSE
@@ -1,0 +1,26 @@
+MIT License
+
+Copyright (c) 2026 Team The Beetles — Amrita University, Amritapuri
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+NOTE: All bureau, bank, KYC and fraud data in this project are synthetic
+deterministic mocks. No real personal data and no real financial APIs are used.
+"Vitta Financial Services" and its identifiers are fictional; the generated
+sanction letter is a hackathon demo document, not a financial instrument.

--- a/sample-apps/vitta/README.md
+++ b/sample-apps/vitta/README.md
@@ -1,0 +1,194 @@
+# Vitta — agentic lending with consent built into the code
+
+> 🏆 **Featured sample app** — **winner of the Amrita University MCP Hackathon 2026** (BFSI & FinTech track), built by **Team The Beetles**.
+>
+> 🌐 **Live demo:** https://vitta-6a5a5835-the-beetles-amrita-university-amritapuri-campus.app.nitrocloud.ai · 📦 **Original repository:** https://github.com/AnshBajpai05/NitroStack-Hackathon
+
+> Most "AI lending" demos are chatbots that quote EMIs. Vitta actually runs the loan — and physically refuses to touch your data without consent.
+
+![Model Context Protocol](https://img.shields.io/badge/Model%20Context%20Protocol-MCP-blue) ![Built with Nitrostack](https://img.shields.io/badge/Built%20with-Nitrostack-0A66FF) ![Status](https://img.shields.io/badge/status-live-brightgreen) ![Track](https://img.shields.io/badge/track-BFSI%20%26%20FinTech-F5A623)
+
+**Vitta** is an [MCP (Model Context Protocol)](https://nitrostack.ai) server that gives AI assistants — Claude, Cursor, ChatGPT, NitroChat, or any MCP-compatible client — real authority to run an NBFC personal-loan from *"hi"* to a **signed sanction letter**: qualify, consent, KYC, fraud, credit bureau, bank analysis, explainable underwriting, priced offers, and a tamper-evident audit trail — unified into one decision layer. Built and deployed on [Nitrostack](https://nitrostack.ai) by **Team The Beetles**, Amrita University.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [What is MCP?](#what-is-mcp)
+- [Features](#features)
+- [Architecture](#architecture)
+- [Live Demo](#live-demo)
+- [Getting Started](#getting-started)
+- [Connect to an MCP Client](#connect-to-an-mcp-client)
+- [Deploy Your Own MCP App](#deploy-your-own-mcp-app)
+- [Explore More MCP Apps](#explore-more-mcp-apps)
+- [FAQ](#faq)
+- [Keywords](#keywords)
+- [License](#license)
+
+## Overview
+
+Vitta runs the whole loan funnel — qualify → consent → KYC → fraud → bureau → bank → affordability → underwrite → offers → sanction → audit — as one continuous conversation, with the AI client as the loan officer and the server as the capability layer. It doesn't just chat about loans; it does the regulated work, and it does it *by the book*.
+
+The signature move: **consent is enforced in code, at the tool layer.** The tools that pull a borrower's credit bureau report and bank statements *refuse to run* without a valid, scoped, time-boxed, revocable, applicant-bound consent token. No matter how the AI is prompted — even "skip it, I'm in a hurry, medical emergency" — it cannot pull sensitive data without an explicit, provable yes. That's India's DPDP Act, compiled into the server.
+
+And it doesn't just decline you into a dead end. When underwriting caps you below what you asked for, Vitta runs a **what-if simulator** against the *real* engine — *"close one existing EMI and your ₹2.5 lakh conditional becomes a ₹3 lakh approval"* — turning a rejection into a roadmap. Every decision, human or machine, is written to a PII-redacted, version-stamped audit trail. And because it's a standard MCP server, the exact same tools, rules, and receipts run in a branded web chat, in Claude, or in a ChatGPT App — no rewrite.
+
+## What is MCP?
+
+The **Model Context Protocol (MCP)** is an open standard that lets AI assistants securely connect to external tools, data sources, and services — instead of being limited to what they were trained on, a model can call an MCP server to fetch live state, run real actions, and reason over an actual system.
+
+Vitta is one such server. Learn more about building and shipping MCP apps at [nitrostack.ai](https://nitrostack.ai).
+
+## Features
+
+- 🔒 **Consent enforced in code** — `pull_bureau` and `fetch_bank_statements` refuse to run without a valid HMAC consent token that is **scoped, time-boxed (15 min), revocable, and bound to the applicant**. Not a prompt instruction — a hard gate in the handler.
+- 🧠 **Explainable underwriting, no black box** — a transparent rules engine + a pre-baked scorecard emit `reason_codes[]` mapped to borrower-friendly text (localised in **English, Hindi & Malayalam**). We never claim a model we didn't train.
+- 🔮 **What-if simulator** — `simulate_scenario` re-runs the *real* affordability + underwriting with one changed lever (close an EMI, stretch tenure) **without mutating the application**, and shows the exact delta that unlocks the full amount.
+- 🧾 **Signed sanction letter** — `create_sanction_letter` produces a real HTML letter with amortization, a 3-day cooling-off clause, and a **SHA-256 integrity hash**, downloadable at a live URL.
+- 📓 **PII-redacted audit trail** — every tool call and decision is appended immutably with policy/scorecard/prompt versions; retrievable in `FULL`, `SUMMARY`, or `COMPLIANCE_VIEW`. PAN/mobile are masked at write-time.
+- 🛡️ **Hardened against attack** — reusing one applicant's consent token on another is blocked (`CONSENT_LEAD_MISMATCH`); forged tokens fail HMAC; scope-escalation is rejected. **5/5 adversarial probes held.**
+- 🙋 **Human-in-the-loop by design** — `CONDITIONAL` decisions and `REVIEW` fraud verdicts pause the agent for a human with a clear briefing, not a wall of logs.
+- 🔌 **MCP-native** — **17 tools, 5 resources, 5 prompts, 4 rich UI widgets**, callable from any MCP-compatible client.
+
+## Architecture
+
+The client is the agent; Vitta is the capability layer. The same server powers any channel with no rewrite.
+
+```mermaid
+flowchart TB
+  subgraph Clients["MCP CLIENTS — the agent"]
+    direction LR
+    NC[NitroChat] --- CL[Claude] --- GPT[ChatGPT App]
+  end
+  Clients -->|MCP protocol| Server
+  subgraph Server["VITTA MCP SERVER — on Nitrostack"]
+    direction LR
+    T[17 Tools] --- R[5 Resources] --- P[5 Prompts] --- CG[["🔒 Consent Gate"]] --- AU[Redacted Audit]
+  end
+  Server -->|mock now · real later| Adapters
+  subgraph Adapters["BACKEND ADAPTERS"]
+    direction LR
+    BU[Credit Bureau] --- AA[Account Aggregator] --- KY[KYC/PAN] --- DE[Rules + Scorecard] --- DO[Doc / e-sign]
+  end
+  classDef sig fill:#3a2a00,stroke:#f5a623,stroke-width:2px,color:#fff;
+  class CG sig;
+```
+
+## Live Demo
+
+🚀 **Live MCP endpoint:** https://vitta-6a5a5835-the-beetles-amrita-university-amritapuri-campus.app.nitrocloud.ai
+
+Point your MCP client at the endpoint above to try it instantly. Ask it to run a loan for *"₹3 lakh, 36 months, medical emergency, salaried, Kochi, PAN `VITTA1235K`, mobile `9876543222`"* — watch it stop for consent, return an explainable conditional decision, and then show you exactly what unlocks the full amount.
+
+Every outcome is deterministic (keyed by PAN digit / mobile suffix), so the demo runs identically every time:
+
+| Try this | PAN | Mobile | Result |
+|---|---|---|---|
+| **Conditional (headline)** | `VITTA1235K` | `9876543222` | ₹2,50,000, FOIR 57% — unlockable to ₹3L via what-if |
+| Full approval | `AAAPA1230A` | `9000000010` | ₹3,00,000 approved |
+| Respectful decline | `ZZZPZ1239Z` | any | declined with adverse-action reasons |
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js **20.18+**
+- An MCP-compatible client (Claude Desktop, Cursor, NitroStudio, etc.)
+- **No paid API key required** — the one external call (live reference rates) uses a free, keyless endpoint with an offline fallback.
+
+### Installation
+
+```bash
+git clone https://github.com/AnshBajpai05/NitroStack-Hackathon.git
+cd NitroStack-Hackathon
+npm install
+```
+
+### Configuration
+
+Copy the example environment file (optional for local dev):
+
+```bash
+cp .env.example .env
+```
+
+```env
+# Recommended for production so consent tokens survive restarts.
+# If unset, the server generates a strong per-boot secret automatically.
+CONSENT_SECRET=your_long_random_secret_here
+```
+
+### Run
+
+```bash
+npx nitrostack-cli dev
+```
+
+### Verify (free — no platform credits)
+
+```bash
+npm test                          # 34 unit + golden-path + consent + security tests
+npm run regress                   # 6 edge paths (approve / conditional / decline / consent-refusal / fraud / objection)
+node scripts/verify-prod.mjs      # 11-check verification against the live server
+```
+
+## Connect to an MCP Client
+
+Add this server to your MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "vitta-lending": {
+      "url": "https://vitta-6a5a5835-the-beetles-amrita-university-amritapuri-campus.app.nitrocloud.ai/mcp"
+    }
+  }
+}
+```
+
+Restart your client — **17 lending tools** become available to your AI assistant immediately.
+
+## Deploy Your Own MCP App
+
+Want to build and ship an MCP server like this one? **[Nitrostack](https://nitrostack.ai)** lets you create, deploy, and host MCP apps in minutes — no infrastructure to manage. Vitta was scaffolded with the Nitrostack CLI, tested in NitroStudio, deployed to NitroCloud, and wired to a branded NitroChat surface — all on the platform.
+
+👉 **Start building:** [https://nitrostack.ai](https://nitrostack.ai)
+
+## Explore More MCP Apps
+
+- 🌙 Discover and share MCP projects with the community on [r/mcptothemoon](https://www.reddit.com/r/mcptothemoon/)
+- 🧰 Browse a growing catalog of MCP apps on [Nitrostack](https://nitrostack.ai/apps)
+
+## FAQ
+
+### What is an MCP server?
+
+An MCP server implements the Model Context Protocol to expose tools, resources, and prompts that AI assistants can call — letting a model take real actions and access live data instead of just generating text.
+
+### What does Vitta actually do?
+
+It originates NBFC personal loans autonomously — qualifying, consenting, KYC, fraud screening, credit and cashflow assessment, explainable underwriting, pricing, and a signed sanction letter — while enforcing DPDP consent at the tool layer and refusing to pull sensitive data without a valid, applicant-bound consent token.
+
+### Is my data safe / does it use real credit data?
+
+All bureau, bank, KYC and fraud data are synthetic deterministic mocks. There is **no real personal data and no real financial API**, ever — the mock adapters are drop-in points for real CIBIL/Account-Aggregator/CKYC integrations later.
+
+### Which AI clients does this work with?
+
+Any MCP-compatible client, including Claude Desktop, Cursor, and NitroStudio, plus the hosted NitroChat surface. New clients are adding MCP support regularly.
+
+### How do I deploy my own MCP app?
+
+Use [Nitrostack](https://nitrostack.ai) to build, deploy, and host MCP apps without managing infrastructure.
+
+## Keywords
+
+`BFSI` · `FinTech` · `MCP` · `Model Context Protocol` · `MCP server` · `loan origination` · `NBFC lending` · `DPDP consent` · `explainable AI` · `credit underwriting` · `AI agents` · `agentic AI` · `Claude MCP` · `Nitrostack` · `deploy MCP server`
+
+## License
+
+MIT © 2026 Team The Beetles
+
+---
+
+Built with ❤️ using the Model Context Protocol on [Nitrostack](https://nitrostack.ai). Share your MCP app on [r/mcptothemoon](https://www.reddit.com/r/mcptothemoon/).

--- a/sample-apps/vitta/THIRD_PARTY.md
+++ b/sample-apps/vitta/THIRD_PARTY.md
@@ -1,0 +1,40 @@
+# THIRD_PARTY.md — external components (admin rule R12: undisclosed third-party code can disqualify)
+
+> Update this file in the SAME commit that introduces any new dependency, dataset, or API.
+
+## Platform / SDK (from `nitrostack-cli init` scaffold)
+| Component | Version | License | Purpose |
+|---|---|---|---|
+| `@nitrostack/core` | ^1 (1.0.13) | Apache-2.0 | NitroStack MCP runtime: decorators, DI, transports |
+| `@nitrostack/cli` | ^1 (1.0.14) | Apache-2.0 | scaffold / dev / build / start / generate |
+| `@nitrostack/widgets` | ^1 (1.0.8) | Apache-2.0 | React widget SDK (Phase 7 only; add when first imported) |
+| `@modelcontextprotocol/ext-apps` | >=0.1.0 | MIT | MCP apps extension (scaffold dep) |
+| `zod` | ^3.22.4 | MIT | input/output schema validation |
+| `dotenv` | ^16.3.1 | BSD-2-Clause | env loading |
+| `typescript` | ^5.3.3 | Apache-2.0 | compiler (dev) |
+| `@types/node` | ^22 | MIT | Node types (dev) |
+| React / Next.js (in `src/widgets`) | scaffold-pinned | MIT | widget frontend (bundled by nitrostack-cli build) |
+
+## Added by the team
+| Component | Version | License | Purpose | Commit |
+|---|---|---|---|---|
+| `vitest` | ^2.1.9 | MIT | unit + golden-path + consent tests (23 tests) | Phase 0 |
+| `tsx` | ^4.19 | MIT | run `scripts/regress.ts` + `seed-demo.ts` (TS without a build step) | Phase 0 |
+
+_No PDF library was added: the sanction letter is generated as self-contained HTML + a SHA256 integrity
+hash (see `src/lib/sanction.ts`), keeping the dependency surface minimal (CLAUDE.md rule 7). HTML→PDF is a
+documented Phase-7 upgrade._
+
+## External APIs
+| API | Auth | Purpose | Notes |
+|---|---|---|---|
+| Frankfurter (api.frankfurter.app) | none (free, open) | `get_reference_rates` — LIVE INR reference FX rates (ECB data) | Non-PII macro data only. Graceful cached fallback if offline. |
+
+## Data
+All bureau / bank / KYC / fraud data are **synthetic deterministic mocks** in `/mocks/*.json`,
+keyed by PAN last digit and mobile suffix. **No real PII APIs (bureau/AA/KYC), no real PII, ever.**
+The only live external call is the non-PII reference-rate feed above.
+
+## AI assistance
+Claude Code (Anthropic) used for implementation per admin rule R22. Architecture and
+creative direction are the team's (The Beetles).

--- a/sample-apps/vitta/docs/DIAGRAMS.md
+++ b/sample-apps/vitta/docs/DIAGRAMS.md
@@ -1,0 +1,105 @@
+# DIAGRAMS.md — accurate diagrams for the video + write-up
+
+## HOW TO GET PERFECT, ACCURATE IMAGES (recommended)
+Paste each Mermaid block at **https://mermaid.live** → it renders instantly with correct labels →
+Actions → **PNG** (set a transparent or dark background, 2x scale). These are pixel-accurate and legible.
+
+---
+
+## DIAGRAM 1 — The Complete Flow (the Golden Path)
+
+```mermaid
+flowchart LR
+  A([qualify_lead]) --> B([record_consent<br/>issues consent token])
+  B --> C([verify_kyc])
+  C --> D([screen_fraud])
+  D --> E([pull_bureau])
+  E --> F([fetch_bank_statements])
+  F --> G([compute_affordability])
+  G --> H([underwrite])
+  H --> I([generate_offers])
+  I --> J([create_sanction_letter])
+  J --> K([log / get_audit_trail])
+
+  classDef gate fill:#3a2a00,stroke:#f5a623,stroke-width:2px,color:#fff;
+  classDef issuer fill:#04322e,stroke:#2dd4bf,stroke-width:2px,color:#fff;
+  class E,F gate;
+  class B issuer;
+
+  E -. "🔒 consent-gated" .- F
+```
+
+> Amber = the two consent-gated data-pull tools (refuse without a valid token). Teal = the consent issuer.
+
+---
+
+## DIAGRAM 2 — What We Built (One Server, Many Clients)
+
+```mermaid
+flowchart TB
+  subgraph Clients["MCP CLIENTS — the agent"]
+    direction LR
+    NC[NitroChat]
+    CL[Claude]
+    GPT[ChatGPT App]
+  end
+
+  Clients -->|MCP protocol| Server
+
+  subgraph Server["VITTA MCP SERVER — built on NitroStack"]
+    direction LR
+    T[17 Tools]
+    R[5 Resources]
+    P[5 Prompts]
+    CG[["🔒 Consent Gate<br/>DPDP enforced in code"]]
+    AU[Redacted Audit Trail]
+  end
+
+  Server -->|mock now · real later| Adapters
+
+  subgraph Adapters["BACKEND ADAPTERS"]
+    direction LR
+    BU[Credit Bureau]
+    AA[Account Aggregator]
+    KY[KYC / PAN]
+    DE[Rules + Scorecard]
+    DO[Document / e-sign]
+  end
+
+  classDef sig fill:#3a2a00,stroke:#f5a623,stroke-width:2px,color:#fff;
+  class CG sig;
+```
+
+> The client is the agent; the server is the capability layer. Same server powers a website, WhatsApp,
+> or an underwriter console — no rewrite.
+
+---
+
+## GEMINI IMAGE PROMPTS (stylized hero look — expect it to fumble some text)
+
+> Use these only for an aesthetic background/hero. For anything with readable labels, use the Mermaid above.
+> Add to each: *"16:9, dark navy background #0D1117, teal (#2DD4BF) and amber (#F5A623) accents, flat modern
+> vector, high text legibility, minimal, professional fintech infographic, no photorealism."*
+
+**Prompt A — the golden path flow:**
+```
+A clean modern horizontal flowchart infographic of a digital lending pipeline, left to right, eleven
+connected rounded-rectangle steps joined by thin arrows, labeled in order: "Qualify Lead", "Record
+Consent (issues consent token)", "Verify KYC", "Screen Fraud", "Pull Bureau", "Fetch Bank Statements",
+"Compute Affordability", "Underwrite", "Generate Offers", "Sanction Letter", "Audit Trail". The two steps
+"Pull Bureau" and "Fetch Bank Statements" each have a small padlock icon and an amber glow to show they are
+consent-gated. Title at top: "Vitta — The Golden Path". 16:9, dark navy background #0D1117, teal and amber
+accents, flat modern vector, crisp legible sans-serif text, minimal, professional.
+```
+
+**Prompt B — what we built (architecture):**
+```
+A clean modern three-layer architecture diagram infographic connected by vertical arrows. Top layer titled
+"MCP Clients — the agent" with three small cards: "NitroChat", "Claude", "ChatGPT App". Middle layer is a
+large rounded container titled "Vitta MCP Server — built on NitroStack" containing four pill badges
+"17 Tools", "5 Resources", "5 Prompts", "Redacted Audit Trail", and one prominent amber shield badge
+"Consent Gate — DPDP enforced in code". Bottom layer titled "Backend adapters — mock now, real later" with
+five small labeled icons: "Credit Bureau", "Account Aggregator", "KYC / PAN", "Rules + Scorecard",
+"Document / e-sign". 16:9, dark navy background #0D1117, teal and amber accents, flat modern vector,
+crisp legible text, minimal, enterprise fintech.
+```

--- a/sample-apps/vitta/docs/NITROSTACK_NOTES.md
+++ b/sample-apps/vitta/docs/NITROSTACK_NOTES.md
@@ -1,0 +1,172 @@
+# NITROSTACK_NOTES.md — the ONLY NitroStack API truth for this repo
+
+> Phase −1 discovery output (17 Jul 2026). Every claim below cites a **local file path**,
+> **CLI `--help` output**, or a **fetched docs URL**. Do NOT add a claim here without a citation.
+> If you need an API that is not here, STOP and ask a NitroStack mentor — do not guess (CLAUDE.md rule 1).
+
+## Verified environment
+- Node `v24.11.0` (plan requires ≥ 20.18 ✓) — `node --version`
+- npm `11.6.1`, git `2.55`, gh `2.95`
+- Packages installed (from npm registry, `npm view`):
+  - `@nitrostack/core@1.0.13` (decorators, DI, runtime) — `package.json` dep `^1`
+  - `@nitrostack/cli@1.0.14` (scaffold/dev/build/start/generate) — devDep `^1`
+  - `@nitrostack/widgets@1.0.8` (React widget SDK) — added only in Phase 7
+  - bare `nitrostack@1.0.85` exists but `npx nitrostack --help` → "could not determine executable"; **do not use the bare package**. The working binary is `nitrostack-cli` (shipped by `@nitrostack/cli`).
+- Scaffold created with: `npx @nitrostack/cli init vitta-lending --template typescript-starter`
+  (templates offered: `typescript-starter`, `typescript-pizzaz`, `typescript-oauth` — from `init --help`).
+
+## CLI — verified from `nitrostack-cli <cmd> --help`
+| Command | Purpose | Notes |
+|---|---|---|
+| `nitrostack-cli init [name]` | scaffold | `--template`, `--description`, `--author`, `--skip-install` |
+| `nitrostack-cli dev` | dev server (MCP + widgets) hot reload | `--port` (widget dev, default 3001). MCP server itself is **stdio** in dev. |
+| `nitrostack-cli build` | build for prod | `--output` (default `dist`) |
+| `nitrostack-cli start` | start prod server | `--port` (default 3000) |
+| `nitrostack-cli generate\|g <type> [name]` | codegen | types: middleware, interceptor, pipe, filter, service, guard, health, module, tools, resources, prompts, types |
+| `nitrostack-cli upgrade` | upgrade nitrostack in project | |
+| `nitrostack-cli install\|i` | install deps in root + src/widgets | |
+| `nitrostack-cli cursor\|c` | Cursor MCP integration | |
+
+npm scripts (from `package.json`): `dev`, `build`, `start` (= build+start), `start:prod`, `upgrade`, `install:all`, `widget`.
+
+> **There is NO `nitro deploy` / `nitrostack-cli deploy` command.** The plan's `nitro deploy --prod`
+> does not exist in this CLI. See **Deployment** below.
+
+## How a TOOL is defined — `src/modules/calculator/calculator.tools.ts`
+```ts
+import { ToolDecorator as Tool, Widget, ExecutionContext, z } from '@nitrostack/core';
+
+export class CalculatorTools {                 // plain class; registered via module `controllers`
+  @Tool({
+    name: 'calculate',                          // snake_case or kebab-case, unique
+    description: 'Perform basic arithmetic calculations',   // model reads this to decide to call
+    inputSchema: z.object({ a: z.number().describe('First number') }),  // Zod, .describe() per field
+    // outputSchema?: z.ZodSchema  (optional, validates output — types.d.ts ToolDefinition)
+    examples: { request: {...}, response: {...} }           // optional
+  })
+  @Widget('calculator-result')                  // optional: attach a React widget by route name
+  async calculate(input: any, ctx: ExecutionContext) {
+    ctx.logger.info('msg', { meta });           // logger on ctx
+    return { ...anyJson };                       // handler return = tool result (structuredContent)
+  }
+}
+```
+- Import name: `ToolDecorator` (aliased `Tool`) OR `Tool` directly — both exported (`core/dist/core/index.d.ts`).
+- Handler signature: `(input, ctx: ExecutionContext) => Promise<output>` (`types.d.ts` `ToolDefinition.handler`).
+- `@InitialTool()` marks a tool auto-invoked on client init (skill: tools-resources-prompts). Not needed for us.
+- Policy decorators (skill: tools-resources-prompts): `@Cache({ttl})`, `@RateLimit({requests,window})`.
+
+## How a RESOURCE is defined — `calculator.resources.ts` + tools-resources-prompts skill
+```ts
+import { ResourceDecorator as Resource, ExecutionContext } from '@nitrostack/core';
+@Resource({ uri: 'calculator://operations', name: '...', description: '...', mimeType: 'application/json' })
+async getOperations(uri: string, ctx: ExecutionContext) {
+  return { contents: [{ uri, mimeType: 'application/json', text: JSON.stringify(data) }] };
+}
+```
+- Handler signature: `(uri: string, ctx) => Promise<{contents:[{uri,mimeType,text}]}>` (scaffold-verified).
+- URI schemes are **arbitrary** (`scheme://path`) — `calculator://operations`, and skill shows `app://settings`,
+  `git://{owner}/{repo}/file` (template style). For our live case record use `case://{lead_id}`.
+- `ResourceTemplate` / `createResourceTemplate` exist for RFC-6570 templated URIs (`index.d.ts`, `types.d.ts`).
+
+## How a PROMPT is defined — `calculator.prompts.ts`
+```ts
+import { PromptDecorator as Prompt, ExecutionContext } from '@nitrostack/core';
+@Prompt({ name: 'calculator_help', description: '...', arguments: [{ name, description, required }] })
+async getHelp(args: any, ctx) {
+  return [ { role: 'user' as const, content: '...' }, { role: 'assistant' as const, content: '...' } ];
+}
+```
+- Scaffold returns a **bare array** of `{role, content}`. (The tools-resources-prompts skill shows an
+  alt shape `{ messages: [...] }` — the scaffold's bare-array form is what this template compiles, use it.)
+
+## Module / App wiring — `calculator.module.ts`, `app.module.ts`, `index.ts`
+```ts
+// feature module — groups controllers (classes holding @Tool/@Resource/@Prompt methods)
+@Module({ name: 'calculator', description: '...', controllers: [CalculatorTools, CalculatorResources, CalculatorPrompts] })
+export class CalculatorModule {}
+
+// root
+@McpApp({ module: AppModule, server: { name: 'calculator-server', version: '1.0.0' }, logging: { level: 'info' } })
+@Module({ name: 'app', description: '...', imports: [ConfigModule.forRoot(), CalculatorModule], providers: [SystemHealthCheck] })
+export class AppModule {}
+
+// entry — index.ts
+import 'dotenv/config';
+import { McpApplicationFactory } from '@nitrostack/core';
+const server = await McpApplicationFactory.create(AppModule); await server.start();
+```
+- `controllers` = classes with tool/resource/prompt methods. `providers` = DI services / health checks.
+- `@Controller('prefix')` optionally prefixes every tool name in a class (mcp-app-architecture skill) — we do NOT prefix (tool names are canonical).
+- DI: `@Injectable({scope})`, constructor injection, `Scope.SINGLETON|TRANSIENT|SCOPED`. Lifecycle hooks:
+  `OnModuleInit`, `OnApplicationBootstrap`, `OnModuleDestroy`, etc. (mcp-app-architecture skill).
+
+## Middleware pipeline — `middleware-pipeline` skill
+- **Guard**: `implements Guard { canActivate(ctx): boolean|Promise<boolean> }`, applied `@UseGuards(A, B)` (chained).
+- **Interceptor**: `intercept(ctx, next)`. **Filter**: `catch(exception, ctx)` → maps thrown error to JSON. `@UseFilters(F)`.
+- **Middleware**: `use(ctx, next)`, `@UseMiddleware`. **Pipe**: `transform(value, meta)`, `@UsePipes`.
+
+## ⚠️ CONSENT-GATE DESIGN DECISION (load-bearing)
+`ExecutionContext` (`core/dist/core/types.d.ts:268`) exposes ONLY:
+`requestId, toolName?, logger, metadata?, auth?, task?`. **It does NOT carry the tool input arguments.**
+Therefore a `Guard.canActivate(ctx)` **cannot read the `consent_token` tool input**.
+Our consent token is a **tool input parameter** (the LLM passes it as a tool arg), not an HTTP/auth header.
+
+**Conclusion (matches PLAN.md §5 Phase 1a fallback):** the consent gate is enforced **inline as the FIRST
+line of each gated handler** via `validConsent(input.consent_token, requiredScope)`, returning the exact
+refusal payload `{ error: "CONSENT_REQUIRED", code, hint }`. Guards remain correct for header/auth-level
+checks (JWT/API-key), but are the wrong tool for an input-level consent token on this platform.
+This is a genuine platform finding, not a shortcut — document it in the write-up.
+
+## Auth modules available (not used for the consent gate, but real) — `auth-security` skill
+`JWTModule.forRoot({secret, expiresIn})`, `ApiKeyModule.forRoot(...)`, `@UseGuards(JWTGuard, RoleGuard)`.
+Guards read `ctx.metadata?.authorization` / `ctx.metadata?.['x-api-key']` and set `ctx.auth`.
+
+## Widgets — `@Widget` + `@nitrostack/widgets` (Phase 7 only) — `ui-widgets` skill + `src/widgets/`
+- Backend: `@Widget('route-name')` on a tool (or object form `{route, domain?, csp?}`).
+- Frontend: Next.js app under `src/widgets/app/<route>/page.tsx`; `useWidgetSDK()` → `getToolOutput<T>()`,
+  `callTool(name,args)`, `useWidgetState()`, `theme`, `requestFullscreen()`, `sendFollowUpMessage()`.
+- Manifest: `src/widgets/widget-manifest.json`. Preview via NitroStudio hot reload.
+
+## Local testing
+- `npm run dev` → stdio MCP server + widget dev server (port 3001). Open the project folder in **NitroStudio**
+  (https://nitrostack.ai/studio) for the visual tool-testing panel + AI chat (chat uses YOUR OpenAI/Gemini key,
+  set `NITROSTACK_APP_MODE` in `.env`; costs nothing on the platform).
+- Unit tests: **`@nitrostack/core/testing`** ships `createMockContext(overrides)`, `MockLogger`, `TestingModule`
+  (`core/dist/testing/index.d.ts`). Test runner: scaffold ships none → **add `vitest`** (decided in Phase 0;
+  declare in THIRD_PARTY.md). Tools/consent are plain functions → unit-testable without the runtime.
+
+## State / persistence
+- No DB in scaffold. Convention: write JSON under `process.cwd()` (calculator example writes `uploads/`).
+  We persist to `./data/*.json` via `src/lib/store.ts` (gitignored `data/`). Env via `dotenv/config` + `ConfigModule`/`ConfigService`.
+
+## Env / secrets
+- `.env` loaded by `import 'dotenv/config'` in `index.ts`. `.env.example` keys: `NITRO_LOG_LEVEL`,
+  `NITROSTACK_APP_MODE` (openai|...), `MCP_TRANSPORT_TYPE` (stdio|http|dual), `PORT`, `HOST`, `ENABLE_CORS`.
+- Transport: **dev = stdio**, **prod (NODE_ENV=production) = dual (stdio + HTTP SSE)** (`index.ts` header comment + `.env.example`).
+- Consent HMAC secret → add `CONSENT_SECRET` to `.env` (Phase 1a).
+
+## Deployment — DEPLOY IS PLATFORM-SIDE (NitroCloud), not a local CLI command
+- Docs (`docs.nitrostack.ai/deployment/checklist`, fetched 17 Jul): local build = `nitrostack-cli build` → `dist/`.
+  Generic run targets shown: `node dist/index.js`, Docker (`-p 3000:3000`), PM2. For managed cloud it says
+  *"Deploy to NitroCloud and we handle security, scaling, monitoring, DevOps"* and points to **nitrocloud.ai**.
+- Dashboard (cloud.nitrostack.ai) "Deploy MCP" step offers **three paths: CLI · GitHub connect · package upload**.
+- **Chosen path for Vitta:** `nitrostack-cli build` locally to prove it compiles, then **GitHub-connect** the repo
+  `AnshBajpai05/NitroStack-Hackathon` in the dashboard (auto-deploys on push) OR **package upload** as fallback.
+  The public URL is generated by the platform (goes in the submission). **Prod deploy is a human/team step** done
+  from the logged-in dashboard (CLAUDE.md rule 11) — Claude Code does NOT deploy.
+
+## UNKNOWNS (honest — ask a mentor, do not guess)
+1. Exact CLI-path deploy command/auth in the dashboard "Deploy MCP → CLI" option (is there a `login`+push CLI
+   distributed only to logged-in users?). GitHub-connect + package-upload are documented and sufficient.
+2. Platform-level rollback / URL-swap mechanics (source-level rollback via git tag + rebuild is our guaranteed path).
+3. Whether hackathon "Platform Credits" top up the Free-plan 5.0M tokens / $0.50 NitroChat (ask mentor desk).
+4. Prompt return shape on the wire: scaffold uses bare `[{role,content}]`; skill shows `{messages:[...]}`. Use the
+   scaffold form; confirm in NitroStudio at Phase 5.
+
+## Prod-mode smoke (17 Jul, local) — known-benign log noise
+`NODE_ENV=production node dist/index.js` boots DUAL MODE (stdio + Streamable HTTP `/mcp` + legacy SSE `/sse`).
+GET `/` and `/mcp` → 200; `initialize` over POST `/mcp` answers correctly.
+KNOWN-BENIGN: one startup error `Failed to instantiate provider OAuthModule … Cannot resolve token "OAUTH_CONFIG"` —
+the framework's built-in OAuth module tries to self-instantiate without `OAuthModule.forRoot()` config (we don't use OAuth).
+Server continues and serves normally. Ignore in cloud logs.

--- a/sample-apps/vitta/docs/SPEC.md
+++ b/sample-apps/vitta/docs/SPEC.md
@@ -1,0 +1,99 @@
+# SPEC.md — Vitta build spec (consolidated from Winning Plan PDF §05–08 + PLAN.md §10 canonical fixes)
+
+Source of tool/resource/prompt contracts: `Vitta_Hackathon_Winning_Plan.pdf` pp.6–10.
+Canonical corrections applied from `PLAN.md` §10. Design decisions below are binding for the build.
+
+## Golden path (only scope)
+qualify_lead → record_consent(⚿ issuer) → verify_kyc → screen_fraud → pull_bureau ⚿
+→ fetch_bank_statements ⚿ → compute_affordability → underwrite → generate_offers
+→ create_sanction_letter → log_audit_event / get_audit_trail
+
+## Canonical determinism (PLAN.md §10)
+- Tool name is **`fetch_bank_statements`** (never fetch_bank_stmts).
+- PAN **last digit**: `0–1 → APPROVE`, `5–6 → CONDITIONAL`, `8–9 → DECLINE` (2–4 lean approve, 7 lean clear).
+- Mobile **suffix (last 2 digits)**: `00–33 → stable salaried`, `34–66 → self-employed`, `67–99 → volatile`.
+- Fraud: mobile suffix `90–99 → REVIEW` (path E uses 99), a reserved value `→ BLOCK`, else `CLEAR`.
+- **Demo pair:** PAN `VITTA1235K` (digit 5 → CONDITIONAL), mobile `9876543222` (suffix 22 → stable salaried).
+  Story (canonical, verified): "₹2,50,000 instead of ₹3L because existing EMIs put FOIR ≈ 57%."
+
+## 12 TOOLS (inputs → outputs; ⚿ = consent-gated)
+1. **qualify_lead** `{purpose, amount, tenure_months, employment, city, income_band}` → `{lead_id, prelim_eligibility, next_step, intent_flag}`
+   - Quick policy: age band handled at KYC; city served? employment ∈ {SALARIED, SELF_EMPLOYED}; min amount.
+   - `intent_flag`: purpose matching /medical|emergency/i → `FAST_TRACK`. Creates case record.
+2. **record_consent** (issuer) `{lead_id, consent_text_version, accepted, channel, scopes?}` → `{consent_token, ts, hash, scopes, expires_at}`
+   - accepted=true → issues HMAC token granting scopes (default all: CREDIT_BUREAU, BANK_STATEMENTS, KYC), TTL 900s.
+   - Stores proof: hash + ts + channel + text version. accepted=false → no token.
+3. **verify_kyc** `{lead_id, pan, name, dob?}` → `{kyc_status: PASS|RETRY|FAIL, kyc_hash, risk_flags[]}`
+   - Deterministic by PAN. (Not consent-gated in this build — PAN name-match is pre-pull identity.)
+4. **screen_fraud** `{lead_id, identifiers:{mobile, pan, device?}}` → `{verdict: CLEAR|REVIEW|BLOCK, signals[], score}`
+5. **pull_bureau** ⚿ `{lead_id, consent_token, pan}` → `BureauReport{score, dpd_max_12m, dpd_max_24m, writeoff_24m, inquiries_6m, active_emi, tradelines[], reason_codes[]}`
+   - requiredScope = CREDIT_BUREAU. Refusal FIRST line.
+6. **fetch_bank_statements** ⚿ `{lead_id, consent_token, months}` → `BankSummary{avg_salary_credit, income_variance_pct, bounce_count, cash_withdrawal_ratio, net_surplus, employer_consistency, stability_index}`
+   - requiredScope = BANK_STATEMENTS. Refusal FIRST line.
+7. **compute_affordability** `{lead_id, requested_amount, tenure_months}` (reads stored bureau+bank) → `{net_income, existing_emi, proposed_emi, foir, dti, stability_index}`
+8. **underwrite** `{lead_id}` (reads stored affordability+bureau) → `Decision{outcome: APPROVE|CONDITIONAL|DECLINE, max_amount, rate_band:{min,max}, tenure_range:{min,max}, score, reason_codes[], explanations[]}`
+9. **generate_offers** `{lead_id}` (reads Decision + case flags) → `{offers: Offer[≤3], recommended_offer_id}` intent-aware ordering (FAST_TRACK → lowest EMI first).
+10. **create_sanction_letter** `{lead_id, offer_id}` → `{url, hash, valid_till, letter_fields}` (HTML→PDF, SHA256 footer).
+11. **log_audit_event** `{session_id, actor, event, payload, version}` → `{ack, seq}` (redacts PII before store; append-only).
+12. **get_audit_trail** `{session_id, view: FULL|SUMMARY|COMPLIANCE_VIEW}` → `{events[], count}`
+
+### Offer object (PDF p.7)
+`{ offer_id, amount, tenure_months, roi_annual_pct, emi, processing_fee_pct, apr_pct, total_cost, valid_till, recommended, why_recommended }`
+
+### Audit envelope (PDF p.7–8; PII redacted)
+`{ session_id, seq, actor, event, payload:{...redacted}, version:{policy:"v1.7", score:"scorecard-2026-07", prompt:"uw_explainer_v1"}, ts }`
+
+## CONSENT (src/lib/consent.ts) — signature feature
+- scopes: `CREDIT_BUREAU | BANK_STATEMENTS | KYC`; TTL **900s**.
+- Token = `base64url(JSON payload) + "." + HMAC-SHA256(payload, CONSENT_SECRET)`; payload `{jti, lead_id, scopes[], iat, exp, version}`.
+- `validConsent(token, requiredScope, now?)` → `{ok:true}` OR `{ok:false, code}` where code ∈
+  `CONSENT_REQUIRED` (missing/garbage) · `CONSENT_INVALID` (bad signature/tamper) · `CONSENT_EXPIRED` (now>exp) ·
+  `SCOPE_NOT_GRANTED` (requiredScope ∉ scopes) · `CONSENT_REVOKED` (jti in revocation set).
+- Gated handler pattern (FIRST line):
+  ```ts
+  const c = validConsent(input.consent_token, 'CREDIT_BUREAU');
+  if (!c.ok) { store.audit('CONSENT_GATE_BLOCKED', ...); return { error: 'CONSENT_REQUIRED', code: c.code, hint: 'Call record_consent first and pass the returned consent_token' }; }
+  ```
+  (Guard NOT used — ExecutionContext has no tool input; see NITROSTACK_NOTES.md.)
+
+## POLICY (src/lib/scorecard.ts, values from PDF p.9; editable, mirrored in policy Resource)
+- `FOIR = (existing_emi + proposed_emi) / net_monthly_income`.
+- Hard negatives → force **DECLINE**: bureau score < 680; DPD > 30 in 12m; write-off in 24m; inquiries > 6 in 6m;
+  FOIR > 55%; employment ∉ {SALARIED, SELF_EMPLOYED}; city not served.
+- Scorecard 0–100 (pre-baked weights) from: bureau score, FOIR headroom, DPD, inquiries, income stability, employment.
+- Bands: **APPROVE ≥ 60 · CONDITIONAL 40–59 · DECLINE < 40** (hard negatives override to DECLINE).
+- `max_amount = min(segment_cap_by_income_band, amount_permitted_by_FOIR(55%))`. CONDITIONAL = approve reduced amount.
+- rate_band by score/risk (e.g. APPROVE 13.5–15.0, CONDITIONAL 15.99–18.0). tenure_range 12–48m.
+
+## EMI (src/lib/emi.ts)
+- Reducing balance: `r = roi_annual/12/100; emi = P·r·(1+r)^n / ((1+r)^n − 1)`, rounded to nearest ₹.
+- APR includes processing fee. total_cost = emi·n + fees. Pin exact EMI for (₹3,00,000, 15.99%, 36m) in a unit test.
+
+## REDACT (src/lib/redact.ts)
+- Mask PAN (`ABCDE1234F`→`ABCXXXXXXF` style), mobile (`98XXXXXX22`), name (`P***a`). Applied to every audit payload.
+  Assert `VITTA1235K` never appears verbatim in stored audit data.
+
+## STORE (src/lib/store.ts)
+- Module-level singleton, JSON-file-backed under `./data/` (gitignored). Namespaces: `cases`, `consents`,
+  `audit` (append-only array + `seq` counter), `revocations`. Methods: `getCase/putCase`, `putConsent/getConsent/revoke`,
+  `audit(actor,event,payload,version)`→seq, `trail(session_id,view)`. In-memory + debounced flush to disk.
+
+## RESOURCES (5) — src/resources/
+- `policy://credit-policy/v1.7` — eligibility rules, FOIR bands, hard negatives (mirrors scorecard.ts).
+- `catalog://products/personal-loan` — ROI bands, processing fees, tenure grid.
+- `ref://city-tiers` — served cities + tier → policy caps.
+- `consent://templates` — versioned consent text registry.
+- `case://{lead_id}` — LIVE application record (reads store; templated URI).
+
+## PROMPTS (5) — src/prompts/
+- `sales-playbook` (tone, mandatory APR/late-fee disclosure, cooling-off, non-coercive, HITL pause on CONDITIONAL/REVIEW),
+- `underwriting-explainer` (reason_codes+features → plain text), `objection-handling` (rate/tenure/amount replies),
+- `adverse-action-notice` (respectful compliant decline), `kyc-consent-script` (consent + data-use explanation).
+
+## TESTS
+- `tests/consent.test.ts` FIRST — 5 cases (none/expired/wrong-scope/tampered/valid).
+- `tests/emi.test.ts` — pinned EMI value.
+- `tests/seeds.test.ts` — demo PAN VITTA1235K → CONDITIONAL bureau profile; mapping table holds.
+- `tests/goldenpath.test.ts` — drive full path in-process for APPROVE(…0) / CONDITIONAL(demo) / DECLINE(…9).
+- `scripts/regress.ts` (`npm run regress`) — paths A APPROVE · B CONDITIONAL(demo) · C DECLINE+adverse ·
+  D consent-refusal(judge probe) · E fraud REVIEW(suffix 99) · F objection-handling render. Prints PASS/FAIL, exit code.

--- a/sample-apps/vitta/mocks/bank_seed.json
+++ b/sample-apps/vitta/mocks/bank_seed.json
@@ -1,0 +1,38 @@
+{
+  "_doc": "Deterministic AA cashflow keyed by MOBILE SUFFIX band (00-33 stable salaried, 34-66 self-employed, 67-99 volatile). net_income = take-home used for FOIR.",
+  "bands": {
+    "stable": {
+      "match": [0, 33],
+      "avg_salary_credit": 65000,
+      "net_income": 62000,
+      "income_variance_pct": 8,
+      "bounce_count": 0,
+      "cash_withdrawal_ratio": 0.1,
+      "net_surplus": 32000,
+      "employer_consistency": 0.95,
+      "stability_index": 88
+    },
+    "self_employed": {
+      "match": [34, 66],
+      "avg_salary_credit": 60000,
+      "net_income": 47000,
+      "income_variance_pct": 28,
+      "bounce_count": 1,
+      "cash_withdrawal_ratio": 0.35,
+      "net_surplus": 19000,
+      "employer_consistency": 0.6,
+      "stability_index": 61
+    },
+    "volatile": {
+      "match": [67, 99],
+      "avg_salary_credit": 43000,
+      "net_income": 34000,
+      "income_variance_pct": 55,
+      "bounce_count": 3,
+      "cash_withdrawal_ratio": 0.5,
+      "net_surplus": 8000,
+      "employer_consistency": 0.35,
+      "stability_index": 34
+    }
+  }
+}

--- a/sample-apps/vitta/mocks/bureau_seed.json
+++ b/sample-apps/vitta/mocks/bureau_seed.json
@@ -1,0 +1,19 @@
+{
+  "_doc": "Deterministic bureau profiles keyed by PAN LAST DIGIT (CLAUDE.md rule 5: 0-1 APPROVE, 5-6 CONDITIONAL, 8-9 DECLINE).",
+  "byLastDigit": {
+    "0": { "score": 782, "dpd_max_12m": 0, "dpd_max_24m": 0, "writeoff_24m": false, "inquiries_6m": 1, "active_emi": 2000, "reason_codes": ["CLEAN_BUREAU", "LOW_UTILISATION"] },
+    "1": { "score": 761, "dpd_max_12m": 0, "dpd_max_24m": 0, "writeoff_24m": false, "inquiries_6m": 2, "active_emi": 3500, "reason_codes": ["CLEAN_BUREAU"] },
+    "2": { "score": 744, "dpd_max_12m": 0, "dpd_max_24m": 5, "writeoff_24m": false, "inquiries_6m": 2, "active_emi": 6000, "reason_codes": ["MINOR_DPD_HISTORICAL"] },
+    "3": { "score": 733, "dpd_max_12m": 0, "dpd_max_24m": 0, "writeoff_24m": false, "inquiries_6m": 3, "active_emi": 8000, "reason_codes": ["MODERATE_INQUIRIES"] },
+    "4": { "score": 719, "dpd_max_12m": 15, "dpd_max_24m": 15, "writeoff_24m": false, "inquiries_6m": 3, "active_emi": 9000, "reason_codes": ["MINOR_DPD_12M"] },
+    "5": { "score": 705, "dpd_max_12m": 20, "dpd_max_24m": 25, "writeoff_24m": false, "inquiries_6m": 5, "active_emi": 25000, "reason_codes": ["HIGH_EXISTING_EMI", "ELEVATED_INQUIRIES"] },
+    "6": { "score": 697, "dpd_max_12m": 25, "dpd_max_24m": 30, "writeoff_24m": false, "inquiries_6m": 6, "active_emi": 21000, "reason_codes": ["HIGH_EXISTING_EMI", "DPD_WITHIN_LIMIT"] },
+    "7": { "score": 690, "dpd_max_12m": 10, "dpd_max_24m": 20, "writeoff_24m": false, "inquiries_6m": 4, "active_emi": 7000, "reason_codes": ["BORDERLINE_SCORE"] },
+    "8": { "score": 655, "dpd_max_12m": 45, "dpd_max_24m": 60, "writeoff_24m": false, "inquiries_6m": 7, "active_emi": 15000, "reason_codes": ["SUBPRIME_SCORE", "DPD_OVER_30_12M", "EXCESS_INQUIRIES"] },
+    "9": { "score": 620, "dpd_max_12m": 60, "dpd_max_24m": 90, "writeoff_24m": true, "inquiries_6m": 8, "active_emi": 22000, "reason_codes": ["SUBPRIME_SCORE", "WRITEOFF_24M", "DPD_OVER_30_12M", "EXCESS_INQUIRIES"] }
+  },
+  "tradelineTemplate": [
+    { "type": "CREDIT_CARD", "sanctioned": 150000, "emi": 0, "status": "ACTIVE" },
+    { "type": "PERSONAL_LOAN", "sanctioned": 200000, "emi": 0, "status": "ACTIVE" }
+  ]
+}

--- a/sample-apps/vitta/mocks/city_tiers.json
+++ b/sample-apps/vitta/mocks/city_tiers.json
@@ -1,0 +1,19 @@
+{
+  "_doc": "Served cities + tier → segment cap (₹). Cities not listed are NOT served (qualify_lead fails on city).",
+  "cities": {
+    "MUMBAI": { "tier": 1, "cap": 1500000 },
+    "DELHI": { "tier": 1, "cap": 1500000 },
+    "BENGALURU": { "tier": 1, "cap": 1500000 },
+    "BANGALORE": { "tier": 1, "cap": 1500000 },
+    "PUNE": { "tier": 2, "cap": 1000000 },
+    "HYDERABAD": { "tier": 2, "cap": 1000000 },
+    "CHENNAI": { "tier": 2, "cap": 1000000 },
+    "KOLKATA": { "tier": 2, "cap": 1000000 },
+    "AHMEDABAD": { "tier": 2, "cap": 1000000 },
+    "JAIPUR": { "tier": 3, "cap": 700000 },
+    "KOCHI": { "tier": 3, "cap": 700000 },
+    "COIMBATORE": { "tier": 3, "cap": 700000 },
+    "KOLLAM": { "tier": 3, "cap": 700000 },
+    "AMRITAPURI": { "tier": 3, "cap": 700000 }
+  }
+}

--- a/sample-apps/vitta/mocks/fraud_seed.json
+++ b/sample-apps/vitta/mocks/fraud_seed.json
@@ -1,0 +1,10 @@
+{
+  "_doc": "Deterministic fraud/AML by MOBILE SUFFIX (last 2 digits). >=90 REVIEW (path E uses 99). Suffix 13 BLOCK (sanctions hit). Else CLEAR.",
+  "rules": {
+    "block_suffixes": [13],
+    "review_from_suffix": 90
+  },
+  "clear": { "verdict": "CLEAR", "signals": [], "score": 8 },
+  "review": { "verdict": "REVIEW", "signals": ["VELOCITY_SPIKE", "DEVICE_REUSE"], "score": 58 },
+  "block": { "verdict": "BLOCK", "signals": ["SANCTIONS_LIST_HIT", "PEP_MATCH"], "score": 95 }
+}

--- a/sample-apps/vitta/mocks/kyc_seed.json
+++ b/sample-apps/vitta/mocks/kyc_seed.json
@@ -1,0 +1,9 @@
+{
+  "_doc": "Deterministic KYC by PAN last digit. Default PASS for a well-formed PAN. Malformed PAN → FAIL. Optional per-digit overrides.",
+  "default": { "kyc_status": "PASS", "risk_flags": [] },
+  "byLastDigit": {
+    "7": { "kyc_status": "PASS", "risk_flags": ["ADDRESS_MISMATCH_MINOR"] },
+    "8": { "kyc_status": "PASS", "risk_flags": ["RECENT_KYC_UPDATE"] }
+  },
+  "panPattern": "^[A-Z]{5}[0-9]{4}[A-Z]$"
+}

--- a/sample-apps/vitta/package-lock.json
+++ b/sample-apps/vitta/package-lock.json
@@ -1,0 +1,5670 @@
+{
+  "name": "vitta-lending",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vitta-lending",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0",
+        "@nitrostack/core": "^1.0.13",
+        "dotenv": "^16.3.1",
+        "zod": "^3.22.4"
+      },
+      "devDependencies": {
+        "@nitrostack/cli": "^1.0.14",
+        "@types/node": "^22.10.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.3.3",
+        "vitest": "^2.1.9"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.4.tgz",
+      "integrity": "sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ==",
+      "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@nitrostack/cli": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@nitrostack/cli/-/cli-1.0.14.tgz",
+      "integrity": "sha512-aZf+59ybqFVU+YtOagnCywpIY+kENkRgsRh5HgOC2d2iRiCxfdAyEf+ookQekpR9JxSNtr0GRwhkc8yA/lAhTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "chokidar": "^3.6.0",
+        "commander": "^12.1.0",
+        "esbuild": "^0.24.0",
+        "fs-extra": "^11.3.2",
+        "inquirer": "^9.3.7",
+        "open": "^10.1.0",
+        "ora": "^8.1.1",
+        "posthog-node": "^5.21.2"
+      },
+      "bin": {
+        "cli": "dist/index.js",
+        "nitrostack-cli": "dist/index.js"
+      }
+    },
+    "node_modules/@nitrostack/core": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@nitrostack/core/-/core-1.0.13.tgz",
+      "integrity": "sha512-cmQqqioxvhvOmASlAAwzFMnFWDcvlrEP47v455UraeZqhrZvm8Jr7ePo2GtpSir4t7OA6uIKhRpVb5XeLDjM5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.4",
+        "bcryptjs": "^2.4.3",
+        "cors": "^2.8.5",
+        "dotenv": "^17.2.3",
+        "express": "^4.21.2",
+        "jose": "^6.1.0",
+        "jsonwebtoken": "^9.0.2",
+        "reflect-metadata": "^0.2.1",
+        "uuid": "^11.0.5",
+        "winston": "^3.17.0",
+        "ws": "^8.18.3",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/@nitrostack/core/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/@nitrostack/core/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/@nitrostack/core/node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.43.1.tgz",
+      "integrity": "sha512-hGM8f5sp3we6Em/RQHXbmyYm554hUx9+9jhf92ZQgDS4/xW72KHyZiO9wcFye+qAx2cJAOhOCDIznmO1FV8IbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.396.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.397.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.397.0.tgz",
+      "integrity": "sha512-Pa7FtsBo3V0XrhY4y8Xquwp8U07syuZ2IGQdlsRyxhz0yejQLceFjI58UssCXE5zDCDj3km5l7H3ufD6rHChCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/inquirer": {
+      "version": "9.3.8",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.8.tgz",
+      "integrity": "sha512-pFGGdaHrmRKMh4WoDDSowddgjT1Vkl90atobmTeSmcPGdYiwikch/m/Ef5wRaiamHejtw0cUUMMerzDUXCci2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/external-editor": "^1.0.2",
+        "@inquirer/figures": "^1.0.3",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "1.0.0",
+        "ora": "^5.4.1",
+        "run-async": "^3.0.0",
+        "rxjs": "^7.8.1",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.45.2",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.45.2.tgz",
+      "integrity": "sha512-QhHw/xL0ntMG/DzqA/qdiKu8JY8ChK5Obm8m1nMJor5sjJ7+pfVJSx1yAynC7iUAJfJ9V+OhBNhDCyi5IFWC0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.43.1"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/sample-apps/vitta/package.json
+++ b/sample-apps/vitta/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "vitta-lending",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Vitta - MCP NBFC personal-loan origination server (consent-gated). Amrita MCP Hackathon 2026, BFSI track.",
+  "scripts": {
+    "dev": "nitrostack-cli dev",
+    "build": "nitrostack-cli build",
+    "start": "npm run build && nitrostack-cli start",
+    "start:prod": "nitrostack-cli start",
+    "upgrade": "nitrostack-cli upgrade",
+    "install:all": "nitrostack-cli install",
+    "widget": "npm --prefix src/widgets",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "regress": "tsx scripts/regress.ts",
+    "seed:demo": "tsx scripts/seed-demo.ts"
+  },
+  "dependencies": {
+    "dotenv": "^16.3.1",
+    "@nitrostack/core": "^1.0.13",
+    "zod": "^3.22.4",
+    "@modelcontextprotocol/ext-apps": ">=0.1.0"
+  },
+  "devDependencies": {
+    "@nitrostack/cli": "^1.0.14",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.3.3",
+    "vitest": "^2.1.9",
+    "tsx": "^4.19.2"
+  },
+  "author": "The Beetles - Amrita University Amritapuri",
+  "nitrostack": {
+    "skillsVersion": "1.0.0"
+  }
+}

--- a/sample-apps/vitta/scripts/e2e-wire.mjs
+++ b/sample-apps/vitta/scripts/e2e-wire.mjs
@@ -1,0 +1,122 @@
+/**
+ * e2e-wire.mjs — drive the FULL demo path over real MCP stdio (JSON-RPC),
+ * exactly what Studio/NitroChat does. Threads the live consent_token between
+ * calls. Run: node scripts/e2e-wire.mjs   (needs a prior `npm run build`)
+ */
+import { spawn } from 'node:child_process';
+
+const srv = spawn(process.execPath, ['dist/index.js'], {
+  stdio: ['pipe', 'pipe', 'ignore'],
+  env: { ...process.env, NODE_ENV: 'development', MCP_TRANSPORT_TYPE: 'stdio' },
+});
+
+let buf = '';
+const pending = new Map();
+srv.stdout.on('data', (c) => {
+  buf += c.toString();
+  let i;
+  while ((i = buf.indexOf('\n')) >= 0) {
+    const line = buf.slice(0, i).trim();
+    buf = buf.slice(i + 1);
+    if (!line) continue;
+    try {
+      const m = JSON.parse(line);
+      if (m.id != null && pending.has(m.id)) {
+        pending.get(m.id)(m);
+        pending.delete(m.id);
+      }
+    } catch {}
+  }
+});
+
+let nextId = 1;
+function rpc(method, params) {
+  const id = nextId++;
+  return new Promise((res, rej) => {
+    pending.set(id, res);
+    srv.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+    setTimeout(() => { if (pending.has(id)) { pending.delete(id); rej(new Error(`timeout ${method}`)); } }, 15000);
+  });
+}
+function notify(method, params) {
+  srv.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n');
+}
+async function call(name, args) {
+  const m = await rpc('tools/call', { name, arguments: args });
+  const r = m.result ?? m.error;
+  if (r?.structuredContent) return r.structuredContent;
+  const t = r?.content?.[0]?.text;
+  try { return JSON.parse(t); } catch { return t ?? r; }
+}
+
+const S = 'demo-1';
+let failures = 0;
+function step(n, label, ok, detail) {
+  console.log(`${ok ? '✓' : '✗'} ${String(n).padStart(2)} ${label}\n      ${detail}`);
+  if (!ok) failures++;
+}
+
+try {
+  await rpc('initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'e2e-wire', version: '1' } });
+  notify('notifications/initialized');
+
+  // 1 qualify_lead
+  const q = await call('qualify_lead', { session_id: S, purpose: 'medical emergency', amount: 300000, tenure_months: 36, employment: 'SALARIED', city: 'Kochi', income_band: '50k-75k' });
+  step(1, 'qualify_lead', q.prelim_eligibility === 'ELIGIBLE' && q.intent_flag === 'FAST_TRACK', `lead_id=${q.lead_id} intent=${q.intent_flag}`);
+  const L = q.lead_id;
+
+  // 2 pull_bureau BEFORE consent → refusal (judge Path D)
+  const probe = await call('pull_bureau', { session_id: S, lead_id: L, pan: 'VITTA1235K', consent_token: 'garbage' });
+  step(2, 'pull_bureau w/o consent → REFUSED', probe.error === 'CONSENT_REQUIRED', JSON.stringify(probe));
+
+  // 3 record_consent → token
+  const c = await call('record_consent', { session_id: S, lead_id: L, consent_text_version: 'consent-v3', accepted: true, channel: 'web' });
+  step(3, 'record_consent', c.accepted === true && !!c.consent_token, `expires=${c.expires_at} scopes=${c.scopes?.join(',')}`);
+  const TOK = c.consent_token;
+
+  // 4 verify_kyc
+  const k = await call('verify_kyc', { session_id: S, lead_id: L, pan: 'VITTA1235K', name: 'Priya Sharma' });
+  step(4, 'verify_kyc', k.kyc_status === 'PASS', `status=${k.kyc_status}`);
+
+  // 5 screen_fraud
+  const f = await call('screen_fraud', { session_id: S, lead_id: L, identifiers: { mobile: '9876543222', pan: 'VITTA1235K' } });
+  step(5, 'screen_fraud', f.verdict === 'CLEAR', `verdict=${f.verdict}`);
+
+  // 6 pull_bureau WITH token
+  const b = await call('pull_bureau', { session_id: S, lead_id: L, pan: 'VITTA1235K', consent_token: TOK });
+  step(6, 'pull_bureau (valid token)', b.score === 705, `score=${b.score} active_emi=${b.active_emi}`);
+
+  // 7 fetch_bank_statements
+  const bs = await call('fetch_bank_statements', { session_id: S, lead_id: L, consent_token: TOK, months: 12 });
+  step(7, 'fetch_bank_statements', bs.stability_index === 88, `stability=${bs.stability_index} surplus=${bs.net_surplus}`);
+
+  // 8 compute_affordability
+  const a = await call('compute_affordability', { session_id: S, lead_id: L });
+  step(8, 'compute_affordability', Math.round(a.foir * 100) === 57, `foir=${(a.foir * 100).toFixed(1)}% proposed_emi=${a.proposed_emi}`);
+
+  // 9 underwrite
+  const d = await call('underwrite', { session_id: S, lead_id: L });
+  step(9, 'underwrite', d.outcome === 'CONDITIONAL' && d.max_amount === 250000, `outcome=${d.outcome} max=${d.max_amount} reasons=[${d.reason_codes?.join(',')}]`);
+
+  // 10 generate_offers
+  const o = await call('generate_offers', { session_id: S, lead_id: L });
+  const rec = o.offers?.find((x) => x.offer_id === o.recommended_offer_id);
+  step(10, 'generate_offers', o.offers?.length >= 1 && rec && rec.emi === Math.min(...o.offers.map((x) => x.emi)), `offers=${o.offers?.length} recommended EMI=₹${rec?.emi}`);
+
+  // 11 create_sanction_letter
+  const sl = await call('create_sanction_letter', { session_id: S, lead_id: L, offer_id: o.recommended_offer_id });
+  step(11, 'create_sanction_letter', !!sl.hash, `hash=${String(sl.hash).slice(0, 16)}… url=${sl.url}`);
+
+  // 12 audit trail — redaction check
+  const t = await call('get_audit_trail', { session_id: S, view: 'FULL' });
+  const blob = JSON.stringify(t);
+  step(12, 'get_audit_trail + PII redaction', t.count >= 10 && !blob.includes('VITTA1235K') && !blob.includes('9876543222'), `events=${t.count} rawPAN=${blob.includes('VITTA1235K')} rawMobile=${blob.includes('9876543222')}`);
+
+  console.log(`\n${failures === 0 ? 'ALL PASS' : failures + ' FAILED'} — full demo path over MCP stdio`);
+} catch (e) {
+  console.error('E2E error:', e.message);
+  failures++;
+} finally {
+  srv.kill();
+  process.exit(failures === 0 ? 0 : 1);
+}

--- a/sample-apps/vitta/scripts/regress.ts
+++ b/sample-apps/vitta/scripts/regress.ts
@@ -1,0 +1,113 @@
+/**
+ * regress.ts — edge-path regression harness (PLAN.md §5 Phase 8).
+ * Runs all six paths in-process and prints PASS/FAIL. Exit code != 0 on any fail.
+ *   A APPROVE (PAN …0)         B CONDITIONAL demo (VITTA1235K)  C DECLINE + adverse (PAN …9)
+ *   D consent-gate refusal      E fraud REVIEW (mobile …99)      F objection-handling render
+ *
+ * Run: npm run regress
+ */
+import { store } from '../src/lib/store.js';
+import {
+  qualifyLead, recordConsent, verifyKyc, screenFraud, pullBureau, fetchBankStatements,
+  computeAffordabilityStep, underwriteStep, generateOffersStep, createSanctionStep,
+} from '../src/lib/engine.js';
+import { VittaPrompts } from '../src/prompts/vitta.prompts.js';
+import type { ConsentRefusal } from '../src/lib/types.js';
+
+const results: { path: string; ok: boolean; detail: string }[] = [];
+function check(path: string, ok: boolean, detail: string) {
+  results.push({ path, ok, detail });
+}
+function isRefusal(x: unknown): x is ConsentRefusal {
+  return !!x && typeof x === 'object' && (x as any).error === 'CONSENT_REQUIRED';
+}
+
+function fullPath(session_id: string, pan: string, mobile: string, city: string, purpose: string) {
+  const q = qualifyLead({ session_id, purpose, amount: 300000, tenure_months: 36, employment: 'SALARIED', city });
+  const c = recordConsent({ session_id, lead_id: q.lead_id, consent_text_version: 'consent-v3', accepted: true, channel: 'web' });
+  if (!c.accepted) throw new Error('consent failed');
+  verifyKyc({ session_id, lead_id: q.lead_id, pan, name: 'Test Applicant' });
+  const fraud = screenFraud({ session_id, lead_id: q.lead_id, identifiers: { mobile, pan } });
+  const b = pullBureau({ session_id, lead_id: q.lead_id, consent_token: c.consent_token, pan });
+  if (isRefusal(b)) throw new Error('unexpected consent refusal');
+  fetchBankStatements({ session_id, lead_id: q.lead_id, consent_token: c.consent_token, months: 12 });
+  const aff = computeAffordabilityStep({ session_id, lead_id: q.lead_id });
+  const decision = underwriteStep({ session_id, lead_id: q.lead_id });
+  const offers = generateOffersStep({ session_id, lead_id: q.lead_id });
+  return { lead_id: q.lead_id, fraud, aff, decision, offers, intent: q.intent_flag };
+}
+
+function main() {
+  store._resetAll();
+
+  // A — APPROVE
+  try {
+    const r = fullPath('rg-A', 'AAAPA1230A', '9000000010', 'Mumbai', 'home renovation');
+    check('A APPROVE (PAN …0)', r.decision.outcome === 'APPROVE' && r.offers.offers.length === 3,
+      `outcome=${r.decision.outcome} amount=${r.decision.max_amount} offers=${r.offers.offers.length}`);
+  } catch (e: any) { check('A APPROVE (PAN …0)', false, e.message); }
+
+  // B — CONDITIONAL demo
+  try {
+    const r = fullPath('rg-B', 'VITTA1235K', '9876543222', 'Kochi', 'medical emergency');
+    const sanction = createSanctionStep({ session_id: 'rg-B', lead_id: r.lead_id, offer_id: r.offers.recommended_offer_id });
+    const ok = r.decision.outcome === 'CONDITIONAL' && r.decision.max_amount === 250000
+      && Math.round(r.aff.foir * 100) === 57 && 'hash' in sanction;
+    check('B CONDITIONAL demo (VITTA1235K)', ok,
+      `outcome=${r.decision.outcome} amount=${r.decision.max_amount} foir=${Math.round(r.aff.foir * 100)}% intent=${r.intent}`);
+  } catch (e: any) { check('B CONDITIONAL demo (VITTA1235K)', false, e.message); }
+
+  // C — DECLINE + adverse action content
+  try {
+    const r = fullPath('rg-C', 'ZZZPZ1239Z', '9000000010', 'Mumbai', 'home renovation');
+    const ok = r.decision.outcome === 'DECLINE' && r.decision.explanations.length > 0 && r.offers.offers.length === 0;
+    check('C DECLINE + adverse-action (PAN …9)', ok,
+      `outcome=${r.decision.outcome} reasons=[${r.decision.reason_codes.join(',')}]`);
+  } catch (e: any) { check('C DECLINE + adverse-action (PAN …9)', false, e.message); }
+
+  // D — consent-gate refusal (judge probe)
+  try {
+    store._resetAll();
+    const q = qualifyLead({ session_id: 'rg-D', purpose: 'x', amount: 300000, tenure_months: 36, employment: 'SALARIED', city: 'Kochi' });
+    const noTok = pullBureau({ session_id: 'rg-D', lead_id: q.lead_id, consent_token: undefined, pan: 'VITTA1235K' });
+    const garbage = fetchBankStatements({ session_id: 'rg-D', lead_id: q.lead_id, consent_token: 'garbage.tok' });
+    const ok = isRefusal(noTok) && noTok.code === 'CONSENT_REQUIRED' && isRefusal(garbage);
+    check('D consent-gate refusal (judge probe)', ok, `pull_bureau→${isRefusal(noTok) ? noTok.code : 'PASSED?!'}`);
+  } catch (e: any) { check('D consent-gate refusal (judge probe)', false, e.message); }
+
+  // E — fraud REVIEW (mobile suffix 99)
+  try {
+    store._resetAll();
+    const q = qualifyLead({ session_id: 'rg-E', purpose: 'x', amount: 300000, tenure_months: 36, employment: 'SALARIED', city: 'Kochi' });
+    const fraud = screenFraud({ session_id: 'rg-E', lead_id: q.lead_id, identifiers: { mobile: '9000000099' } });
+    check('E fraud REVIEW (mobile …99)', fraud.verdict === 'REVIEW', `verdict=${fraud.verdict} signals=[${fraud.signals.join(',')}]`);
+  } catch (e: any) { check('E fraud REVIEW (mobile …99)', false, e.message); }
+
+  // F — objection-handling prompt renders
+  try {
+    const prompts = new VittaPrompts();
+    (async () => {
+      const msgs = await prompts.objectionHandling({ objection: 'rate too high' }, {} as any);
+      const text = msgs.map((m) => m.content).join(' ');
+      check('F objection-handling render', text.length > 50 && /rate|EMI|tenure/i.test(text), `len=${text.length}`);
+      report();
+    })();
+    return; // report() called in async
+  } catch (e: any) { check('F objection-handling render', false, e.message); }
+
+  report();
+}
+
+function report() {
+  console.log('\n  VITTA REGRESSION — paths A–F\n  ' + '─'.repeat(48));
+  let pass = 0;
+  for (const r of results) {
+    console.log(`  ${r.ok ? '✓ PASS' : '✗ FAIL'}  ${r.path}\n           ${r.detail}`);
+    if (r.ok) pass++;
+  }
+  console.log('  ' + '─'.repeat(48));
+  console.log(`  ${pass}/${results.length} PASS\n`);
+  process.exit(pass === results.length ? 0 : 1);
+}
+
+main();

--- a/sample-apps/vitta/scripts/seed-demo.ts
+++ b/sample-apps/vitta/scripts/seed-demo.ts
@@ -1,0 +1,46 @@
+/**
+ * seed-demo.ts — reset demo state and pre-run the golden path so the live case
+ * record (case://<lead_id>) has data before a recording. Prints the ids to use.
+ * Run: npm run seed:demo
+ */
+import { store } from '../src/lib/store.js';
+import {
+  qualifyLead, recordConsent, verifyKyc, screenFraud, pullBureau, fetchBankStatements,
+  computeAffordabilityStep, underwriteStep, generateOffersStep,
+} from '../src/lib/engine.js';
+
+const SESSION = 'demo-seed';
+store.resetSession(SESSION);
+
+const q = qualifyLead({
+  session_id: SESSION,
+  purpose: 'medical emergency',
+  amount: 300000,
+  tenure_months: 36,
+  employment: 'SALARIED',
+  city: 'Kochi',
+  income_band: '50k-75k',
+});
+const c = recordConsent({
+  session_id: SESSION,
+  lead_id: q.lead_id,
+  consent_text_version: 'consent-v3',
+  accepted: true,
+  channel: 'web',
+});
+if (!c.accepted) throw new Error('consent failed');
+verifyKyc({ session_id: SESSION, lead_id: q.lead_id, pan: 'VITTA1235K', name: 'Priya Sharma' });
+screenFraud({ session_id: SESSION, lead_id: q.lead_id, identifiers: { mobile: '9876543222', pan: 'VITTA1235K' } });
+pullBureau({ session_id: SESSION, lead_id: q.lead_id, consent_token: c.consent_token, pan: 'VITTA1235K' });
+fetchBankStatements({ session_id: SESSION, lead_id: q.lead_id, consent_token: c.consent_token, months: 12 });
+computeAffordabilityStep({ session_id: SESSION, lead_id: q.lead_id });
+const d = underwriteStep({ session_id: SESSION, lead_id: q.lead_id });
+const o = generateOffersStep({ session_id: SESSION, lead_id: q.lead_id });
+
+console.log('Demo state seeded.');
+console.log(`  session_id      ${SESSION}`);
+console.log(`  lead_id         ${q.lead_id}`);
+console.log(`  consent_token   ${c.consent_token.slice(0, 24)}… (15-min TTL — reissue live on camera)`);
+console.log(`  decision        ${d.outcome} ₹${d.max_amount.toLocaleString('en-IN')}`);
+console.log(`  offers          ${o.offers.length} (recommended ${o.recommended_offer_id})`);
+console.log(`  case resource   case://${q.lead_id}`);

--- a/sample-apps/vitta/scripts/verify-prod.mjs
+++ b/sample-apps/vitta/scripts/verify-prod.mjs
@@ -1,0 +1,116 @@
+/**
+ * verify-prod.mjs — §6.5 post-deploy verification against the LIVE deployment.
+ * Speaks Streamable HTTP with session handling (cloud runs sessions enabled).
+ * Run after EVERY deploy:  node scripts/verify-prod.mjs <base-url>
+ * Exit 0 = all checks pass. Log the result in docs/DEPLOY_LOG.md.
+ */
+
+const BASE = (process.argv[2] ?? 'https://vitta-6a5a5835-the-beetles-amrita-university-amritapuri-campus.app.nitrocloud.ai').replace(/\/$/, '');
+const MCP = `${BASE}/mcp`;
+
+let SESSION_HEADER = null;
+let nextId = 1;
+
+async function rpc(method, params) {
+  const headers = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+  };
+  if (SESSION_HEADER) headers['Mcp-Session-Id'] = SESSION_HEADER;
+  const res = await fetch(MCP, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ jsonrpc: '2.0', id: nextId++, method, params }),
+  });
+  const sid = res.headers.get('mcp-session-id');
+  if (sid) SESSION_HEADER = sid;
+  const text = await res.text();
+  // parse SSE (event:/data:) or plain JSON
+  const dataLine = text.split(/\r?\n/).find((l) => l.startsWith('data:'));
+  const payload = dataLine ? dataLine.slice(5).trim() : text;
+  if (!payload) throw new Error(`empty response (HTTP ${res.status}) for ${method}`);
+  return JSON.parse(payload);
+}
+
+function toolResult(m) {
+  const r = m.result ?? m.error;
+  if (r?.structuredContent) return r.structuredContent;
+  const t = r?.content?.[0]?.text;
+  try { return JSON.parse(t); } catch { return t ?? r; }
+}
+async function call(name, args) {
+  return toolResult(await rpc('tools/call', { name, arguments: args }));
+}
+
+let failures = 0;
+function check(label, ok, detail) {
+  console.log(`${ok ? '✓' : '✗'} ${label}\n    ${detail}`);
+  if (!ok) failures++;
+}
+
+console.log(`Verifying PROD: ${BASE}\n`);
+
+// init + session
+const init = await rpc('initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'verify-prod', version: '1' } });
+check('initialize', init.result?.serverInfo?.name === 'vitta-lending', `server=${init.result?.serverInfo?.name} session=${SESSION_HEADER ? 'yes' : 'no'}`);
+await rpc('notifications/initialized', {}).catch(() => {});
+
+// 6.5-2: primitives enumerate
+const tools = await rpc('tools/list', {});
+const resources = await rpc('resources/list', {});
+const prompts = await rpc('prompts/list', {});
+check('primitives enumerate', tools.result?.tools?.length >= 16 && prompts.result?.prompts?.length === 5 && resources.result?.resources?.length >= 5,
+  `tools=${tools.result?.tools?.length} resources=${resources.result?.resources?.length} prompts=${prompts.result?.prompts?.length}`);
+
+// 6.5-3: health + secret configured
+const h = await call('health_check', {});
+check('health_check ok', h.ok === true, `version=${h.version} commit=${h.commit}`);
+check('CONSENT_SECRET configured in prod', h.consent_secret_configured === true,
+  h.consent_secret_configured ? 'strong secret set' : 'NOT SET — tokens forgeable, set env var and redeploy!');
+
+// 6.5-4: consent probe (judge Path D) on PROD
+const probe = await call('pull_bureau', { session_id: 'prod-verify', lead_id: 'probe', pan: 'VITTA1235K', consent_token: 'garbage' });
+check('consent gate refuses on prod', probe?.error === 'CONSENT_REQUIRED', JSON.stringify(probe));
+
+// 6.5-5: demo pair story end-to-end on PROD (also proves cross-request state persistence)
+const S = `prod-verify-${Date.now().toString(36)}`;
+const q = await call('qualify_lead', { session_id: S, purpose: 'medical emergency', amount: 300000, tenure_months: 36, employment: 'SALARIED', city: 'Kochi' });
+const c = await call('record_consent', { session_id: S, lead_id: q.lead_id, consent_text_version: 'consent-v3', accepted: true, channel: 'web' });
+await call('verify_kyc', { session_id: S, lead_id: q.lead_id, pan: 'VITTA1235K', name: 'Priya Sharma' });
+await call('screen_fraud', { session_id: S, lead_id: q.lead_id, identifiers: { mobile: '9876543222' } });
+const b = await call('pull_bureau', { session_id: S, lead_id: q.lead_id, pan: 'VITTA1235K', consent_token: c.consent_token });
+await call('fetch_bank_statements', { session_id: S, lead_id: q.lead_id, consent_token: c.consent_token, months: 12 });
+const a = await call('compute_affordability', { session_id: S, lead_id: q.lead_id });
+const d = await call('underwrite', { session_id: S, lead_id: q.lead_id });
+check('demo pair → CONDITIONAL ₹2.5L on prod', d.outcome === 'CONDITIONAL' && d.max_amount === 250000 && Math.round(a.foir * 100) === 57,
+  `outcome=${d.outcome} max=${d.max_amount} foir=${Math.round((a.foir ?? 0) * 100)}% bureau=${b.score}`);
+
+// what-if flip on prod
+const sim = await call('simulate_scenario', { session_id: S, lead_id: q.lead_id, close_existing_emi: 25000 });
+check('what-if flip on prod', sim?.scenario?.decision?.outcome === 'APPROVE' && sim?.scenario?.decision?.max_amount === 300000,
+  sim?.delta?.summary ?? JSON.stringify(sim).slice(0, 120));
+
+// offers + sanction + audit redaction
+const o = await call('generate_offers', { session_id: S, lead_id: q.lead_id });
+const sl = await call('create_sanction_letter', { session_id: S, lead_id: q.lead_id, offer_id: o.recommended_offer_id });
+const t = await call('get_audit_trail', { session_id: S, view: 'FULL' });
+const blob = JSON.stringify(t);
+check('offers + sanction on prod', (o.offers?.length ?? 0) >= 1 && !!sl.hash, `offers=${o.offers?.length} hash=${String(sl.hash).slice(0, 12)}…`);
+check('audit redaction on prod', (t.count ?? 0) >= 10 && !blob.includes('VITTA1235K') && !blob.includes('9876543222'), `events=${t.count}`);
+
+// live external data
+const rates = await call('get_reference_rates', {});
+check('live reference rates', !!rates?.inr_per?.USD, `source=${rates.source} USD→INR=${rates?.inr_per?.USD}`);
+
+// sanction letter downloadable over HTTP (GET /letters/:leadId)
+try {
+  const letterRes = await fetch(sl.url);
+  const letterHtml = letterRes.ok ? await letterRes.text() : '';
+  check('letter URL serves the signed letter', letterRes.ok && letterHtml.includes(String(sl.hash)),
+    `${sl.url} → HTTP ${letterRes.status}, hash-in-doc=${letterHtml.includes(String(sl.hash))}`);
+} catch (e) {
+  check('letter URL serves the signed letter', false, `${sl.url} → ${e.message}`);
+}
+
+console.log(`\n${failures === 0 ? 'ALL PROD CHECKS PASS' : failures + ' CHECKS FAILED'} — ${BASE}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/sample-apps/vitta/src/app.module.ts
+++ b/sample-apps/vitta/src/app.module.ts
@@ -1,0 +1,25 @@
+import { McpApp, Module, ConfigModule } from '@nitrostack/core';
+import { VittaModule } from './vitta.module.js';
+import { SystemHealthCheck } from './health/system.health.js';
+
+/**
+ * Root Application Module — Vitta MCP lending server.
+ * The MCP client is the agent; this server is the capability layer.
+ */
+@McpApp({
+  module: AppModule,
+  server: {
+    name: 'vitta-lending',
+    version: '1.0.0',
+  },
+  logging: {
+    level: 'info',
+  },
+})
+@Module({
+  name: 'app',
+  description: 'Vitta — MCP-native NBFC lending assistant (Amrita MCP Hackathon 2026, BFSI).',
+  imports: [ConfigModule.forRoot(), VittaModule],
+  providers: [SystemHealthCheck],
+})
+export class AppModule {}

--- a/sample-apps/vitta/src/health/system.health.ts
+++ b/sample-apps/vitta/src/health/system.health.ts
@@ -1,0 +1,55 @@
+import { HealthCheck, HealthCheckInterface, HealthCheckResult } from '@nitrostack/core';
+
+/**
+ * System Health Check
+ * 
+ * Monitors system resources and uptime
+ */
+@HealthCheck({ 
+  name: 'system', 
+  description: 'System resource and uptime check',
+  interval: 30 // Check every 30 seconds
+})
+export class SystemHealthCheck implements HealthCheckInterface {
+  private startTime: number;
+
+  constructor() {
+    this.startTime = Date.now();
+  }
+
+  async check(): Promise<HealthCheckResult> {
+    try {
+      const memoryUsage = process.memoryUsage();
+      const uptime = Date.now() - this.startTime;
+      const uptimeSeconds = Math.floor(uptime / 1000);
+      
+      // Convert memory to MB
+      const memoryUsedMB = Math.round(memoryUsage.heapUsed / 1024 / 1024);
+      const memoryTotalMB = Math.round(memoryUsage.heapTotal / 1024 / 1024);
+      
+      // Consider unhealthy if memory usage is > 90%
+      const memoryPercent = (memoryUsage.heapUsed / memoryUsage.heapTotal) * 100;
+      const isHealthy = memoryPercent < 90;
+      
+      return {
+        status: isHealthy ? 'up' : 'degraded',
+        message: isHealthy 
+          ? 'System is healthy' 
+          : 'High memory usage detected',
+        details: {
+          uptime: `${uptimeSeconds}s`,
+          memory: `${memoryUsedMB}MB / ${memoryTotalMB}MB (${Math.round(memoryPercent)}%)`,
+          pid: process.pid,
+          nodeVersion: process.version,
+        },
+      };
+    } catch (error: any) {
+      return {
+        status: 'down',
+        message: 'System health check failed',
+        details: error.message,
+      };
+    }
+  }
+}
+

--- a/sample-apps/vitta/src/index.ts
+++ b/sample-apps/vitta/src/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Vitta MCP Lending Server
+ *
+ * Main entry point for the MCP server.
+ * Uses the @McpApp decorator pattern for clean, NestJS-style architecture.
+ *
+ * Transport Configuration:
+ * - Development (NODE_ENV=development): STDIO only
+ * - Production (NODE_ENV=production): Dual transport (STDIO + HTTP SSE)
+ */
+
+import 'dotenv/config';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { McpApplicationFactory } from '@nitrostack/core';
+import { AppModule } from './app.module.js';
+import { store } from './lib/store.js';
+
+/**
+ * Bootstrap the application
+ */
+async function bootstrap() {
+  // Create and start the MCP server
+  const server = await McpApplicationFactory.create(AppModule);
+  await server.start();
+
+  // Sanction-letter download route on the built-in HTTP transport
+  // (getHttpTransport()/getApp() are public API — core/dist/core/server.d.ts:197,
+  //  transports/streamable-http.d.ts:158). Available in http/dual mode only.
+  const app = (server as any).getHttpTransport?.()?.getApp?.();
+  if (app) {
+    app.get('/letters/:leadId', (req: any, res: any) => {
+      const leadId = String(req.params.leadId ?? '');
+      if (!/^[A-Za-z0-9-]{1,64}$/.test(leadId)) {
+        res.status(400).json({ error: 'BAD_LEAD_ID' });
+        return;
+      }
+      // 1) in-memory store (works on read-only cloud filesystems)
+      const html = store.getCase(leadId)?.sanction?.letter_fields?.html as string | undefined;
+      if (html) {
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.send(html);
+        return;
+      }
+      // 2) disk fallback (local dev)
+      const file = join(process.cwd(), 'data', 'letters', `${leadId}.html`);
+      if (existsSync(file)) {
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.send(readFileSync(file, 'utf8'));
+        return;
+      }
+      res.status(404).json({ error: 'LETTER_NOT_FOUND', hint: 'Run create_sanction_letter first.' });
+    });
+    console.error('[vitta] sanction-letter route mounted: GET /letters/:leadId');
+  }
+}
+
+// Start the application
+bootstrap().catch((error) => {
+  console.error('❌ Failed to start server:', error);
+  process.exit(1);
+});

--- a/sample-apps/vitta/src/lib/affordability.ts
+++ b/sample-apps/vitta/src/lib/affordability.ts
@@ -1,0 +1,33 @@
+/**
+ * affordability.ts — FOIR / DTI computation (PDF p.9). Pure.
+ * FOIR = (existing_emi + proposed_emi) / net_monthly_income.
+ */
+import { computeEmi } from './emi.js';
+import { POLICY } from './policy.js';
+import type { Affordability, BureauReport, BankSummary } from './types.js';
+
+export function computeAffordability(args: {
+  requested_amount: number;
+  tenure_months: number;
+  bureau: BureauReport;
+  bank: BankSummary;
+  net_income: number;
+}): Affordability {
+  const existing_emi = args.bureau.active_emi;
+  const proposed_emi = computeEmi(args.requested_amount, POLICY.base_rate_pct, args.tenure_months);
+  const net_income = args.net_income;
+  const foir = round3((existing_emi + proposed_emi) / net_income);
+  const dti = round3(existing_emi / net_income);
+  return {
+    net_income,
+    existing_emi,
+    proposed_emi,
+    foir,
+    dti,
+    stability_index: args.bank.stability_index,
+  };
+}
+
+function round3(n: number): number {
+  return Math.round(n * 1000) / 1000;
+}

--- a/sample-apps/vitta/src/lib/consent.ts
+++ b/sample-apps/vitta/src/lib/consent.ts
@@ -1,0 +1,149 @@
+/**
+ * consent.ts — THE SIGNATURE FEATURE.
+ *
+ * DPDP consent expressed as code: a scoped, time-boxed, tamper-evident token.
+ * Data-pull tools (pull_bureau, fetch_bank_statements) MUST refuse without a
+ * valid token for the required scope. Enforced INLINE as the first line of each
+ * gated handler (NitroStack Guards cannot read tool input — see NITROSTACK_NOTES.md).
+ *
+ * Pure module: node:crypto only, no NitroStack imports, injectable clock → testable.
+ */
+import { createHmac, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
+import type { ConsentPayload, ConsentScope, ConsentFailureCode, ConsentRefusal } from './types.js';
+
+export const CONSENT_TTL_SECONDS = 900; // 15 minutes
+export const ALL_SCOPES: ConsentScope[] = ['CREDIT_BUREAU', 'BANK_STATEMENTS', 'KYC'];
+
+/**
+ * Per-process random fallback secret. If CONSENT_SECRET is unset, tokens are
+ * still internally consistent within THIS running instance (demo never breaks)
+ * but CANNOT be forged from the public repo — unlike a hardcoded fallback.
+ * Trade-off: tokens don't survive a process restart (fine under a 15-min TTL).
+ */
+const EPHEMERAL_SECRET = randomBytes(32).toString('hex');
+let warnedDevSecret = false;
+function secret(): string {
+  const s = process.env.CONSENT_SECRET;
+  if (s && s.length >= 16) return s;
+  if (process.env.NODE_ENV === 'production' && !warnedDevSecret) {
+    warnedDevSecret = true;
+    console.error(
+      '[VITTA SECURITY] CONSENT_SECRET is not set — using an ephemeral per-boot secret. ' +
+        'Tokens are unforgeable from the repo but will not survive a restart. ' +
+        'Set CONSENT_SECRET in the deployment env for stable tokens.',
+    );
+  }
+  return EPHEMERAL_SECRET;
+}
+
+function b64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+function b64urlDecode(s: string): Buffer {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
+  return Buffer.from(s.replace(/-/g, '+').replace(/_/g, '/') + pad, 'base64');
+}
+function sign(body: string): string {
+  return createHmac('sha256', secret()).update(body).digest('hex');
+}
+
+export function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/** Issue a signed consent token. `now` is injectable for deterministic tests. */
+export function issueToken(args: {
+  lead_id: string;
+  scopes?: ConsentScope[];
+  version: string;
+  ttl?: number;
+  now?: number;
+}): { token: string; payload: ConsentPayload } {
+  const iat = args.now ?? nowSeconds();
+  const payload: ConsentPayload = {
+    jti: randomUUID(),
+    lead_id: args.lead_id,
+    scopes: args.scopes && args.scopes.length ? args.scopes : [...ALL_SCOPES],
+    iat,
+    exp: iat + (args.ttl ?? CONSENT_TTL_SECONDS),
+    version: args.version,
+  };
+  const body = b64url(Buffer.from(JSON.stringify(payload)));
+  return { token: `${body}.${sign(body)}`, payload };
+}
+
+export interface VerifyResult {
+  valid: boolean;
+  code?: ConsentFailureCode;
+  payload?: ConsentPayload;
+}
+
+/** Verify signature + parse. Does NOT check expiry/scope/revocation. */
+export function verifyToken(token: unknown): VerifyResult {
+  if (typeof token !== 'string' || !token.includes('.')) {
+    return { valid: false, code: 'CONSENT_REQUIRED' };
+  }
+  const [body, mac] = token.split('.');
+  if (!body || !mac) return { valid: false, code: 'CONSENT_INVALID' };
+
+  const expected = sign(body);
+  // constant-time compare; length mismatch → invalid
+  const a = Buffer.from(mac);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) {
+    return { valid: false, code: 'CONSENT_INVALID' };
+  }
+  try {
+    const payload = JSON.parse(b64urlDecode(body).toString('utf8')) as ConsentPayload;
+    if (!payload || typeof payload.exp !== 'number' || !Array.isArray(payload.scopes)) {
+      return { valid: false, code: 'CONSENT_INVALID' };
+    }
+    return { valid: true, payload };
+  } catch {
+    return { valid: false, code: 'CONSENT_INVALID' };
+  }
+}
+
+export type ConsentCheck = { ok: true; payload: ConsentPayload } | { ok: false; code: ConsentFailureCode };
+
+/**
+ * The gate. Returns ok:true only for a signed, unexpired, in-scope, non-revoked token.
+ * @param opts.now       injectable clock (epoch seconds)
+ * @param opts.isRevoked predicate on jti (store-backed revocation)
+ */
+export function validConsent(
+  token: unknown,
+  requiredScope: ConsentScope,
+  opts?: { now?: number; isRevoked?: (jti: string) => boolean; leadId?: string },
+): ConsentCheck {
+  const v = verifyToken(token);
+  if (!v.valid || !v.payload) return { ok: false, code: v.code ?? 'CONSENT_INVALID' };
+
+  const now = opts?.now ?? nowSeconds();
+  if (now > v.payload.exp) return { ok: false, code: 'CONSENT_EXPIRED' };
+  if (opts?.isRevoked?.(v.payload.jti)) return { ok: false, code: 'CONSENT_REVOKED' };
+  // Token binding: a consent issued for one applicant must NOT unlock another's data.
+  if (opts?.leadId && v.payload.lead_id !== opts.leadId) return { ok: false, code: 'CONSENT_LEAD_MISMATCH' };
+  if (!v.payload.scopes.includes(requiredScope)) return { ok: false, code: 'SCOPE_NOT_GRANTED' };
+  return { ok: true, payload: v.payload };
+}
+
+/** Build the exact refusal payload returned by a gated tool. */
+export function refusal(code: ConsentFailureCode): ConsentRefusal {
+  const hints: Record<ConsentFailureCode, string> = {
+    CONSENT_REQUIRED: 'Call record_consent first and pass the returned consent_token',
+    CONSENT_INVALID: 'The consent_token is malformed or tampered — re-run record_consent',
+    CONSENT_EXPIRED: 'The consent_token expired (15-min TTL) — re-run record_consent',
+    SCOPE_NOT_GRANTED: 'This consent_token does not grant the scope this tool needs',
+    CONSENT_REVOKED: 'Consent was revoked — obtain fresh consent via record_consent',
+    CONSENT_LEAD_MISMATCH: 'This consent_token was issued for a different application — obtain consent for this lead_id',
+  };
+  return { error: 'CONSENT_REQUIRED', code, hint: hints[code] };
+}
+
+/** Stable content hash of the consent proof (stored on file). */
+export function consentHash(input: { lead_id: string; version: string; ts: string; channel: string }): string {
+  return createHmac('sha256', secret())
+    .update(`${input.lead_id}|${input.version}|${input.ts}|${input.channel}`)
+    .digest('hex');
+}

--- a/sample-apps/vitta/src/lib/emi.ts
+++ b/sample-apps/vitta/src/lib/emi.ts
@@ -1,0 +1,46 @@
+/**
+ * emi.ts — reducing-balance EMI + APR math (SPEC.md). Pure, deterministic.
+ */
+
+/** Reducing-balance EMI, rounded to nearest rupee. */
+export function computeEmi(principal: number, annualRatePct: number, tenureMonths: number): number {
+  if (tenureMonths <= 0) return 0;
+  const r = annualRatePct / 12 / 100;
+  if (r === 0) return Math.round(principal / tenureMonths);
+  const pow = Math.pow(1 + r, tenureMonths);
+  const emi = (principal * r * pow) / (pow - 1);
+  return Math.round(emi);
+}
+
+/** Max principal serviceable by a given EMI (inverse of computeEmi). */
+export function principalForEmi(emi: number, annualRatePct: number, tenureMonths: number): number {
+  const r = annualRatePct / 12 / 100;
+  if (r === 0) return Math.round(emi * tenureMonths);
+  const pow = Math.pow(1 + r, tenureMonths);
+  return Math.round((emi * (pow - 1)) / (r * pow));
+}
+
+/**
+ * APR including one-time processing fee, approximated as the flat-fee uplift on
+ * the reducing-balance rate over the tenure. Good enough for offer display.
+ */
+export function computeApr(
+  principal: number,
+  annualRatePct: number,
+  tenureMonths: number,
+  processingFeePct: number,
+): number {
+  const emi = computeEmi(principal, annualRatePct, tenureMonths);
+  const totalInterest = emi * tenureMonths - principal;
+  const fee = (processingFeePct / 100) * principal;
+  const totalCost = totalInterest + fee;
+  // annualised cost over average outstanding (~principal/2), expressed as %
+  const years = tenureMonths / 12;
+  const apr = (totalCost / (principal / 2)) / years * 100;
+  return Math.round(apr * 100) / 100;
+}
+
+export function totalCost(emi: number, tenureMonths: number, principal: number, processingFeePct: number): number {
+  const fee = Math.round((processingFeePct / 100) * principal);
+  return emi * tenureMonths + fee;
+}

--- a/sample-apps/vitta/src/lib/engine.ts
+++ b/sample-apps/vitta/src/lib/engine.ts
@@ -1,0 +1,263 @@
+/**
+ * engine.ts — the golden-path orchestration as PURE-ish functions over `store`.
+ * Both the MCP tool handlers (src/tools/*) and the tests/regression drive THESE
+ * functions, so tool behavior and tested behavior are identical by construction.
+ *
+ * Gated steps (pullBureau, fetchBankStatements) call validConsent() as their
+ * FIRST line and return the exact refusal payload — the signature feature.
+ */
+import { randomUUID } from 'node:crypto';
+import { store } from './store.js';
+import { issueToken, validConsent, refusal, consentHash, nowSeconds, ALL_SCOPES } from './consent.js';
+import { resolveBureau, resolveBank, resolveKyc, resolveFraud, resolveCity, resolveNetIncome } from './seeds.js';
+import { computeAffordability } from './affordability.js';
+import { underwrite } from './scorecard.js';
+import { generateOffers } from './offers.js';
+import { createSanction } from './sanction.js';
+import { POLICY } from './policy.js';
+import type {
+  CaseRecord, ConsentScope, ConsentRefusal, KycResult, FraudResult,
+  BureauReport, BankSummary, Affordability, Decision, Offer, SanctionResult,
+} from './types.js';
+
+function isRevoked(jti: string): boolean {
+  return store.isRevoked(jti);
+}
+
+// ---------- Tool 1: qualify_lead ----------
+export function qualifyLead(input: {
+  session_id: string;
+  purpose: string;
+  amount: number;
+  tenure_months: number;
+  employment: string;
+  city: string;
+  income_band?: string;
+}): { lead_id: string; prelim_eligibility: string; next_step: string; intent_flag: 'FAST_TRACK' | 'STANDARD'; notes: string[] } {
+  const lead_id = `VITTA-${randomUUID().slice(0, 8).toUpperCase()}`;
+  const intent_flag: 'FAST_TRACK' | 'STANDARD' = /medical|emergenc|hospital|urgent/i.test(input.purpose)
+    ? 'FAST_TRACK'
+    : 'STANDARD';
+
+  const city = resolveCity(input.city);
+  const notes: string[] = [];
+  let prelim = 'ELIGIBLE';
+  if (!city.served) { prelim = 'INELIGIBLE_CITY'; notes.push('City not currently served.'); }
+  if (!POLICY.eligible_employment.includes(input.employment as any)) { prelim = 'INELIGIBLE_EMPLOYMENT'; notes.push('Employment type ineligible.'); }
+  if (input.amount < POLICY.min_amount) { prelim = 'BELOW_MIN_AMOUNT'; notes.push(`Minimum amount is ₹${POLICY.min_amount}.`); }
+
+  const rec: CaseRecord = {
+    lead_id,
+    session_id: input.session_id,
+    created_at: new Date().toISOString(),
+    purpose: input.purpose,
+    intent_flag,
+    amount: input.amount,
+    tenure_months: input.tenure_months,
+    employment: input.employment as any,
+    city: input.city,
+    income_band: input.income_band,
+    prelim_eligibility: prelim,
+    status: 'QUALIFIED',
+  };
+  store.putCase(rec);
+  store.audit(input.session_id, 'qualify_lead', 'LEAD_QUALIFIED', { lead_id, purpose: input.purpose, amount: input.amount, city: input.city, prelim, intent_flag });
+
+  return { lead_id, prelim_eligibility: prelim, next_step: 'record_consent', intent_flag, notes };
+}
+
+// ---------- Tool 2: record_consent (consent_token issuer) ----------
+export function recordConsent(input: {
+  session_id: string;
+  lead_id: string;
+  consent_text_version: string;
+  accepted: boolean;
+  channel: string;
+  scopes?: ConsentScope[];
+}):
+  | { accepted: false; message: string }
+  | { accepted: true; consent_token: string; jti: string; ts: string; hash: string; scopes: ConsentScope[]; expires_at: string } {
+  const ts = new Date().toISOString();
+  if (!input.accepted) {
+    store.audit(input.session_id, 'record_consent', 'CONSENT_DECLINED', { lead_id: input.lead_id, version: input.consent_text_version });
+    return { accepted: false, message: 'Consent not granted — data-pull tools will refuse to run.' };
+  }
+  const scopes = input.scopes?.length ? input.scopes : [...ALL_SCOPES];
+  const { token, payload } = issueToken({ lead_id: input.lead_id, scopes, version: input.consent_text_version });
+  const hash = consentHash({ lead_id: input.lead_id, version: input.consent_text_version, ts, channel: input.channel });
+  store.putConsentProof(payload.jti, { lead_id: input.lead_id, ts, channel: input.channel, version: input.consent_text_version, hash, scopes });
+  store.patchCase(input.lead_id, { status: 'CONSENTED' });
+  store.audit(input.session_id, 'record_consent', 'CONSENT_GRANTED', { lead_id: input.lead_id, version: input.consent_text_version, channel: input.channel, scopes, hash });
+  // jti is returned so revoke_consent is usable without decoding the token
+  return { accepted: true, consent_token: token, jti: payload.jti, ts, hash, scopes, expires_at: new Date(payload.exp * 1000).toISOString() };
+}
+
+// ---------- Tool 3: verify_kyc ----------
+export function verifyKyc(input: { session_id: string; lead_id: string; pan: string; name: string; dob?: string }): KycResult {
+  const kyc = resolveKyc(input.pan, input.name);
+  store.patchCase(input.lead_id, { pan: input.pan, name: input.name, kyc, status: 'KYC_' + kyc.kyc_status });
+  store.audit(input.session_id, 'verify_kyc', 'KYC_CHECKED', { lead_id: input.lead_id, pan: input.pan, name: input.name, kyc_status: kyc.kyc_status, risk_flags: kyc.risk_flags });
+  return kyc;
+}
+
+// ---------- Tool 4: screen_fraud ----------
+export function screenFraud(input: { session_id: string; lead_id: string; identifiers: { mobile: string; pan?: string; device?: string } }): FraudResult {
+  const fraud = resolveFraud(input.identifiers.mobile);
+  store.patchCase(input.lead_id, { mobile: input.identifiers.mobile, fraud });
+  store.audit(input.session_id, 'screen_fraud', 'FRAUD_SCREENED', { lead_id: input.lead_id, mobile: input.identifiers.mobile, verdict: fraud.verdict, score: fraud.score, signals: fraud.signals });
+  return fraud;
+}
+
+// ---------- Tool 5: pull_bureau ⚿ ----------
+export function pullBureau(input: { session_id: string; lead_id: string; consent_token: unknown; pan: string }): BureauReport | ConsentRefusal {
+  const c = validConsent(input.consent_token, 'CREDIT_BUREAU', { now: nowSeconds(), isRevoked, leadId: input.lead_id });
+  if (!c.ok) {
+    store.audit(input.session_id, 'pull_bureau', 'CONSENT_GATE_BLOCKED', { lead_id: input.lead_id, required_scope: 'CREDIT_BUREAU', code: c.code });
+    return refusal(c.code);
+  }
+  const bureau = resolveBureau(input.pan);
+  store.patchCase(input.lead_id, { bureau });
+  store.audit(input.session_id, 'pull_bureau', 'BUREAU_PULLED', { lead_id: input.lead_id, pan: input.pan, score: bureau.score, reason_codes: bureau.reason_codes });
+  return bureau;
+}
+
+// ---------- Tool 6: fetch_bank_statements ⚿ ----------
+export function fetchBankStatements(input: { session_id: string; lead_id: string; consent_token: unknown; months?: number }): BankSummary | ConsentRefusal {
+  const c = validConsent(input.consent_token, 'BANK_STATEMENTS', { now: nowSeconds(), isRevoked, leadId: input.lead_id });
+  if (!c.ok) {
+    store.audit(input.session_id, 'fetch_bank_statements', 'CONSENT_GATE_BLOCKED', { lead_id: input.lead_id, required_scope: 'BANK_STATEMENTS', code: c.code });
+    return refusal(c.code);
+  }
+  const rec = store.getCase(input.lead_id);
+  const mobile = rec?.mobile ?? '9000000000';
+  const bank = resolveBank(mobile, input.months ?? 12);
+  store.patchCase(input.lead_id, { bank });
+  store.audit(input.session_id, 'fetch_bank_statements', 'BANK_FETCHED', { lead_id: input.lead_id, months: input.months ?? 12, net_surplus: bank.net_surplus, stability_index: bank.stability_index });
+  return bank;
+}
+
+// ---------- Tool 7: compute_affordability ----------
+export function computeAffordabilityStep(input: { session_id: string; lead_id: string; requested_amount?: number; tenure_months?: number }): Affordability {
+  const rec = must(input.lead_id);
+  if (!rec.bureau || !rec.bank) throw new Error('AFFORDABILITY_PRECONDITION: run pull_bureau and fetch_bank_statements first');
+  const net_income = resolveNetIncome(rec.mobile ?? '9000000000');
+  // Overrides become the case's requested terms — underwrite/generate_offers must
+  // see the SAME tenure/amount this affordability was computed against.
+  const requested_amount = input.requested_amount ?? rec.amount ?? 0;
+  const tenure_months = input.tenure_months ?? rec.tenure_months ?? 36;
+  const aff = computeAffordability({
+    requested_amount,
+    tenure_months,
+    bureau: rec.bureau,
+    bank: rec.bank,
+    net_income,
+  });
+  store.patchCase(input.lead_id, { affordability: aff, amount: requested_amount, tenure_months });
+  store.audit(input.session_id, 'compute_affordability', 'AFFORDABILITY_COMPUTED', { lead_id: input.lead_id, foir: aff.foir, dti: aff.dti, proposed_emi: aff.proposed_emi, tenure_months, requested_amount });
+  return aff;
+}
+
+// ---------- Tool 8: underwrite ----------
+export function underwriteStep(input: { session_id: string; lead_id: string }): Decision {
+  const rec = must(input.lead_id);
+  if (!rec.bureau || !rec.affordability) throw new Error('UNDERWRITE_PRECONDITION: run compute_affordability first');
+  const cap = resolveCity(rec.city ?? '').cap ?? 700000;
+  const decision = underwrite({
+    requested_amount: rec.amount ?? 0,
+    tenure_months: rec.tenure_months ?? 36,
+    employment: rec.employment ?? 'SALARIED',
+    segment_cap: cap,
+    bureau: rec.bureau,
+    affordability: rec.affordability,
+  });
+  store.patchCase(input.lead_id, { decision, status: `DECISION_${decision.outcome}` });
+  store.audit(input.session_id, 'underwrite', 'DECISION', { lead_id: input.lead_id, outcome: decision.outcome, max_amount: decision.max_amount, score: decision.score, reason_codes: decision.reason_codes });
+  return decision;
+}
+
+// ---------- Tool 9: generate_offers ----------
+export function generateOffersStep(input: { session_id: string; lead_id: string }): { offers: Offer[]; recommended_offer_id: string } {
+  const rec = must(input.lead_id);
+  if (!rec.decision) throw new Error('OFFERS_PRECONDITION: run underwrite first');
+  const result = generateOffers({
+    lead_id: input.lead_id,
+    decision: rec.decision,
+    tenure_months: rec.tenure_months ?? 36,
+    intent_flag: rec.intent_flag,
+    affordability: rec.affordability
+      ? { existing_emi: rec.affordability.existing_emi, net_income: rec.affordability.net_income }
+      : undefined,
+  });
+  store.patchCase(input.lead_id, { offers: result.offers, recommended_offer_id: result.recommended_offer_id });
+  store.audit(input.session_id, 'generate_offers', 'OFFERS_GENERATED', { lead_id: input.lead_id, count: result.offers.length, recommended: result.recommended_offer_id });
+  return result;
+}
+
+// ---------- Tool 10: create_sanction_letter ----------
+export function createSanctionStep(input: { session_id: string; lead_id: string; offer_id: string }): SanctionResult | { error: string; hint: string } {
+  const rec = must(input.lead_id);
+  const offer = rec.offers?.find((o) => o.offer_id === input.offer_id);
+  if (!offer) return { error: 'OFFER_NOT_FOUND', hint: 'Pass an offer_id returned by generate_offers' };
+  const sanction = createSanction(rec, offer);
+  store.patchCase(input.lead_id, { sanction, status: 'SANCTIONED' });
+  store.audit(input.session_id, 'create_sanction_letter', 'SANCTION_CREATED', { lead_id: input.lead_id, offer_id: input.offer_id, amount: offer.amount, hash: sanction.hash });
+  return sanction;
+}
+
+// ---------- Fast-path: run the whole post-consent chain in ONE call ----------
+// Collapses verify_kyc → screen_fraud → pull_bureau ⚿ → fetch_bank_statements ⚿
+// → compute_affordability → underwrite so agentic clients that cap tool-calls-per-turn
+// don't stall mid-chain. The consent gate is STILL enforced (pull/fetch refuse without
+// a valid, in-scope, lead-bound token). Returns a Decision-shaped object so the
+// underwriting-result widget renders the gauge.
+export function advanceApplication(input: {
+  session_id: string;
+  lead_id: string;
+  consent_token: unknown;
+  pan: string;
+  name: string;
+  mobile: string;
+  dob?: string;
+}): (Decision & { kyc_status: string; fraud_verdict: string; foir: number; bureau_score: number; net_income: number; existing_emi: number }) | ConsentRefusal {
+  const kyc = verifyKyc({ session_id: input.session_id, lead_id: input.lead_id, pan: input.pan, name: input.name, dob: input.dob });
+  const fraud = screenFraud({ session_id: input.session_id, lead_id: input.lead_id, identifiers: { mobile: input.mobile, pan: input.pan } });
+
+  const bureau = pullBureau({ session_id: input.session_id, lead_id: input.lead_id, consent_token: input.consent_token, pan: input.pan });
+  if ('error' in bureau) return bureau; // consent gate refusal — short-circuit
+  const bank = fetchBankStatements({ session_id: input.session_id, lead_id: input.lead_id, consent_token: input.consent_token });
+  if ('error' in bank) return bank;
+
+  const aff = computeAffordabilityStep({ session_id: input.session_id, lead_id: input.lead_id });
+  const decision = underwriteStep({ session_id: input.session_id, lead_id: input.lead_id });
+
+  return {
+    ...decision,
+    kyc_status: kyc.kyc_status,
+    fraud_verdict: fraud.verdict,
+    foir: aff.foir,
+    net_income: aff.net_income,
+    existing_emi: aff.existing_emi,
+    bureau_score: bureau.score,
+  };
+}
+
+// ---------- Tools 11 & 12: audit ----------
+export function logAuditEvent(input: { session_id: string; actor: string; event: string; payload: Record<string, unknown> }): { ack: true; seq: number } {
+  return store.audit(input.session_id, input.actor, input.event, input.payload);
+}
+export function getAuditTrail(input: { session_id: string; view?: 'FULL' | 'SUMMARY' | 'COMPLIANCE_VIEW' }) {
+  return store.trail(input.session_id, input.view ?? 'FULL');
+}
+
+// revoke helper (SHOULD-HAVE: DPDP withdrawal)
+export function revokeConsent(input: { session_id: string; lead_id: string; jti: string }): { revoked: true } {
+  store.revoke(input.jti);
+  store.audit(input.session_id, 'record_consent', 'CONSENT_REVOKED', { lead_id: input.lead_id, jti: input.jti });
+  return { revoked: true };
+}
+
+function must(leadId: string): CaseRecord {
+  const rec = store.getCase(leadId);
+  if (!rec) throw new Error(`CASE_NOT_FOUND: ${leadId}. Run qualify_lead first.`);
+  return rec;
+}

--- a/sample-apps/vitta/src/lib/offers.ts
+++ b/sample-apps/vitta/src/lib/offers.ts
@@ -1,0 +1,94 @@
+/**
+ * offers.ts — up to 3 offers, intent-aware ordering (SPEC.md).
+ * FAST_TRACK (medical/emergency) → lowest EMI first; else lowest total cost first.
+ */
+import { computeEmi, computeApr, totalCost } from './emi.js';
+import { POLICY } from './policy.js';
+import type { Decision, Offer } from './types.js';
+
+export function generateOffers(args: {
+  lead_id: string;
+  decision: Decision;
+  tenure_months: number;
+  intent_flag?: 'FAST_TRACK' | 'STANDARD';
+  existing_customer?: boolean;
+  /** FOIR guard: when provided, candidate tenures whose EMI would breach the
+   *  FOIR cap at max_amount are dropped (shorter tenure = higher EMI — the
+   *  approved amount is only serviceable at tenures ≥ the underwritten one). */
+  affordability?: { existing_emi: number; net_income: number };
+}): { offers: Offer[]; recommended_offer_id: string } {
+  const { decision } = args;
+  if (decision.outcome === 'DECLINE' || decision.max_amount <= 0) {
+    return { offers: [], recommended_offer_id: '' };
+  }
+
+  const amount = decision.max_amount;
+  const rate = decision.rate_band.min; // best rate the applicant qualifies for
+  const fee = args.existing_customer ? POLICY.processing_fee_pct - 0.5 : POLICY.processing_fee_pct;
+  const validTill = isoPlusDays(45);
+
+  // candidate tenures around the requested tenure, clamped to policy grid
+  const t = clampTenure(args.tenure_months);
+  let tenures = uniq([clampTenure(t - 12), t, clampTenure(t + 12)]).slice(0, 3);
+
+  // FOIR guard: every offer must itself be serviceable (agent-found bug #2:
+  // a shorter-tenure offer at max_amount can breach the cap that set max_amount)
+  if (args.affordability) {
+    const { existing_emi, net_income } = args.affordability;
+    const serviceable = tenures.filter(
+      (tn) => (existing_emi + computeEmi(amount, rate, tn)) / net_income <= POLICY.foir_cap + 1e-9,
+    );
+    if (serviceable.length) tenures = serviceable;
+  }
+
+  const offers: Offer[] = tenures.map((tenure, i) => {
+    const emi = computeEmi(amount, rate, tenure);
+    return {
+      offer_id: `${args.lead_id}-OF${i + 1}`,
+      amount,
+      tenure_months: tenure,
+      roi_annual_pct: rate,
+      emi,
+      processing_fee_pct: fee,
+      apr_pct: computeApr(amount, rate, tenure, fee),
+      total_cost: totalCost(emi, tenure, amount, fee),
+      valid_till: validTill,
+      recommended: false,
+    };
+  });
+
+  // recommend: FAST_TRACK → lowest EMI; else lowest total cost
+  const recommended =
+    args.intent_flag === 'FAST_TRACK'
+      ? [...offers].sort((a, b) => a.emi - b.emi)[0]
+      : [...offers].sort((a, b) => a.total_cost - b.total_cost)[0];
+
+  for (const o of offers) {
+    if (o.offer_id === recommended.offer_id) {
+      o.recommended = true;
+      o.why_recommended =
+        args.intent_flag === 'FAST_TRACK'
+          ? `Lowest monthly EMI (₹${o.emi.toLocaleString('en-IN')}) — eases your immediate cash burden for a time-sensitive need.`
+          : `Lowest total cost (₹${o.total_cost.toLocaleString('en-IN')}) over the loan life.`;
+    }
+  }
+
+  // intent-aware ordering of the list itself
+  const ordered =
+    args.intent_flag === 'FAST_TRACK'
+      ? [...offers].sort((a, b) => a.emi - b.emi)
+      : [...offers].sort((a, b) => a.total_cost - b.total_cost);
+
+  return { offers: ordered, recommended_offer_id: recommended.offer_id };
+}
+
+function clampTenure(t: number): number {
+  return Math.max(POLICY.tenure.min, Math.min(POLICY.tenure.max, t));
+}
+function uniq(a: number[]): number[] {
+  return [...new Set(a)];
+}
+function isoPlusDays(days: number): string {
+  const d = new Date(Date.now() + days * 86400_000);
+  return d.toISOString();
+}

--- a/sample-apps/vitta/src/lib/policy.ts
+++ b/sample-apps/vitta/src/lib/policy.ts
@@ -1,0 +1,40 @@
+/**
+ * policy.ts — editable credit policy constants (PDF p.9). Mirrored by the
+ * policy://credit-policy/v1.7 Resource so the client can read the same rules.
+ */
+export const POLICY = {
+  version: 'v1.7',
+  base_rate_pct: 15.99, // representative rate for FOIR headroom + demo EMI
+  foir_cap: 0.55, // FOIR ≤ 55%
+  min_bureau_score: 680,
+  max_dpd_12m: 30, // days past due
+  max_inquiries_6m: 6,
+  min_amount: 25000,
+  max_amount_floor: 50000, // below this serviceable amount → decline (no viable loan)
+  eligible_employment: ['SALARIED', 'SELF_EMPLOYED'] as const,
+  processing_fee_pct: 1.5,
+  tenure: { min: 12, max: 48 },
+  score_bands: { approve_min: 60, conditional_min: 40 },
+  rate_bands: {
+    APPROVE: { min: 13.5, max: 15.0 },
+    CONDITIONAL: { min: 15.99, max: 18.0 },
+  },
+} as const;
+
+export const REASON_TEXT: Record<string, string> = {
+  SUBPRIME_SCORE: 'Your bureau score is below our current cut-off of 680.',
+  DPD_OVER_30_12M: 'A repayment was overdue by more than 30 days in the last 12 months.',
+  WRITEOFF_24M: 'A written-off account appears on your bureau in the last 24 months.',
+  EXCESS_INQUIRIES: 'There were more than 6 credit inquiries in the last 6 months.',
+  EMPLOYMENT_INELIGIBLE: 'This product is available to salaried and self-employed applicants only.',
+  CITY_NOT_SERVED: 'We do not currently lend in this city.',
+  FOIR_NO_HEADROOM: 'Your existing EMIs already use most of your monthly income.',
+  FOIR_LIMIT: 'Existing EMIs raise your FOIR, so we reduced the eligible amount to keep repayments affordable.',
+  SCORE_BELOW_THRESHOLD: 'Your overall profile score is below the approval threshold.',
+  HIGH_EXISTING_EMI: 'Your existing monthly EMIs are high relative to your income.',
+  ELEVATED_INQUIRIES: 'Several recent credit inquiries were considered.',
+  CLEAN_BUREAU: 'Your bureau record is clean with no adverse markers.',
+  LOW_UTILISATION: 'Your existing credit utilisation is low.',
+  MANUAL_REVIEW: 'Your application needs a brief review by our team before final approval.',
+  STABLE_INCOME: 'Your income pattern is stable and consistent.',
+};

--- a/sample-apps/vitta/src/lib/rates.ts
+++ b/sample-apps/vitta/src/lib/rates.ts
@@ -1,0 +1,66 @@
+/**
+ * rates.ts — LIVE external data source (Completeness: "≥1 external data source").
+ * Fetches live INR reference FX rates from the Frankfurter API (ECB data,
+ * free, no key, no PII — safe under CLAUDE.md rule 3 which bans only
+ * bureau/AA/KYC-style PII APIs). Gracefully degrades to a cached snapshot so
+ * the demo NEVER breaks offline.
+ */
+
+export interface ReferenceRates {
+  source: 'live' | 'cached_fallback';
+  as_of: string;
+  base: string;
+  inr_per: Record<string, number>;
+  policy_context: {
+    repo_rate_pct: number; // RBI repo rate (static reference — printed on rate card)
+    mclr_proxy_pct: number;
+    note: string;
+  };
+}
+
+/** Static snapshot used when the live call fails (airplane-mode demo safety). */
+const FALLBACK: ReferenceRates = {
+  source: 'cached_fallback',
+  as_of: '2026-07-15',
+  base: 'INR',
+  inr_per: { USD: 87.2, EUR: 95.1, GBP: 110.4 },
+  policy_context: {
+    repo_rate_pct: 5.5,
+    mclr_proxy_pct: 8.9,
+    note: 'Cached snapshot — live feed unavailable. Lending rates in catalog://products/personal-loan are set off these references.',
+  },
+};
+
+export async function fetchReferenceRates(timeoutMs = 4000): Promise<ReferenceRates> {
+  try {
+    const ctl = new AbortController();
+    const t = setTimeout(() => ctl.abort(), timeoutMs);
+    const res = await fetch('https://api.frankfurter.app/latest?from=USD&to=INR,EUR,GBP', { signal: ctl.signal });
+    clearTimeout(t);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data: any = await res.json();
+    const usdInr = data?.rates?.INR;
+    if (typeof usdInr !== 'number') throw new Error('unexpected shape');
+    return {
+      source: 'live',
+      as_of: data.date ?? new Date().toISOString().slice(0, 10),
+      base: 'INR',
+      inr_per: {
+        USD: round2(usdInr),
+        EUR: data.rates.EUR ? round2(usdInr / data.rates.EUR) : FALLBACK.inr_per.EUR,
+        GBP: data.rates.GBP ? round2(usdInr / data.rates.GBP) : FALLBACK.inr_per.GBP,
+      },
+      policy_context: {
+        repo_rate_pct: 5.5,
+        mclr_proxy_pct: 8.9,
+        note: 'Live ECB reference rates via Frankfurter API. Lending ROI bands in catalog://products/personal-loan are set off these macro references.',
+      },
+    };
+  } catch {
+    return { ...FALLBACK };
+  }
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}

--- a/sample-apps/vitta/src/lib/redact.ts
+++ b/sample-apps/vitta/src/lib/redact.ts
@@ -1,0 +1,78 @@
+/**
+ * redact.ts — PII redaction (CLAUDE.md rule 9). Applied to EVERY audit payload
+ * before storage. Never let PAN / mobile / name land in the audit log in clear.
+ */
+
+/** ABCDE1234F → ABCXXXXXXF (keep first 3 + last 1). */
+export function maskPan(pan: string): string {
+  if (typeof pan !== 'string' || pan.length < 5) return 'XXXXXXXXXX';
+  return pan.slice(0, 3) + 'X'.repeat(pan.length - 4) + pan.slice(-1);
+}
+
+/** 9876543222 → 98XXXXXX22 (keep first 2 + last 2). */
+export function maskMobile(m: string): string {
+  const digits = String(m).replace(/\D/g, '');
+  if (digits.length < 4) return 'XXXX';
+  return digits.slice(0, 2) + 'X'.repeat(digits.length - 4) + digits.slice(-2);
+}
+
+/** Priya Sharma → P**** S***** (keep initials). */
+export function maskName(name: string): string {
+  if (typeof name !== 'string' || !name.trim()) return '****';
+  return name
+    .trim()
+    .split(/\s+/)
+    .map((w) => (w.length <= 1 ? w : w[0] + '*'.repeat(w.length - 1)))
+    .join(' ');
+}
+
+const SENSITIVE_KEYS = new Set([
+  'pan',
+  'mobile',
+  'phone',
+  'name',
+  'full_name',
+  'customer_name',
+  'dob',
+  'aadhaar',
+  'account_number',
+  'email',
+]);
+
+const PAN_RE = /\b[A-Z]{5}[0-9]{4}[A-Z]\b/g;
+const MOBILE_RE = /\b[6-9]\d{9}\b/g;
+
+function redactStringContent(s: string): string {
+  return s.replace(PAN_RE, (m) => maskPan(m)).replace(MOBILE_RE, (m) => maskMobile(m));
+}
+
+/** Deep-redact an arbitrary payload: mask by key name AND scrub PAN/mobile patterns in strings. */
+export function redactAuditPayload(payload: unknown): Record<string, unknown> {
+  return redactValue(payload) as Record<string, unknown>;
+}
+
+function redactValue(value: unknown, key?: string): unknown {
+  if (value == null) return value;
+
+  if (typeof value === 'string') {
+    if (key && SENSITIVE_KEYS.has(key.toLowerCase())) {
+      const k = key.toLowerCase();
+      if (k === 'pan') return maskPan(value);
+      if (k === 'mobile' || k === 'phone') return maskMobile(value);
+      if (k.includes('name')) return maskName(value);
+      if (k === 'dob') return '****-**-**';
+      return 'REDACTED';
+    }
+    return redactStringContent(value);
+  }
+
+  if (Array.isArray(value)) return value.map((v) => redactValue(v));
+
+  if (typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = redactValue(v, k);
+    return out;
+  }
+
+  return value;
+}

--- a/sample-apps/vitta/src/lib/sanction.ts
+++ b/sample-apps/vitta/src/lib/sanction.ts
@@ -1,0 +1,122 @@
+/**
+ * sanction.ts — build a signed sanction letter (HTML) + SHA256 integrity hash.
+ * HTML→PDF is a Phase-7/stretch upgrade; the HTML letter + hash satisfies the
+ * demo's "downloadable letter with hash footer" without a heavy PDF dependency
+ * (keeps THIRD_PARTY.md minimal — CLAUDE.md rule 7).
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { CaseRecord, Offer, SanctionResult } from './types.js';
+
+const NBFC = {
+  name: 'Vitta Financial Services Pvt. Ltd. (NBFC)',
+  rbi_reg: 'N-14.99999 (mock)',
+  cin: 'U65999KL2026PTC000000 (mock)',
+};
+
+export function createSanction(caseRec: CaseRecord, offer: Offer): SanctionResult {
+  const firstEmi = new Date(Date.now() + 30 * 86400_000);
+  const first_emi_date = firstEmi.toISOString().slice(0, 10);
+  const amort = amortization(offer.amount, offer.roi_annual_pct, offer.emi, 3);
+
+  const letter_fields: Record<string, unknown> = {
+    nbfc: NBFC,
+    lead_id: caseRec.lead_id,
+    borrower_name: caseRec.name ?? 'Applicant',
+    sanction_amount: offer.amount,
+    roi_annual_pct: offer.roi_annual_pct,
+    apr_pct: offer.apr_pct,
+    emi: offer.emi,
+    tenure_months: offer.tenure_months,
+    processing_fee_pct: offer.processing_fee_pct,
+    total_cost: offer.total_cost,
+    first_emi_date,
+    valid_till: offer.valid_till,
+    cooling_off_days: 3,
+    amortization_preview: amort,
+  };
+
+  const html = renderHtml(letter_fields, amort);
+  const hash = createHash('sha256').update(canonical(letter_fields)).digest('hex');
+  const htmlWithFooter = html.replace('{{HASH}}', hash);
+
+  // The server mounts GET /letters/:leadId (src/index.ts), served from the
+  // in-memory store (letter_fields.html), so the URL is a real clickable link
+  // even on read-only cloud filesystems. Disk write is a best-effort bonus.
+  const base =
+    process.env.PUBLIC_BASE_URL ??
+    (process.env.NODE_ENV === 'production'
+      ? 'https://vitta-6a5a5835-the-beetles-amrita-university-amritapuri-campus.app.nitrocloud.ai'
+      : `http://localhost:${process.env.PORT ?? 3000}`);
+  const url = `${base}/letters/${caseRec.lead_id}`;
+  try {
+    const dir = join(process.cwd(), 'data', 'letters');
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${caseRec.lead_id}.html`), htmlWithFooter, 'utf8');
+  } catch {
+    /* read-only FS on cloud — the route serves from the store instead */
+  }
+
+  return { url, hash, valid_till: offer.valid_till, letter_fields: { ...letter_fields, html: htmlWithFooter } };
+}
+
+function amortization(principal: number, annualRatePct: number, emi: number, rows: number) {
+  const r = annualRatePct / 12 / 100;
+  let bal = principal;
+  const out: { month: number; opening: number; interest: number; principal: number; closing: number }[] = [];
+  for (let m = 1; m <= rows; m++) {
+    const interest = Math.round(bal * r);
+    const princ = Math.round(emi - interest);
+    const closing = Math.max(0, Math.round(bal - princ));
+    out.push({ month: m, opening: Math.round(bal), interest, principal: princ, closing });
+    bal = closing;
+  }
+  return out;
+}
+
+function canonical(fields: Record<string, unknown>): string {
+  // stable string over the load-bearing money fields (excludes volatile html)
+  const f = fields as any;
+  return [
+    f.lead_id,
+    f.sanction_amount,
+    f.roi_annual_pct,
+    f.apr_pct,
+    f.emi,
+    f.tenure_months,
+    f.total_cost,
+    f.first_emi_date,
+    f.valid_till,
+  ].join('|');
+}
+
+function renderHtml(f: Record<string, unknown>, amort: ReturnType<typeof amortization>): string {
+  const inr = (n: unknown) => `₹${Number(n).toLocaleString('en-IN')}`;
+  const rows = amort
+    .map(
+      (a) =>
+        `<tr><td>${a.month}</td><td>${inr(a.opening)}</td><td>${inr(a.interest)}</td><td>${inr(a.principal)}</td><td>${inr(a.closing)}</td></tr>`,
+    )
+    .join('');
+  return `<!doctype html><html><head><meta charset="utf-8"><title>Sanction Letter — ${f.lead_id}</title>
+<style>body{font-family:Georgia,serif;max-width:720px;margin:32px auto;color:#1a1a1a}
+h1{font-size:20px}.big{font-size:28px;font-weight:700}.muted{color:#666;font-size:12px}
+table{border-collapse:collapse;width:100%;margin:12px 0}td,th{border:1px solid #ddd;padding:6px 8px;font-size:13px;text-align:right}
+th{background:#f6f6f6}.hash{word-break:break-all;font-family:monospace;font-size:11px;color:#888}</style></head>
+<body>
+<h1>${(NBFC.name)}</h1>
+<p class="muted">RBI Reg: ${NBFC.rbi_reg} · CIN: ${NBFC.cin}</p>
+<hr/>
+<p>Dear <b>${f.borrower_name}</b>, we are pleased to sanction your personal loan.</p>
+<p class="big">${inr(f.sanction_amount)}</p>
+<p>ROI ${f.roi_annual_pct}% p.a. · APR ${f.apr_pct}% · EMI <b>${inr(f.emi)}</b> × ${f.tenure_months} months ·
+Processing fee ${f.processing_fee_pct}% · Total cost ${inr(f.total_cost)}</p>
+<p>First EMI date: <b>${f.first_emi_date}</b> · Offer valid till: ${String(f.valid_till).slice(0, 10)}</p>
+<h3>Amortization (first 3 months)</h3>
+<table><tr><th>Month</th><th>Opening</th><th>Interest</th><th>Principal</th><th>Closing</th></tr>${rows}</table>
+<p class="muted">Cooling-off: you may cancel within <b>${f.cooling_off_days} days</b> of disbursal without penalty (interest for the used period applies).</p>
+<p class="muted">Digitally signed by ${NBFC.name} via mock e-sign (eMudhra placeholder). This is a hackathon demo document; not a real financial instrument.</p>
+<p class="hash">SHA256: {{HASH}}</p>
+</body></html>`;
+}

--- a/sample-apps/vitta/src/lib/scorecard.ts
+++ b/sample-apps/vitta/src/lib/scorecard.ts
@@ -1,0 +1,137 @@
+/**
+ * scorecard.ts — rules-first, pre-baked scorecard, explainable reason codes
+ * (CLAUDE.md rule 8: NEVER trained ML). Pure, deterministic.
+ *
+ * Pipeline: hard negatives → FOIR cap → weighted score band → Decision.
+ */
+import { POLICY, REASON_TEXT } from './policy.js';
+import { principalForEmi } from './emi.js';
+import type { Affordability, BureauReport, Decision, Employment, Outcome } from './types.js';
+
+/** Weighted 0–100 creditworthiness score (independent of requested amount). */
+export function computeScore(bureau: BureauReport, affordability: Affordability): number {
+  // bureau score → 0..40 (620 floor, 800 ceiling)
+  const bureauComp = clamp((bureau.score - 620) / (800 - 620), 0, 1) * 40;
+  // existing-EMI burden → 0..20 (lower burden better; 0 burden ~20, 50% burden ~0)
+  const burden = affordability.existing_emi / affordability.net_income;
+  const burdenComp = clamp((0.5 - burden) / 0.5, 0, 1) * 20;
+  // DPD → 0..15
+  const dpdComp = bureau.dpd_max_12m === 0 ? 15 : bureau.dpd_max_12m <= 15 ? 10 : bureau.dpd_max_12m <= 30 ? 6 : 0;
+  // inquiries → 0..10
+  const inqComp = bureau.inquiries_6m <= 2 ? 10 : bureau.inquiries_6m <= 4 ? 7 : bureau.inquiries_6m <= 6 ? 4 : 0;
+  // income stability → 0..15
+  const stabComp = clamp(affordability.stability_index / 100, 0, 1) * 15;
+  return Math.round(bureauComp + burdenComp + dpdComp + inqComp + stabComp);
+}
+
+export function underwrite(args: {
+  requested_amount: number;
+  tenure_months: number;
+  employment: Employment | string;
+  segment_cap: number;
+  bureau: BureauReport;
+  affordability: Affordability;
+}): Decision {
+  const { bureau, affordability } = args;
+  const reason_codes: string[] = [];
+
+  // 1) hard negatives → DECLINE
+  const hard: string[] = [];
+  if (bureau.score < POLICY.min_bureau_score) hard.push('SUBPRIME_SCORE');
+  if (bureau.dpd_max_12m > POLICY.max_dpd_12m) hard.push('DPD_OVER_30_12M');
+  if (bureau.writeoff_24m) hard.push('WRITEOFF_24M');
+  if (bureau.inquiries_6m > POLICY.max_inquiries_6m) hard.push('EXCESS_INQUIRIES');
+  if (!POLICY.eligible_employment.includes(args.employment as any)) hard.push('EMPLOYMENT_INELIGIBLE');
+
+  if (hard.length) {
+    return decline(hard, bureau);
+  }
+
+  // 2) FOIR headroom → max serviceable principal
+  const maxProposedEmi = POLICY.foir_cap * affordability.net_income - affordability.existing_emi;
+  if (maxProposedEmi < 1000) {
+    return decline(['FOIR_NO_HEADROOM'], bureau);
+  }
+  const maxPrincipalByFoir = principalForEmi(maxProposedEmi, POLICY.base_rate_pct, args.tenure_months);
+  const maxServiceable = Math.min(maxPrincipalByFoir, args.segment_cap);
+  const approvedAmount = floorTo(Math.min(args.requested_amount, maxServiceable), 10000);
+
+  // 3) score band
+  const score = computeScore(bureau, affordability);
+  const foirPct = Math.round(affordability.foir * 100);
+
+  let outcome: Outcome;
+  const explanations: string[] = [];
+
+  if (score < POLICY.score_bands.conditional_min) {
+    return decline(['SCORE_BELOW_THRESHOLD', ...topBureauReasons(bureau)], bureau, score);
+  }
+
+  const fullAmount = approvedAmount >= floorTo(args.requested_amount, 10000);
+  const bandApprove = score >= POLICY.score_bands.approve_min;
+
+  if (bandApprove && fullAmount) {
+    outcome = 'APPROVE';
+    reason_codes.push('CLEAN_BUREAU', ...bureau.reason_codes.filter((r) => r === 'LOW_UTILISATION'));
+    explanations.push(`Approved for ₹${fmt(approvedAmount)} at a FOIR of ${foirPct}%.`);
+  } else {
+    outcome = 'CONDITIONAL';
+    if (!fullAmount) {
+      reason_codes.push('FOIR_LIMIT', 'HIGH_EXISTING_EMI');
+      explanations.push(
+        `Approved for ₹${fmt(approvedAmount)} instead of ₹${fmt(args.requested_amount)} because existing EMIs put your FOIR at ${foirPct}%.`,
+      );
+    }
+    if (!bandApprove) {
+      reason_codes.push('MANUAL_REVIEW', ...topBureauReasons(bureau));
+      explanations.push(REASON_TEXT.MANUAL_REVIEW);
+    }
+  }
+
+  const band = outcome === 'APPROVE' ? POLICY.rate_bands.APPROVE : POLICY.rate_bands.CONDITIONAL;
+  // dedupe reason codes and attach human text
+  const uniqReasons = [...new Set(reason_codes)];
+  for (const rc of uniqReasons) {
+    const t = REASON_TEXT[rc];
+    if (t && !explanations.includes(t)) explanations.push(t);
+  }
+
+  return {
+    outcome,
+    max_amount: approvedAmount,
+    rate_band: { min: band.min, max: band.max },
+    tenure_range: { min: POLICY.tenure.min, max: POLICY.tenure.max },
+    score,
+    reason_codes: uniqReasons,
+    explanations,
+  };
+}
+
+function decline(codes: string[], bureau: BureauReport, score?: number): Decision {
+  const uniq = [...new Set([...codes, ...bureau.reason_codes])];
+  const explanations = uniq.map((c) => REASON_TEXT[c]).filter(Boolean) as string[];
+  explanations.push('You can reapply once these factors improve. We can share a short improvement plan.');
+  return {
+    outcome: 'DECLINE',
+    max_amount: 0,
+    rate_band: { min: 0, max: 0 },
+    tenure_range: { min: POLICY.tenure.min, max: POLICY.tenure.max },
+    score: score ?? 0,
+    reason_codes: codes,
+    explanations,
+  };
+}
+
+function topBureauReasons(bureau: BureauReport): string[] {
+  return bureau.reason_codes.filter((r) => ['HIGH_EXISTING_EMI', 'ELEVATED_INQUIRIES', 'BORDERLINE_SCORE'].includes(r));
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, n));
+}
+function floorTo(n: number, step: number): number {
+  return Math.floor(n / step) * step;
+}
+function fmt(n: number): string {
+  return n.toLocaleString('en-IN');
+}

--- a/sample-apps/vitta/src/lib/seeds.ts
+++ b/sample-apps/vitta/src/lib/seeds.ts
@@ -1,0 +1,149 @@
+/**
+ * seeds.ts — deterministic mock resolvers (CLAUDE.md rules 3 & 5).
+ * Reads /mocks/*.json once and resolves bureau/bank/kyc/fraud/city by
+ * PAN last digit and mobile suffix. NO real APIs, NO real PII, ever.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { BureauReport, BankSummary, KycResult, FraudResult } from './types.js';
+import { createHash } from 'node:crypto';
+
+/** Resolve the /mocks dir robustly (works from project root AND from dist/). */
+function resolveMockDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(process.cwd(), 'mocks'),
+    join(here, '..', '..', 'mocks'), // dist/lib -> project root
+    join(here, '..', '..', '..', 'mocks'),
+    join(here, '..', 'mocks'),
+  ];
+  for (const c of candidates) if (existsSync(join(c, 'bureau_seed.json'))) return c;
+  return join(process.cwd(), 'mocks');
+}
+const MOCK_DIR = resolveMockDir();
+
+function load<T>(name: string): T {
+  return JSON.parse(readFileSync(join(MOCK_DIR, name), 'utf8')) as T;
+}
+
+let _cache: {
+  bureau: any;
+  bank: any;
+  kyc: any;
+  fraud: any;
+  city: any;
+} | null = null;
+
+function mocks() {
+  if (!_cache) {
+    _cache = {
+      bureau: load('bureau_seed.json'),
+      bank: load('bank_seed.json'),
+      kyc: load('kyc_seed.json'),
+      fraud: load('fraud_seed.json'),
+      city: load('city_tiers.json'),
+    };
+  }
+  return _cache;
+}
+
+/** Raw seed data (for the MCP Resources that expose reference data). */
+export function allSeeds() {
+  return mocks();
+}
+
+/** The last DIGIT in a PAN (PAN = 5 letters, 4 digits, 1 letter → last of the 4 digits). */
+export function panLastDigit(pan: string): string {
+  const digits = String(pan).match(/\d/g);
+  return digits && digits.length ? digits[digits.length - 1] : '0';
+}
+
+/** Last two digits of a mobile number as an integer (0–99). */
+export function mobileSuffix(mobile: string): number {
+  const digits = String(mobile).replace(/\D/g, '');
+  if (digits.length < 2) return 0;
+  return parseInt(digits.slice(-2), 10);
+}
+
+export function resolveBureau(pan: string): BureauReport {
+  const d = panLastDigit(pan);
+  const p = mocks().bureau.byLastDigit[d] ?? mocks().bureau.byLastDigit['7'];
+  // split active_emi across two illustrative tradelines
+  const tl = (mocks().bureau.tradelineTemplate as any[]).map((t, i) => ({
+    ...t,
+    emi: i === 0 ? Math.round(p.active_emi * 0.4) : Math.round(p.active_emi * 0.6),
+  }));
+  return {
+    score: p.score,
+    dpd_max_12m: p.dpd_max_12m,
+    dpd_max_24m: p.dpd_max_24m,
+    writeoff_24m: p.writeoff_24m,
+    inquiries_6m: p.inquiries_6m,
+    active_emi: p.active_emi,
+    tradelines: tl,
+    reason_codes: [...p.reason_codes],
+  };
+}
+
+export function resolveBank(mobile: string, months = 12): BankSummary {
+  const s = mobileSuffix(mobile);
+  const bands = mocks().bank.bands;
+  let band = bands.stable;
+  for (const key of Object.keys(bands)) {
+    const [lo, hi] = bands[key].match;
+    if (s >= lo && s <= hi) {
+      band = bands[key];
+      break;
+    }
+  }
+  return {
+    avg_salary_credit: band.avg_salary_credit,
+    income_variance_pct: band.income_variance_pct,
+    bounce_count: band.bounce_count,
+    cash_withdrawal_ratio: band.cash_withdrawal_ratio,
+    net_surplus: band.net_surplus,
+    employer_consistency: band.employer_consistency,
+    stability_index: band.stability_index,
+    // carried for affordability (net take-home used in FOIR)
+    ...( { net_income: band.net_income } as any ),
+  } as BankSummary & { net_income: number };
+}
+
+/** net take-home income for FOIR (mock: from the AA band). */
+export function resolveNetIncome(mobile: string): number {
+  const s = mobileSuffix(mobile);
+  const bands = mocks().bank.bands;
+  for (const key of Object.keys(bands)) {
+    const [lo, hi] = bands[key].match;
+    if (s >= lo && s <= hi) return bands[key].net_income;
+  }
+  return bands.stable.net_income;
+}
+
+export function resolveKyc(pan: string, name: string): KycResult {
+  const k = mocks().kyc;
+  const pattern = new RegExp(k.panPattern);
+  const status = pattern.test(String(pan).toUpperCase());
+  const base = status
+    ? k.byLastDigit[panLastDigit(pan)] ?? k.default
+    : { kyc_status: 'FAIL', risk_flags: ['PAN_FORMAT_INVALID'] };
+  const kyc_hash = createHash('sha256')
+    .update(`${String(pan).toUpperCase()}|${String(name).toUpperCase()}`)
+    .digest('hex')
+    .slice(0, 32);
+  return { kyc_status: base.kyc_status, kyc_hash, risk_flags: [...base.risk_flags] };
+}
+
+export function resolveFraud(mobile: string): FraudResult {
+  const f = mocks().fraud;
+  const s = mobileSuffix(mobile);
+  if (f.rules.block_suffixes.includes(s)) return { ...f.block };
+  if (s >= f.rules.review_from_suffix) return { ...f.review };
+  return { ...f.clear };
+}
+
+export function resolveCity(city: string): { served: boolean; tier?: number; cap?: number } {
+  const c = mocks().city.cities[String(city).toUpperCase().trim()];
+  return c ? { served: true, tier: c.tier, cap: c.cap } : { served: false };
+}

--- a/sample-apps/vitta/src/lib/simulate.ts
+++ b/sample-apps/vitta/src/lib/simulate.ts
@@ -1,0 +1,111 @@
+/**
+ * simulate.ts — the What-If Simulator (demo money-shot).
+ * Re-runs affordability + underwriting with overridden levers (income, tenure,
+ * existing EMI closed, amount) WITHOUT mutating the case. Proves the decisioning
+ * is deterministic + explainable: same inputs, one lever moved, watch the
+ * decision change with reasons.
+ */
+import { computeAffordability } from './affordability.js';
+import { underwrite } from './scorecard.js';
+import { resolveCity, resolveNetIncome } from './seeds.js';
+import { store } from './store.js';
+import type { Affordability, Decision } from './types.js';
+
+export interface ScenarioInput {
+  lead_id: string;
+  /** Override monthly net income (₹), e.g. "what if my salary were 70,000?" */
+  net_income?: number;
+  /** Override tenure in months, e.g. "what about 48 months?" */
+  tenure_months?: number;
+  /** Override requested amount (₹) */
+  requested_amount?: number;
+  /** Simulate closing existing EMIs: subtract this ₹/month from current obligations */
+  close_existing_emi?: number;
+}
+
+export interface ScenarioResult {
+  baseline: { affordability: Affordability; decision: Decision };
+  scenario: { affordability: Affordability; decision: Decision; levers: Record<string, number> };
+  delta: {
+    outcome_changed: boolean;
+    outcome: string;
+    max_amount_change: number;
+    foir_change_pct: number;
+    summary: string;
+  };
+}
+
+export function simulateScenario(input: ScenarioInput): ScenarioResult {
+  const rec = store.getCase(input.lead_id);
+  if (!rec || !rec.bureau || !rec.bank || !rec.affordability || !rec.decision) {
+    throw new Error('SIMULATE_PRECONDITION: run the path through underwrite first');
+  }
+
+  const baseAff = rec.affordability;
+  const baseDec = rec.decision;
+  const cap = resolveCity(rec.city ?? '').cap ?? 700000;
+
+  // build the scenario inputs (levers override baseline)
+  const levers: Record<string, number> = {};
+  const net_income = input.net_income ?? resolveNetIncome(rec.mobile ?? '9000000000');
+  if (input.net_income != null) levers.net_income = input.net_income;
+
+  const tenure = input.tenure_months ?? rec.tenure_months ?? 36;
+  if (input.tenure_months != null) levers.tenure_months = input.tenure_months;
+
+  const amount = input.requested_amount ?? rec.amount ?? 0;
+  if (input.requested_amount != null) levers.requested_amount = input.requested_amount;
+
+  // closing existing EMIs → reduce bureau active_emi for the scenario
+  const bureau = { ...rec.bureau };
+  if (input.close_existing_emi != null && input.close_existing_emi > 0) {
+    bureau.active_emi = Math.max(0, bureau.active_emi - input.close_existing_emi);
+    levers.close_existing_emi = input.close_existing_emi;
+  }
+
+  const scenAff = computeAffordability({
+    requested_amount: amount,
+    tenure_months: tenure,
+    bureau,
+    bank: rec.bank,
+    net_income,
+  });
+  const scenDec = underwrite({
+    requested_amount: amount,
+    tenure_months: tenure,
+    employment: rec.employment ?? 'SALARIED',
+    segment_cap: cap,
+    bureau,
+    affordability: scenAff,
+  });
+
+  const foirDelta = Math.round((scenAff.foir - baseAff.foir) * 1000) / 10;
+  const amtDelta = scenDec.max_amount - baseDec.max_amount;
+  const outcomeChanged = scenDec.outcome !== baseDec.outcome;
+
+  const bits: string[] = [];
+  if (outcomeChanged) bits.push(`Outcome moves ${baseDec.outcome} → ${scenDec.outcome}.`);
+  if (amtDelta !== 0) bits.push(`Eligible amount ${amtDelta > 0 ? 'rises' : 'falls'} by ₹${Math.abs(amtDelta).toLocaleString('en-IN')} to ₹${scenDec.max_amount.toLocaleString('en-IN')}.`);
+  if (foirDelta !== 0) bits.push(`FOIR moves ${Math.round(baseAff.foir * 100)}% → ${Math.round(scenAff.foir * 100)}%.`);
+  if (!bits.length) bits.push('No change — this lever does not move the decision.');
+
+  // audit the simulation (redacted, non-mutating)
+  store.audit(rec.session_id, 'simulate_scenario', 'SCENARIO_SIMULATED', {
+    lead_id: input.lead_id,
+    levers,
+    baseline_outcome: baseDec.outcome,
+    scenario_outcome: scenDec.outcome,
+  });
+
+  return {
+    baseline: { affordability: baseAff, decision: baseDec },
+    scenario: { affordability: scenAff, decision: scenDec, levers },
+    delta: {
+      outcome_changed: outcomeChanged,
+      outcome: scenDec.outcome,
+      max_amount_change: amtDelta,
+      foir_change_pct: foirDelta,
+      summary: bits.join(' '),
+    },
+  };
+}

--- a/sample-apps/vitta/src/lib/store.ts
+++ b/sample-apps/vitta/src/lib/store.ts
@@ -1,0 +1,147 @@
+/**
+ * store.ts — tiny JSON-file-backed singleton (no DB, per CLAUDE.md rule 7).
+ * Namespaces: cases, consents (proof), audit (append-only + seq), revocations.
+ * Persists to ./data/*.json (gitignored). In-memory + synchronous flush.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { redactAuditPayload } from './redact.js';
+import { VERSION_BLOCK } from './types.js';
+import type { CaseRecord, AuditEnvelope } from './types.js';
+
+const DATA_DIR = join(process.cwd(), 'data');
+
+interface DiskShape {
+  cases: Record<string, CaseRecord>;
+  consents: Record<string, unknown>;
+  audit: AuditEnvelope[];
+  revocations: string[]; // jti list
+  seq: number;
+}
+
+function emptyShape(): DiskShape {
+  return { cases: {}, consents: {}, audit: [], revocations: [], seq: 0 };
+}
+
+class Store {
+  private data: DiskShape = emptyShape();
+  private loaded = false;
+  private file = join(DATA_DIR, 'store.json');
+
+  private ensureLoaded(): void {
+    if (this.loaded) return;
+    try {
+      if (existsSync(this.file)) {
+        this.data = { ...emptyShape(), ...JSON.parse(readFileSync(this.file, 'utf8')) };
+      }
+    } catch {
+      this.data = emptyShape();
+    }
+    this.loaded = true;
+  }
+
+  private flush(): void {
+    try {
+      if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
+      writeFileSync(this.file, JSON.stringify(this.data, null, 2), 'utf8');
+    } catch {
+      /* best-effort persistence; in-memory remains authoritative for the session */
+    }
+  }
+
+  // ---- cases ----
+  getCase(leadId: string): CaseRecord | undefined {
+    this.ensureLoaded();
+    return this.data.cases[leadId];
+  }
+  putCase(rec: CaseRecord): CaseRecord {
+    this.ensureLoaded();
+    this.data.cases[rec.lead_id] = rec;
+    this.flush();
+    return rec;
+  }
+  patchCase(leadId: string, patch: Partial<CaseRecord>): CaseRecord | undefined {
+    this.ensureLoaded();
+    const cur = this.data.cases[leadId];
+    if (!cur) return undefined;
+    const next = { ...cur, ...patch };
+    this.data.cases[leadId] = next;
+    this.flush();
+    return next;
+  }
+
+  // ---- consent proof + revocation ----
+  putConsentProof(jti: string, proof: unknown): void {
+    this.ensureLoaded();
+    this.data.consents[jti] = proof;
+    this.flush();
+  }
+  revoke(jti: string): void {
+    this.ensureLoaded();
+    if (!this.data.revocations.includes(jti)) this.data.revocations.push(jti);
+    this.flush();
+  }
+  isRevoked(jti: string): boolean {
+    this.ensureLoaded();
+    return this.data.revocations.includes(jti);
+  }
+
+  // ---- audit (append-only, PII redacted) ----
+  audit(
+    session_id: string,
+    actor: string,
+    event: string,
+    payload: Record<string, unknown>,
+  ): { ack: true; seq: number } {
+    this.ensureLoaded();
+    const seq = ++this.data.seq;
+    const envelope: AuditEnvelope = {
+      session_id,
+      seq,
+      actor,
+      event,
+      payload: redactAuditPayload(payload),
+      version: { ...VERSION_BLOCK },
+      ts: new Date().toISOString(),
+    };
+    this.data.audit.push(envelope);
+    this.flush();
+    return { ack: true, seq };
+  }
+
+  trail(session_id: string, view: 'FULL' | 'SUMMARY' | 'COMPLIANCE_VIEW' = 'FULL'): {
+    events: Partial<AuditEnvelope>[];
+    count: number;
+  } {
+    this.ensureLoaded();
+    const events = this.data.audit.filter((e) => e.session_id === session_id);
+    if (view === 'SUMMARY') {
+      return { events: events.map((e) => ({ seq: e.seq, actor: e.actor, event: e.event, ts: e.ts })), count: events.length };
+    }
+    if (view === 'COMPLIANCE_VIEW') {
+      return {
+        events: events.map((e) => ({ seq: e.seq, actor: e.actor, event: e.event, version: e.version, ts: e.ts })),
+        count: events.length,
+      };
+    }
+    return { events, count: events.length };
+  }
+
+  /** Test/demo helper: wipe a session's state. */
+  resetSession(session_id: string): void {
+    this.ensureLoaded();
+    this.data.audit = this.data.audit.filter((e) => e.session_id !== session_id);
+    for (const [id, c] of Object.entries(this.data.cases)) {
+      if (c.session_id === session_id) delete this.data.cases[id];
+    }
+    this.flush();
+  }
+
+  /** Test helper: fully in-memory reset (does not touch disk of other sessions). */
+  _resetAll(): void {
+    this.data = emptyShape();
+    this.loaded = true;
+  }
+}
+
+export const store = new Store();

--- a/sample-apps/vitta/src/lib/types.ts
+++ b/sample-apps/vitta/src/lib/types.ts
@@ -1,0 +1,147 @@
+/** Shared domain types for Vitta. Pure — no NitroStack imports. */
+
+export type ConsentScope = 'CREDIT_BUREAU' | 'BANK_STATEMENTS' | 'KYC';
+
+export type Employment = 'SALARIED' | 'SELF_EMPLOYED';
+
+export type Outcome = 'APPROVE' | 'CONDITIONAL' | 'DECLINE';
+
+export interface ConsentPayload {
+  jti: string;
+  lead_id: string;
+  scopes: ConsentScope[];
+  iat: number; // epoch seconds
+  exp: number; // epoch seconds
+  version: string; // consent text version
+}
+
+export interface CaseRecord {
+  lead_id: string;
+  session_id: string;
+  created_at: string;
+  purpose?: string;
+  intent_flag?: 'FAST_TRACK' | 'STANDARD';
+  amount?: number;
+  tenure_months?: number;
+  employment?: Employment;
+  city?: string;
+  income_band?: string;
+  pan?: string;
+  mobile?: string;
+  name?: string;
+  prelim_eligibility?: string;
+  kyc?: KycResult;
+  fraud?: FraudResult;
+  bureau?: BureauReport;
+  bank?: BankSummary;
+  affordability?: Affordability;
+  decision?: Decision;
+  offers?: Offer[];
+  recommended_offer_id?: string;
+  sanction?: SanctionResult;
+  status?: string;
+}
+
+export interface KycResult {
+  kyc_status: 'PASS' | 'RETRY' | 'FAIL';
+  kyc_hash: string;
+  risk_flags: string[];
+}
+
+export interface FraudResult {
+  verdict: 'CLEAR' | 'REVIEW' | 'BLOCK';
+  signals: string[];
+  score: number;
+}
+
+export interface BureauReport {
+  score: number;
+  dpd_max_12m: number;
+  dpd_max_24m: number;
+  writeoff_24m: boolean;
+  inquiries_6m: number;
+  active_emi: number;
+  tradelines: { type: string; sanctioned: number; emi: number; status: string }[];
+  reason_codes: string[];
+}
+
+export interface BankSummary {
+  avg_salary_credit: number;
+  income_variance_pct: number;
+  bounce_count: number;
+  cash_withdrawal_ratio: number;
+  net_surplus: number;
+  employer_consistency: number; // 0..1
+  stability_index: number; // 0..100
+}
+
+export interface Affordability {
+  net_income: number;
+  existing_emi: number;
+  proposed_emi: number;
+  foir: number; // 0..1
+  dti: number; // 0..1
+  stability_index: number;
+}
+
+export interface Decision {
+  outcome: Outcome;
+  max_amount: number;
+  rate_band: { min: number; max: number };
+  tenure_range: { min: number; max: number };
+  score: number;
+  reason_codes: string[];
+  explanations: string[];
+}
+
+export interface Offer {
+  offer_id: string;
+  amount: number;
+  tenure_months: number;
+  roi_annual_pct: number;
+  emi: number;
+  processing_fee_pct: number;
+  apr_pct: number;
+  total_cost: number;
+  valid_till: string;
+  recommended: boolean;
+  why_recommended?: string;
+}
+
+export interface SanctionResult {
+  url: string;
+  hash: string;
+  valid_till: string;
+  letter_fields: Record<string, unknown>;
+}
+
+export interface AuditEnvelope {
+  session_id: string;
+  seq: number;
+  actor: string;
+  event: string;
+  payload: Record<string, unknown>;
+  version: { policy: string; score: string; prompt: string };
+  ts: string;
+}
+
+/** Consent-gate refusal payload (the signature feature). */
+export interface ConsentRefusal {
+  error: 'CONSENT_REQUIRED';
+  code: ConsentFailureCode;
+  hint: string;
+}
+
+export type ConsentFailureCode =
+  | 'CONSENT_REQUIRED'
+  | 'CONSENT_INVALID'
+  | 'CONSENT_EXPIRED'
+  | 'SCOPE_NOT_GRANTED'
+  | 'CONSENT_REVOKED'
+  | 'CONSENT_LEAD_MISMATCH';
+
+export const VERSION_BLOCK = {
+  policy: 'v1.7',
+  score: 'scorecard-2026-07',
+  prompt: 'uw_explainer_v1',
+} as const;

--- a/sample-apps/vitta/src/prompts/vitta.prompts.ts
+++ b/sample-apps/vitta/src/prompts/vitta.prompts.ts
@@ -1,0 +1,163 @@
+/**
+ * vitta.prompts.ts — the 5 MCP Prompts (reusable templates that standardise
+ * tone, disclosures and explanations across every client). Returns the scaffold's
+ * bare [{role, content}] shape (see NITROSTACK_NOTES.md).
+ */
+import { PromptDecorator as Prompt, ControllerDecorator as Controller, ExecutionContext } from '@nitrostack/core';
+
+type Msg = { role: 'user' | 'assistant'; content: string };
+
+@Controller()
+export class VittaPrompts {
+  @Prompt({
+    name: 'sales-playbook',
+    description:
+      'System guidance for the loan agent: tone, mandatory APR/late-fee disclosure, cooling-off language, non-coercive persuasion, and human-in-the-loop pauses on CONDITIONAL/REVIEW.',
+    arguments: [
+      { name: 'intent', description: 'Applicant intent, e.g. "medical emergency" (drives FAST_TRACK).', required: false },
+      { name: 'language', description: 'Preferred language, e.g. "English", "Hindi".', required: false },
+    ],
+  })
+  async salesPlaybook(args: any, _ctx: ExecutionContext): Promise<Msg[]> {
+    const intent = args?.intent ? ` The applicant's stated intent is "${args.intent}".` : '';
+    const lang = args?.language ? ` Respond in ${args.language}.` : '';
+    return [
+      { role: 'user', content: `Guide me as an NBFC loan officer for this application.${intent}` },
+      {
+        role: 'assistant',
+        content:
+          `CRITICAL: reply only in short plain-text sentences — never output JSON, a "spec", "op":"add", ` +
+          `"/elements", or any self-built UI/tables/cards. The tools render their own rich cards; give one ` +
+          `short sentence of narration per step.\n` +
+          `FAST PATH (do this): once consent is granted, call advance_application ONCE ` +
+          `(pass lead_id, consent_token, pan, name, mobile) — it runs KYC, fraud, bureau, bank, affordability and ` +
+          `underwrite in a single step and returns the decision. Then call generate_offers, then create_sanction_letter. ` +
+          `This avoids stalling. Pause ONLY for: (a) the explicit consent yes/no, (b) a CONDITIONAL or REVIEW ` +
+          `human-in-the-loop confirmation, (c) the applicant choosing an offer.\n` +
+          `NEVER STOP SILENTLY: do not end your turn in the middle of the chain without a reason. Every time you stop ` +
+          `you MUST end your message with a clear one-line question stating exactly what you need from me (e.g. ` +
+          `"Do you consent?", "Shall I proceed past the manual review?", "Which offer would you like?"). Only ask for ` +
+          `information you don't already have — never re-ask for details I already gave, and never re-run qualify_lead ` +
+          `once a lead_id exists. If you need nothing, continue to the next tool automatically.\n` +
+          `You are Vitta, a calm, precise, warm loan officer. Never pressure; never say "we regret to inform you".${lang}\n` +
+          `Order of operations: qualify_lead → record_consent → verify_kyc → screen_fraud → pull_bureau → ` +
+          `fetch_bank_statements → compute_affordability → underwrite → generate_offers → create_sanction_letter.\n` +
+          `CONSENT: NEVER call pull_bureau or fetch_bank_statements before a valid consent_token exists. Explain what you ` +
+          `will access, then call record_consent with accepted=true ONLY AFTER the applicant explicitly says yes in this ` +
+          `conversation — never assume or pre-fill their consent.\n` +
+          `PRESENTATION: each tool's result is shown to the applicant in a rich interactive card attached to that tool ` +
+          `(decision gauge, offer cards, sanction letter, what-if compare). Do NOT re-print those results as your own ` +
+          `tables, JSON, ASCII or custom UI — add at most one short plain-text sentence of narration per step and let the ` +
+          `card do the showing.\n` +
+          `Always disclose APR and late-fee before an offer is accepted. Mention the 3-day cooling-off.\n` +
+          `If the intent is medical/emergency, acknowledge the stress briefly and prioritise the lowest-EMI offer.\n` +
+          `HUMAN-IN-THE-LOOP: if underwrite returns CONDITIONAL or screen_fraud returns REVIEW, PAUSE. Tell the applicant ` +
+          `"a brief review by our team" is needed and DO NOT proceed to generate_offers until a human confirms.\n` +
+          `Never promise approval ("looks strong", not "you'll be approved"). Never collect data you don't need.`,
+      },
+    ];
+  }
+
+  @Prompt({
+    name: 'underwriting-explainer',
+    description: 'Turn reason_codes + features into a short, borrower-friendly explanation of the decision.',
+    arguments: [
+      { name: 'reason_codes', description: 'Comma-separated reason codes from underwrite.', required: true },
+      { name: 'features', description: 'Key features, e.g. "FOIR=57%, score=705".', required: false },
+    ],
+  })
+  async underwritingExplainer(args: any, _ctx: ExecutionContext): Promise<Msg[]> {
+    return [
+      { role: 'user', content: `Explain this decision to the borrower. reason_codes: ${args?.reason_codes}. features: ${args?.features ?? 'n/a'}.` },
+      {
+        role: 'assistant',
+        content:
+          'Write 2–4 warm, plain-English sentences. Lead with the outcome, then the single biggest driver in concrete terms ' +
+          '(e.g. "existing EMIs put your FOIR at 57%, so we could offer ₹2.5L rather than ₹3L"). Offer one concrete next step. ' +
+          'No jargon, no blame, no false hope.',
+      },
+    ];
+  }
+
+  @Prompt({
+    name: 'objection-handling',
+    description: 'Templated, compliant, non-pushy replies to common objections (rate too high / need more / shorter tenure).',
+    arguments: [{ name: 'objection', description: 'The applicant objection text.', required: true }],
+  })
+  async objectionHandling(args: any, _ctx: ExecutionContext): Promise<Msg[]> {
+    return [
+      { role: 'user', content: `The applicant said: "${args?.objection}". How should I respond?` },
+      {
+        role: 'assistant',
+        content:
+          'Acknowledge the concern honestly. If "rate too high": explain what drives the rate (risk band) and offer a concrete ' +
+          'lever (longer tenure lowers EMI; closing an existing EMI improves FOIR) — never invent a discount. If "need more": ' +
+          'explain the FOIR cap protects them and show what would unlock a higher amount. If "shorter tenure": show the EMI/total-cost ' +
+          'trade-off using generate_offers. Offer a summary they can share with family. Never pressure; if they want to think, respect it.',
+      },
+    ];
+  }
+
+  @Prompt({
+    name: 'adverse-action-notice',
+    description:
+      'Compliant, respectful decline explanation (RBI/DPDP-aligned adverse action). Localised: language="hindi" or "malayalam" for the vernacular framing.',
+    arguments: [
+      { name: 'reason_codes', description: 'Comma-separated reason codes from a DECLINE.', required: true },
+      { name: 'language', description: 'Preferred language: english (default), hindi, malayalam.', required: false },
+    ],
+  })
+  async adverseActionNotice(args: any, _ctx: ExecutionContext): Promise<Msg[]> {
+    const lang = String(args?.language ?? 'english').toLowerCase();
+    const guides: Record<string, string> = {
+      english:
+        'Say clearly and kindly that we cannot approve right now, then give the specific, factual reasons (mapped from the codes). ' +
+        'Provide a short, achievable improvement path and a realistic reapply window. Include the applicant\'s right to the reasons ' +
+        'and to dispute bureau data. Tone: respectful, never "we regret to inform you". End with a genuine door left open.',
+      hindi:
+        'उत्तर हिंदी में लिखें। साफ़ और सम्मान से बताएं कि अभी हम यह लोन स्वीकृत नहीं कर सकते, फिर कोड से जुड़े ठोस, तथ्यात्मक कारण दें। ' +
+        'एक छोटा, व्यावहारिक सुधार-रास्ता और दोबारा आवेदन की यथार्थ समय-सीमा बताएं। आवेदक का यह अधिकार भी बताएं कि वे कारण जान सकते हैं ' +
+        'और ब्यूरो डेटा पर आपत्ति कर सकते हैं। लहजा: सम्मानजनक — "हमें खेद है" जैसी घिसी-पिटी भाषा नहीं। अंत सकारात्मक रखें: दरवाज़ा खुला है।',
+      malayalam:
+        'മറുപടി മലയാളത്തിൽ എഴുതുക. ഇപ്പോൾ വായ്പ അനുവദിക്കാനാവില്ലെന്ന് വ്യക്തമായും മാന്യമായും പറയുക; തുടർന്ന് കോഡുകളിൽ നിന്നുള്ള കൃത്യമായ, വസ്തുതാപരമായ കാരണങ്ങൾ നൽകുക. ' +
+        'ചെറുതും പ്രായോഗികവുമായ മെച്ചപ്പെടുത്തൽ പാതയും വീണ്ടും അപേക്ഷിക്കാനുള്ള യഥാർത്ഥ സമയപരിധിയും നൽകുക. കാരണങ്ങൾ അറിയാനും ബ്യൂറോ ഡാറ്റയിൽ തർക്കം ഉന്നയിക്കാനുമുള്ള ' +
+        'അപേക്ഷകന്റെ അവകാശം സൂചിപ്പിക്കുക. ശൈലി: മാന്യം — അവസാനം പ്രതീക്ഷയോടെ: വാതിൽ തുറന്നിരിക്കുന്നു.',
+    };
+    return [
+      { role: 'user', content: `Draft a decline notice for reason_codes: ${args?.reason_codes} (${lang}).` },
+      { role: 'assistant', content: guides[lang] ?? guides.english },
+    ];
+  }
+
+  @Prompt({
+    name: 'kyc-consent-script',
+    description:
+      'Standardised consent + data-use explanation to read before record_consent. Localised: language="hindi" or "malayalam" returns the vernacular script (India-first design).',
+    arguments: [{ name: 'language', description: 'Preferred language: english (default), hindi, malayalam.', required: false }],
+  })
+  async kycConsentScript(args: any, _ctx: ExecutionContext): Promise<Msg[]> {
+    const lang = String(args?.language ?? 'english').toLowerCase();
+    const scripts: Record<string, string> = {
+      english:
+        'Before I check anything, I need your permission. To assess this loan I\'ll access: your credit bureau report, ' +
+        '12 months of bank statements (via Account Aggregator), and your PAN/CKYC. I will NOT access your Aadhaar number, ' +
+        'social media, location, or contacts. This consent is scoped, expires in 15 minutes, and you can withdraw it anytime. ' +
+        'Do you agree? (Yes records versioned consent and unlocks the checks; No means I cannot pull this data.)',
+      hindi:
+        'कुछ भी जाँचने से पहले मुझे आपकी अनुमति चाहिए। इस लोन के आकलन के लिए मैं देखूँगा: आपकी क्रेडिट ब्यूरो रिपोर्ट, ' +
+        '12 महीने के बैंक स्टेटमेंट (अकाउंट एग्रीगेटर के ज़रिए), और आपका PAN/CKYC। मैं आपका आधार नंबर, सोशल मीडिया, ' +
+        'लोकेशन या कॉन्टैक्ट्स नहीं देखूँगा। यह सहमति सीमित दायरे की है, 15 मिनट में समाप्त हो जाती है, और आप इसे कभी भी वापस ले सकते हैं। ' +
+        'क्या आप सहमत हैं? (हाँ — सहमति दर्ज होगी और जाँच शुरू होगी; नहीं — मैं यह डेटा नहीं देख पाऊँगा।)',
+      malayalam:
+        'എന്തെങ്കിലും പരിശോധിക്കും മുൻപ് എനിക്ക് നിങ്ങളുടെ അനുമതി വേണം. ഈ വായ്പ വിലയിരുത്താൻ ഞാൻ നോക്കുന്നത്: നിങ്ങളുടെ ക്രെഡിറ്റ് ബ്യൂറോ റിപ്പോർട്ട്, ' +
+        '12 മാസത്തെ ബാങ്ക് സ്റ്റേറ്റ്മെന്റുകൾ (അക്കൗണ്ട് അഗ്രിഗേറ്റർ വഴി), നിങ്ങളുടെ PAN/CKYC എന്നിവയാണ്. നിങ്ങളുടെ ആധാർ നമ്പർ, സോഷ്യൽ മീഡിയ, ' +
+        'ലൊക്കേഷൻ, കോൺടാക്റ്റുകൾ എന്നിവ ഞാൻ നോക്കില്ല. ഈ സമ്മതം പരിമിത പരിധിയിലുള്ളതാണ്, 15 മിനിറ്റിൽ കാലഹരണപ്പെടും, എപ്പോൾ വേണമെങ്കിലും പിൻവലിക്കാം. ' +
+        'നിങ്ങൾ സമ്മതിക്കുന്നുണ്ടോ? (അതെ — സമ്മതം രേഖപ്പെടുത്തി പരിശോധനകൾ തുടങ്ങും; ഇല്ല — എനിക്ക് ഈ ഡാറ്റ എടുക്കാനാവില്ല.)',
+    };
+    const content = scripts[lang] ?? scripts.english;
+    return [
+      { role: 'user', content: `Give me the consent script to read to the applicant (${lang}).` },
+      { role: 'assistant', content },
+    ];
+  }
+}

--- a/sample-apps/vitta/src/resources/vitta.resources.ts
+++ b/sample-apps/vitta/src/resources/vitta.resources.ts
@@ -1,0 +1,110 @@
+/**
+ * vitta.resources.ts — the 5 MCP Resources (data the agent reads).
+ * policy / product catalog / city-tiers / consent-templates / live case record.
+ */
+import { ResourceDecorator as Resource, ControllerDecorator as Controller, ExecutionContext } from '@nitrostack/core';
+import { POLICY, REASON_TEXT } from '../lib/policy.js';
+import { allSeeds } from '../lib/seeds.js';
+import { store } from '../lib/store.js';
+import { maskPan, maskMobile, maskName } from '../lib/redact.js';
+
+function json(uri: string, data: unknown) {
+  return { contents: [{ uri, mimeType: 'application/json', text: JSON.stringify(data, null, 2) }] };
+}
+
+@Controller()
+export class VittaResources {
+  @Resource({
+    uri: 'policy://credit-policy/v1.7',
+    name: 'Credit Policy v1.7',
+    description: 'Eligibility rules, FOIR cap, hard negatives, score bands and rate bands. The same rules underwrite() enforces.',
+    mimeType: 'application/json',
+  })
+  async creditPolicy(uri: string, _ctx: ExecutionContext) {
+    return json(uri, {
+      version: POLICY.version,
+      eligibility: {
+        age_band: '21–60',
+        employment: POLICY.eligible_employment,
+        min_bureau_score: POLICY.min_bureau_score,
+        max_dpd_12m: POLICY.max_dpd_12m,
+        max_inquiries_6m: POLICY.max_inquiries_6m,
+        foir_cap: POLICY.foir_cap,
+      },
+      score_bands: POLICY.score_bands,
+      rate_bands: POLICY.rate_bands,
+      reason_code_glossary: REASON_TEXT,
+      note: 'RBI/KYC master-direction alignment (mock corpus). Rules editable here; underwrite() reads the same constants.',
+    });
+  }
+
+  @Resource({
+    uri: 'catalog://products/personal-loan',
+    name: 'Personal Loan Catalog',
+    description: 'Product, ROI bands, processing fee and tenure grid.',
+    mimeType: 'application/json',
+  })
+  async productCatalog(uri: string, _ctx: ExecutionContext) {
+    return json(uri, {
+      product: 'Vitta Personal Loan',
+      roi_bands: POLICY.rate_bands,
+      processing_fee_pct: POLICY.processing_fee_pct,
+      tenure_grid_months: [12, 24, 36, 48],
+      amount_range: { min: POLICY.min_amount, max: 1500000 },
+      incentives: { autopay_discount_pct: 0.25, existing_customer_fee_waiver_pct: 0.5 },
+    });
+  }
+
+  @Resource({
+    uri: 'ref://city-tiers',
+    name: 'City Tiers',
+    description: 'Served cities and their tier → segment cap.',
+    mimeType: 'application/json',
+  })
+  async cityTiers(uri: string, _ctx: ExecutionContext) {
+    return json(uri, { cities: allSeeds().city.cities });
+  }
+
+  @Resource({
+    uri: 'consent://templates',
+    name: 'Consent Templates',
+    description: 'Versioned DPDP consent text registry — the exact language + version presented to applicants.',
+    mimeType: 'application/json',
+  })
+  async consentTemplates(uri: string, _ctx: ExecutionContext) {
+    return json(uri, {
+      current_version: 'consent-v3',
+      templates: {
+        'consent-v3': {
+          scopes: ['CREDIT_BUREAU', 'BANK_STATEMENTS', 'KYC'],
+          ttl_seconds: 900,
+          text:
+            'I authorise Vitta to access my credit bureau report, 12 months of bank statements (via Account Aggregator), ' +
+            'and CKYC/PAN records solely to assess this loan application. This consent is scoped, expires in 15 minutes, ' +
+            'and I may withdraw it at any time. I understand what will and will NOT be accessed.',
+          will_not_access: ['Aadhaar number', 'Social media', 'Location', 'Contacts'],
+        },
+      },
+    });
+  }
+
+  @Resource({
+    uri: 'case://{lead_id}',
+    name: 'Live Case Record',
+    description: 'The live application record for a lead_id (state the client reads to reason). PII is masked. URI: case://<lead_id>.',
+    mimeType: 'application/json',
+  })
+  async caseRecord(uri: string, _ctx: ExecutionContext) {
+    const lead_id = uri.replace(/^case:\/\//, '').split('/')[0];
+    const rec = store.getCase(lead_id);
+    if (!rec) return json(uri, { lead_id, found: false });
+    // mask PII for the read view
+    const safe = {
+      ...rec,
+      pan: rec.pan ? maskPan(rec.pan) : undefined,
+      mobile: rec.mobile ? maskMobile(rec.mobile) : undefined,
+      name: rec.name ? maskName(rec.name) : undefined,
+    };
+    return json(uri, { found: true, case: safe });
+  }
+}

--- a/sample-apps/vitta/src/tools/advisory.tools.ts
+++ b/sample-apps/vitta/src/tools/advisory.tools.ts
@@ -1,0 +1,62 @@
+/**
+ * advisory.tools.ts — the What-If Simulator + live reference-rate feed.
+ * simulate_scenario: the demo money-shot — deterministic, explainable
+ * counterfactuals ("what if my salary were ₹70k?") without mutating the case.
+ */
+import { ToolDecorator as Tool, ControllerDecorator as Controller, Widget, ExecutionContext, z } from '@nitrostack/core';
+import { simulateScenario } from '../lib/simulate.js';
+import { fetchReferenceRates } from '../lib/rates.js';
+import { advanceApplication } from '../lib/engine.js';
+
+@Controller()
+export class AdvisoryTools {
+  @Tool({
+    name: 'advance_application',
+    description:
+      'FAST PATH: after record_consent, run the entire post-consent chain in ONE call — verify_kyc, screen_fraud, ' +
+      'pull_bureau (consent-gated), fetch_bank_statements (consent-gated), compute_affordability, and underwrite — and ' +
+      'return the decision. Use this right after consent instead of calling those six tools one by one. Refuses with ' +
+      '{error:"CONSENT_REQUIRED"} if the consent_token is missing, wrong-scope, or issued for a different lead.',
+    inputSchema: z.object({
+      session_id: z.string().describe('Session id from qualify_lead.'),
+      lead_id: z.string(),
+      consent_token: z.string().describe('Token from record_consent.'),
+      pan: z.string().describe('Applicant PAN.'),
+      name: z.string().describe('Applicant full name (for KYC name-match).'),
+      mobile: z.string().describe('Applicant mobile (for fraud screen).'),
+      dob: z.string().optional(),
+    }),
+  })
+  @Widget('underwriting-result')
+  async advance_application(input: any, _ctx: ExecutionContext) {
+    return advanceApplication(input);
+  }
+
+  @Tool({
+    name: 'simulate_scenario',
+    description:
+      'What-If Simulator: re-run affordability + underwriting with one or two changed levers (net_income, tenure_months, requested_amount, close_existing_emi) WITHOUT changing the real application. Returns baseline vs scenario decisions and a plain-language delta (e.g. "close your ₹4,000 card EMI and the offer rises to ₹3L"). Use after underwrite, especially on CONDITIONAL or DECLINE, to show the applicant a constructive path.',
+    inputSchema: z.object({
+      session_id: z.string().describe('Session id from qualify_lead.'),
+      lead_id: z.string(),
+      net_income: z.number().optional().describe('Scenario monthly net income in INR (e.g. 70000).'),
+      tenure_months: z.number().optional().describe('Scenario tenure in months (12–48).'),
+      requested_amount: z.number().optional().describe('Scenario loan amount in INR.'),
+      close_existing_emi: z.number().optional().describe('₹/month of existing EMIs the applicant would close before this loan.'),
+    }),
+  })
+  @Widget('scenario-compare')
+  async simulate_scenario(input: any, _ctx: ExecutionContext) {
+    return simulateScenario(input);
+  }
+
+  @Tool({
+    name: 'get_reference_rates',
+    description:
+      'LIVE external data: fetch current INR reference FX rates (Frankfurter/ECB free API) plus the policy rate context our ROI bands are set against. Falls back to a cached snapshot if offline, so it always answers.',
+    inputSchema: z.object({}),
+  })
+  async get_reference_rates(_input: any, _ctx: ExecutionContext) {
+    return fetchReferenceRates();
+  }
+}

--- a/sample-apps/vitta/src/tools/audit.tools.ts
+++ b/sample-apps/vitta/src/tools/audit.tools.ts
@@ -1,0 +1,51 @@
+/**
+ * audit.tools.ts — MCP tools 11 & 12 (log_audit_event / get_audit_trail) + a
+ * DPDP consent-revocation helper. Every payload is PII-redacted before storage.
+ */
+import { ToolDecorator as Tool, ControllerDecorator as Controller, ExecutionContext, z } from '@nitrostack/core';
+import { logAuditEvent, getAuditTrail, revokeConsent } from '../lib/engine.js';
+
+@Controller()
+export class AuditTools {
+  @Tool({
+    name: 'log_audit_event',
+    description:
+      'Append a redacted event to the immutable audit trail (returns an ack + sequence number). Every decision, prompt and parameter version is stamped. PII is redacted automatically.',
+    inputSchema: z.object({
+      session_id: z.string(),
+      actor: z.string().describe('The tool/agent recording the event, e.g. "underwrite".'),
+      event: z.string().describe('Event type, e.g. "DECISION", "NOTE".'),
+      payload: z.record(z.any()).describe('Arbitrary event payload (will be PII-redacted).'),
+    }),
+  })
+  async log_audit_event(input: any, ctx: ExecutionContext) {
+    return logAuditEvent(input);
+  }
+
+  @Tool({
+    name: 'get_audit_trail',
+    description:
+      'Retrieve the append-only audit trail for a session. view=FULL (all fields), SUMMARY (seq/actor/event/ts) or COMPLIANCE_VIEW (adds version stamps). PII is already redacted at write time.',
+    inputSchema: z.object({
+      session_id: z.string(),
+      view: z.enum(['FULL', 'SUMMARY', 'COMPLIANCE_VIEW']).optional().describe('Default FULL.'),
+    }),
+  })
+  async get_audit_trail(input: any, ctx: ExecutionContext) {
+    return getAuditTrail(input);
+  }
+
+  @Tool({
+    name: 'revoke_consent',
+    description:
+      'DPDP withdrawal: revoke a previously issued consent by its token id (jti — returned by record_consent). After revocation, consent-gated tools refuse with CONSENT_REVOKED.',
+    inputSchema: z.object({
+      session_id: z.string(),
+      lead_id: z.string(),
+      jti: z.string().describe('The consent token id to revoke (from the consent proof).'),
+    }),
+  })
+  async revoke_consent(input: any, ctx: ExecutionContext) {
+    return revokeConsent(input);
+  }
+}

--- a/sample-apps/vitta/src/tools/decision.tools.ts
+++ b/sample-apps/vitta/src/tools/decision.tools.ts
@@ -1,0 +1,55 @@
+/**
+ * decision.tools.ts — MCP tools 7–9 (affordability → underwrite → offers).
+ * Thin wrappers over engine. Underwriting is rules + scorecard + reason codes
+ * (never trained ML — CLAUDE.md rule 8).
+ */
+import { ToolDecorator as Tool, ControllerDecorator as Controller, Widget, ExecutionContext, z } from '@nitrostack/core';
+import { computeAffordabilityStep, underwriteStep, generateOffersStep } from '../lib/engine.js';
+
+const SESSION = z.string().describe('Session id from qualify_lead — reuse for every call.');
+
+@Controller()
+export class DecisionTools {
+  @Tool({
+    name: 'compute_affordability',
+    description:
+      'Compute net income, proposed EMI, FOIR and DTI from the pulled bureau + bank data. Run after pull_bureau and fetch_bank_statements.',
+    inputSchema: z.object({
+      session_id: SESSION,
+      lead_id: z.string(),
+      requested_amount: z.number().optional().describe('Defaults to the amount from qualify_lead.'),
+      tenure_months: z.number().optional(),
+    }),
+  })
+  async compute_affordability(input: any, ctx: ExecutionContext) {
+    return computeAffordabilityStep(input);
+  }
+
+  @Tool({
+    name: 'underwrite',
+    description:
+      'Explainable underwriting: hard negatives + FOIR cap + a pre-baked scorecard → APPROVE / CONDITIONAL / DECLINE, with reason_codes and borrower-friendly explanations. CONDITIONAL should pause for human review before generate_offers.',
+    inputSchema: z.object({
+      session_id: SESSION,
+      lead_id: z.string(),
+    }),
+  })
+  @Widget('underwriting-result')
+  async underwrite(input: any, ctx: ExecutionContext) {
+    return underwriteStep(input);
+  }
+
+  @Tool({
+    name: 'generate_offers',
+    description:
+      'Produce up to 3 priced offers (amount, ROI, EMI, APR, total cost) with a recommended flag. Intent-aware: FAST_TRACK (medical/emergency) surfaces the lowest-EMI offer first. Only runs after an APPROVE or CONDITIONAL decision.',
+    inputSchema: z.object({
+      session_id: SESSION,
+      lead_id: z.string(),
+    }),
+  })
+  @Widget('offer-comparison')
+  async generate_offers(input: any, ctx: ExecutionContext) {
+    return generateOffersStep(input);
+  }
+}

--- a/sample-apps/vitta/src/tools/document.tools.ts
+++ b/sample-apps/vitta/src/tools/document.tools.ts
@@ -1,0 +1,24 @@
+/**
+ * document.tools.ts — MCP tool 10 (create_sanction_letter).
+ * Merges T&Cs + amortization, system-signs, returns a downloadable letter + SHA256 hash.
+ */
+import { ToolDecorator as Tool, ControllerDecorator as Controller, Widget, ExecutionContext, z } from '@nitrostack/core';
+import { createSanctionStep } from '../lib/engine.js';
+
+@Controller()
+export class DocumentTools {
+  @Tool({
+    name: 'create_sanction_letter',
+    description:
+      'Generate a signed sanction letter for a chosen offer: borrower + amount + EMI/APR, first-EMI date, a 3-row amortization preview, 3-day cooling-off notice, a mock e-sign line, and a SHA256 integrity hash. Returns a downloadable url. Only after the applicant accepts an offer.',
+    inputSchema: z.object({
+      session_id: z.string().describe('Session id from qualify_lead.'),
+      lead_id: z.string(),
+      offer_id: z.string().describe('offer_id chosen from generate_offers.'),
+    }),
+  })
+  @Widget('sanction-letter')
+  async create_sanction_letter(input: any, ctx: ExecutionContext) {
+    return createSanctionStep(input);
+  }
+}

--- a/sample-apps/vitta/src/tools/intake.tools.ts
+++ b/sample-apps/vitta/src/tools/intake.tools.ts
@@ -1,0 +1,115 @@
+/**
+ * intake.tools.ts — MCP tools 1–6 (qualify → consent → KYC → fraud → bureau ⚿ → bank ⚿).
+ * Thin decorator wrappers over src/lib/engine.ts (single source of truth).
+ * Gated tools (⚿) enforce consent as the FIRST line inside the engine.
+ */
+import { ToolDecorator as Tool, ControllerDecorator as Controller, ExecutionContext, z } from '@nitrostack/core';
+import {
+  qualifyLead, recordConsent, verifyKyc, screenFraud, pullBureau, fetchBankStatements,
+} from '../lib/engine.js';
+
+const SESSION = z.string().describe('Session id from qualify_lead — reuse the SAME value for every tool call in this application.');
+
+@Controller()
+export class IntakeTools {
+  @Tool({
+    name: 'qualify_lead',
+    description:
+      'Start a loan application: capture intent (purpose, amount, tenure, employment, city) and run quick eligibility. Returns a lead_id and a session_id you MUST reuse for every later tool call. Detects medical/emergency intent as FAST_TRACK.',
+    inputSchema: z.object({
+      session_id: z.string().optional().describe('Optional; a new one is generated and returned if omitted.'),
+      purpose: z.string().describe('Why the loan is needed, e.g. "medical emergency", "home renovation".'),
+      amount: z.number().describe('Requested loan amount in INR.'),
+      tenure_months: z.number().describe('Requested tenure in months (12–48).'),
+      employment: z.enum(['SALARIED', 'SELF_EMPLOYED']).describe('Employment type.'),
+      city: z.string().describe('Applicant city (serviceability is checked).'),
+      income_band: z.string().optional().describe('Self-declared monthly income band, e.g. "50k-75k".'),
+    }),
+  })
+  async qualify_lead(input: any, ctx: ExecutionContext) {
+    const session_id = input.session_id || `sess-${Date.now().toString(36)}`;
+    const r = qualifyLead({ ...input, session_id });
+    return { session_id, ...r };
+  }
+
+  @Tool({
+    name: 'record_consent',
+    description:
+      'Capture explicit, versioned, timestamped DPDP consent and ISSUE the consent_token that unlocks data-pull tools (also returns jti for revoke_consent). Call this BEFORE pull_bureau or fetch_bank_statements. IMPORTANT: only call with accepted=true AFTER the human has explicitly agreed in this conversation — never assume or pre-fill consent on their behalf. If accepted=false, no token is issued and those tools will refuse.',
+    inputSchema: z.object({
+      session_id: SESSION,
+      lead_id: z.string().describe('lead_id from qualify_lead.'),
+      consent_text_version: z.string().describe('Version id of the consent text shown to the applicant.'),
+      accepted: z.boolean().describe('Whether the applicant explicitly accepted.'),
+      channel: z.string().describe('Channel of consent, e.g. "web", "whatsapp".'),
+      scopes: z.array(z.enum(['CREDIT_BUREAU', 'BANK_STATEMENTS', 'KYC'])).optional()
+        .describe('Data scopes consented to. Defaults to all three.'),
+    }),
+  })
+  async record_consent(input: any, ctx: ExecutionContext) {
+    return recordConsent(input);
+  }
+
+  @Tool({
+    name: 'verify_kyc',
+    description: 'PAN name-match + CKYC alignment (mock). Returns PASS / RETRY / FAIL, a kyc_hash, and any risk flags.',
+    inputSchema: z.object({
+      session_id: SESSION,
+      lead_id: z.string(),
+      pan: z.string().describe('PAN, format ABCDE1234F.'),
+      name: z.string().describe('Applicant full name for name-match.'),
+      dob: z.string().optional().describe('Date of birth (optional).'),
+    }),
+  })
+  async verify_kyc(input: any, ctx: ExecutionContext) {
+    return verifyKyc(input);
+  }
+
+  @Tool({
+    name: 'screen_fraud',
+    description:
+      'Fraud, velocity and AML/PEP watchlist screening (mock). Returns CLEAR / REVIEW / BLOCK with signals and a score. A REVIEW verdict should pause for human handoff.',
+    inputSchema: z.object({
+      session_id: SESSION,
+      lead_id: z.string(),
+      identifiers: z.object({
+        mobile: z.string().describe('Applicant mobile number.'),
+        pan: z.string().optional(),
+        device: z.string().optional(),
+      }),
+    }),
+  })
+  async screen_fraud(input: any, ctx: ExecutionContext) {
+    return screenFraud(input);
+  }
+
+  @Tool({
+    name: 'pull_bureau',
+    description:
+      'CONSENT-GATED. Pull the credit bureau report (score, DPD, write-offs, inquiries, active EMIs). Refuses with {error:"CONSENT_REQUIRED"} unless a valid consent_token granting CREDIT_BUREAU scope is passed.',
+    inputSchema: z.object({
+      session_id: SESSION,
+      lead_id: z.string(),
+      consent_token: z.string().describe('Token from record_consent (CREDIT_BUREAU scope). Required.'),
+      pan: z.string(),
+    }),
+  })
+  async pull_bureau(input: any, ctx: ExecutionContext) {
+    return pullBureau(input);
+  }
+
+  @Tool({
+    name: 'fetch_bank_statements',
+    description:
+      'CONSENT-GATED. Fetch 12-month bank/Account-Aggregator cashflow summary (salary credits, variance, bounces, surplus, stability). Refuses with {error:"CONSENT_REQUIRED"} unless a valid consent_token granting BANK_STATEMENTS scope is passed.',
+    inputSchema: z.object({
+      session_id: SESSION,
+      lead_id: z.string(),
+      consent_token: z.string().describe('Token from record_consent (BANK_STATEMENTS scope). Required.'),
+      months: z.number().optional().describe('Months of history (default 12).'),
+    }),
+  })
+  async fetch_bank_statements(input: any, ctx: ExecutionContext) {
+    return fetchBankStatements(input);
+  }
+}

--- a/sample-apps/vitta/src/tools/system.tools.ts
+++ b/sample-apps/vitta/src/tools/system.tools.ts
@@ -1,0 +1,26 @@
+/**
+ * system.tools.ts — health_check tool (PLAN.md §5 Phase 0). Cheap liveness probe
+ * used by the post-deploy verification checklist (§6.5).
+ */
+import { ToolDecorator as Tool, ControllerDecorator as Controller, ExecutionContext, z } from '@nitrostack/core';
+
+export const SERVER_VERSION = '1.0.0';
+
+@Controller()
+export class SystemTools {
+  @Tool({
+    name: 'health_check',
+    description: 'Liveness probe. Returns {ok:true, version, commit, server, ts}. Use to verify the deployment is reachable and which build is live.',
+    inputSchema: z.object({}),
+  })
+  async health_check(_input: any, _ctx: ExecutionContext) {
+    return {
+      ok: true,
+      version: SERVER_VERSION,
+      commit: process.env.GIT_COMMIT ?? process.env.SOURCE_VERSION ?? 'local',
+      consent_secret_configured: Boolean(process.env.CONSENT_SECRET && process.env.CONSENT_SECRET.length >= 16),
+      server: 'vitta-lending',
+      ts: new Date().toISOString(),
+    };
+  }
+}

--- a/sample-apps/vitta/src/vitta.module.ts
+++ b/sample-apps/vitta/src/vitta.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nitrostack/core';
+import { IntakeTools } from './tools/intake.tools.js';
+import { DecisionTools } from './tools/decision.tools.js';
+import { DocumentTools } from './tools/document.tools.js';
+import { AuditTools } from './tools/audit.tools.js';
+import { SystemTools } from './tools/system.tools.js';
+import { AdvisoryTools } from './tools/advisory.tools.js';
+import { VittaResources } from './resources/vitta.resources.js';
+import { VittaPrompts } from './prompts/vitta.prompts.js';
+
+/**
+ * VittaModule — the NBFC lending capability layer.
+ * 16 Tools (12 golden-path + simulate_scenario + get_reference_rates + revoke_consent + health_check),
+ * 5 Resources, 5 Prompts.
+ */
+@Module({
+  name: 'vitta',
+  description: 'NBFC personal-loan origination: qualify → consent → KYC → bureau → underwrite → offers → sanction → audit.',
+  controllers: [
+    IntakeTools,
+    DecisionTools,
+    DocumentTools,
+    AuditTools,
+    SystemTools,
+    AdvisoryTools,
+    VittaResources,
+    VittaPrompts,
+  ],
+})
+export class VittaModule {}

--- a/sample-apps/vitta/src/widgets/app/layout.tsx
+++ b/sample-apps/vitta/src/widgets/app/layout.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { WidgetLayout } from '@nitrostack/widgets';
+
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, padding: 0, fontFamily: 'system-ui, sans-serif' }}>
+        <WidgetLayout>{children}</WidgetLayout>
+      </body>
+    </html>
+  );
+}

--- a/sample-apps/vitta/src/widgets/app/offer-comparison/page.tsx
+++ b/sample-apps/vitta/src/widgets/app/offer-comparison/page.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useState } from 'react';
+import { useTheme, useWidgetSDK } from '@nitrostack/widgets';
+
+/**
+ * Offer Comparison widget — up to 3 tappable offer cards with recommended badge.
+ * Renders output of `generate_offers`. Accept button chains create_sanction_letter.
+ */
+
+interface Offer {
+  offer_id: string;
+  amount: number;
+  tenure_months: number;
+  roi_annual_pct: number;
+  emi: number;
+  processing_fee_pct: number;
+  apr_pct: number;
+  total_cost: number;
+  valid_till: string;
+  recommended: boolean;
+  why_recommended?: string;
+}
+interface OffersOut {
+  offers: Offer[];
+  recommended_offer_id: string;
+}
+
+const inr = (n: number) => '₹' + Number(n || 0).toLocaleString('en-IN');
+
+export default function OfferComparison() {
+  const theme = useTheme();
+  const { getToolOutput, callTool, sendFollowUpMessage } = useWidgetSDK();
+  const data = getToolOutput<OffersOut>();
+  const [selected, setSelected] = useState<string | null>(null);
+  const [accepting, setAccepting] = useState(false);
+  const [fallbackHint, setFallbackHint] = useState<string | null>(null);
+  const isDark = theme === 'dark';
+
+  const fg = isDark ? '#f5f5f5' : '#111827';
+  const muted = isDark ? 'rgba(255,255,255,0.55)' : 'rgba(0,0,0,0.55)';
+  const card = isDark ? '#111827' : '#ffffff';
+  const line = isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
+  const accent = '#3b82f6';
+
+  if (!data || !data.offers?.length) {
+    return <div style={{ padding: 24, textAlign: 'center', color: muted }}>No offers to display.</div>;
+  }
+
+  const sel = selected ?? data.recommended_offer_id;
+
+  const accept = async (offer: Offer) => {
+    setAccepting(true);
+    try {
+      // let the agent narrate + run create_sanction_letter with full context
+      await Promise.resolve(
+        sendFollowUpMessage(`I accept offer ${offer.offer_id} (${inr(offer.amount)} for ${offer.tenure_months} months at EMI ${inr(offer.emi)}). Please generate my sanction letter.`),
+      );
+    } catch {
+      // host doesn't support follow-up messages (e.g. sandboxed preview) —
+      // degrade to an explicit typed instruction instead of a dead button
+      setFallbackHint(`This host blocks widget actions — type "I accept ${offer.offer_id}" in the chat to proceed.`);
+    } finally {
+      setAccepting(false);
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 720, fontFamily: 'system-ui, sans-serif', color: fg }}>
+      <div style={{ fontSize: 13, color: muted, marginBottom: 10 }}>Your offers — tap a card to compare, accept when ready. APR and total cost shown upfront.</div>
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+        {data.offers.map((o) => {
+          const active = o.offer_id === sel;
+          return (
+            <div key={o.offer_id} onClick={() => setSelected(o.offer_id)}
+              style={{
+                flex: '1 1 200px', minWidth: 200, cursor: 'pointer', borderRadius: 14, padding: 16,
+                background: card, border: `2px solid ${active ? accent : line}`,
+                boxShadow: active ? '0 8px 24px rgba(59,130,246,0.25)' : '0 2px 8px rgba(0,0,0,0.08)',
+                transition: 'all 0.2s ease', position: 'relative',
+              }}>
+              {o.recommended && (
+                <div style={{ position: 'absolute', top: -10, left: 12, background: '#10b981', color: '#fff', fontSize: 10, fontWeight: 700, padding: '3px 10px', borderRadius: 999 }}>★ RECOMMENDED</div>
+              )}
+              <div style={{ fontSize: 12, color: muted, marginTop: 6 }}>{o.tenure_months} months</div>
+              <div style={{ fontSize: 24, fontWeight: 800, margin: '2px 0' }}>{inr(o.emi)}<span style={{ fontSize: 12, fontWeight: 500, color: muted }}>/mo</span></div>
+              <div style={{ fontSize: 12, color: muted }}>{inr(o.amount)} @ {o.roi_annual_pct}% p.a.</div>
+              <div style={{ borderTop: `1px solid ${line}`, marginTop: 10, paddingTop: 8, fontSize: 11.5, color: muted, display: 'grid', gap: 3 }}>
+                <span>APR {o.apr_pct}%</span>
+                <span>Fee {o.processing_fee_pct}%</span>
+                <span>Total cost {inr(o.total_cost)}</span>
+              </div>
+              {active && (
+                <>
+                  {o.why_recommended && <div style={{ fontSize: 11.5, marginTop: 8, color: '#10b981' }}>{o.why_recommended}</div>}
+                  <button onClick={(e) => { e.stopPropagation(); accept(o); }} disabled={accepting}
+                    style={{ marginTop: 10, width: '100%', padding: '9px 0', borderRadius: 10, border: 'none', background: accent, color: '#fff', fontWeight: 700, fontSize: 13, cursor: 'pointer', opacity: accepting ? 0.6 : 1 }}>
+                    {accepting ? 'Working…' : 'Accept this offer →'}
+                  </button>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {fallbackHint && (
+        <div style={{ marginTop: 10, padding: '8px 12px', borderRadius: 8, background: 'rgba(245,158,11,0.14)', color: '#f59e0b', fontSize: 12 }}>{fallbackHint}</div>
+      )}
+      <div style={{ fontSize: 10, color: muted, marginTop: 10 }}>3-day cooling-off applies after sanction. No hidden charges — the total cost above is everything.</div>
+    </div>
+  );
+}

--- a/sample-apps/vitta/src/widgets/app/sanction-letter/page.tsx
+++ b/sample-apps/vitta/src/widgets/app/sanction-letter/page.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useState } from 'react';
+import { useTheme, useWidgetSDK } from '@nitrostack/widgets';
+
+/**
+ * Sanction Letter widget — the ceremony moment. Document card with key numbers,
+ * SHA256 integrity hash and a download affordance. Renders create_sanction_letter output.
+ */
+
+interface SanctionOut {
+  url: string;
+  hash: string;
+  valid_till: string;
+  letter_fields: {
+    borrower_name?: string;
+    sanction_amount?: number;
+    roi_annual_pct?: number;
+    apr_pct?: number;
+    emi?: number;
+    tenure_months?: number;
+    total_cost?: number;
+    first_emi_date?: string;
+    cooling_off_days?: number;
+    html?: string;
+  };
+}
+
+const inr = (n?: number) => '₹' + Number(n || 0).toLocaleString('en-IN');
+
+export default function SanctionLetter() {
+  const theme = useTheme();
+  const { getToolOutput, openExternal } = useWidgetSDK();
+  const [linkHint, setLinkHint] = useState<string | null>(null); // hooks BEFORE any early return
+  const d = getToolOutput<SanctionOut>();
+  const isDark = theme === 'dark';
+
+  const fg = isDark ? '#f5f5f5' : '#1f2430';
+  const muted = isDark ? 'rgba(255,255,255,0.55)' : 'rgba(0,0,0,0.55)';
+  const paper = isDark ? '#15181f' : '#fffdf7';
+  const line = isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
+
+  if (!d) return <div style={{ padding: 24, textAlign: 'center' }}>Preparing letter…</div>;
+  const f = d.letter_fields || {};
+
+  const download = () => {
+    // 1) real hosted URL (server mounts GET /letters/:leadId) — works everywhere
+    if (d.url?.startsWith('http')) {
+      try {
+        openExternal(d.url);
+        return;
+      } catch {
+        /* host blocks openExternal — try blob next */
+      }
+    }
+    // 2) blob download from the embedded html
+    if (f.html) {
+      try {
+        const blob = new Blob([f.html], { type: 'text/html' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'vitta-sanction-letter.html';
+        a.click();
+        URL.revokeObjectURL(url);
+        return;
+      } catch {
+        /* sandbox blocks downloads too */
+      }
+    }
+    // 3) last resort: surface the link as selectable text
+    setLinkHint(d.url ?? 'Ask the agent for your sanction letter link.');
+  };
+
+  return (
+    <div style={{ maxWidth: 440, fontFamily: 'Georgia, serif', color: fg }}>
+      <div style={{ borderRadius: 16, background: paper, border: `1px solid ${line}`, boxShadow: '0 12px 32px rgba(0,0,0,0.22)', overflow: 'hidden' }}>
+        {/* letterhead */}
+        <div style={{ padding: '18px 22px 12px', borderBottom: `2px solid #b8860b` }}>
+          <div style={{ fontSize: 11, letterSpacing: 2, color: '#b8860b', fontWeight: 700 }}>SANCTION LETTER</div>
+          <div style={{ fontSize: 15, fontWeight: 700, marginTop: 2 }}>Vitta Financial Services Pvt. Ltd.</div>
+          <div style={{ fontSize: 10, color: muted }}>NBFC · RBI Reg N-14.99999 (mock) · digitally signed</div>
+        </div>
+
+        <div style={{ padding: '16px 22px' }}>
+          <div style={{ fontSize: 13, marginBottom: 6 }}>Dear <b>{f.borrower_name ?? 'Applicant'}</b>, your loan is approved.</div>
+          <div style={{ fontSize: 32, fontWeight: 800, fontFamily: 'system-ui, sans-serif', margin: '6px 0 10px' }}>{inr(f.sanction_amount)}</div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, fontFamily: 'system-ui, sans-serif', fontSize: 12.5 }}>
+            <div><span style={{ color: muted }}>EMI</span><br /><b>{inr(f.emi)}/mo × {f.tenure_months}m</b></div>
+            <div><span style={{ color: muted }}>Rate / APR</span><br /><b>{f.roi_annual_pct}% · {f.apr_pct}% APR</b></div>
+            <div><span style={{ color: muted }}>First EMI</span><br /><b>{f.first_emi_date}</b></div>
+            <div><span style={{ color: muted }}>Total cost</span><br /><b>{inr(f.total_cost)}</b></div>
+          </div>
+
+          <div style={{ marginTop: 12, padding: '8px 10px', borderRadius: 8, background: isDark ? 'rgba(184,134,11,0.12)' : 'rgba(184,134,11,0.08)', fontSize: 11, fontFamily: 'system-ui, sans-serif' }}>
+            {f.cooling_off_days ?? 3}-day cooling-off: cancel without penalty. Offer valid till {String(d.valid_till).slice(0, 10)}.
+          </div>
+
+          <button onClick={download}
+            style={{ marginTop: 14, width: '100%', padding: '11px 0', borderRadius: 10, border: 'none', background: '#b8860b', color: '#fff', fontWeight: 700, fontSize: 13, cursor: 'pointer', fontFamily: 'system-ui, sans-serif' }}>
+            ⬇ Download signed letter
+          </button>
+
+          {linkHint && (
+            <div style={{ marginTop: 8, padding: '6px 10px', borderRadius: 8, background: 'rgba(184,134,11,0.14)', fontSize: 11, fontFamily: 'system-ui, sans-serif', wordBreak: 'break-all' }}>
+              Letter link: {linkHint}
+            </div>
+          )}
+          <div style={{ marginTop: 10, fontSize: 9, fontFamily: 'monospace', color: muted, wordBreak: 'break-all' }}>
+            SHA256 {d.hash}
+          </div>
+        </div>
+      </div>
+      <div style={{ fontSize: 10, color: muted, marginTop: 8, fontFamily: 'system-ui, sans-serif', textAlign: 'center' }}>
+        Integrity-hashed · every step in your audit trail · Vitta
+      </div>
+    </div>
+  );
+}

--- a/sample-apps/vitta/src/widgets/app/scenario-compare/page.tsx
+++ b/sample-apps/vitta/src/widgets/app/scenario-compare/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useTheme, useWidgetSDK } from '@nitrostack/widgets';
+
+/**
+ * Scenario Compare widget — the What-If money shot.
+ * Baseline vs scenario side-by-side: outcome flip, FOIR movement, amount delta.
+ * Renders output of `simulate_scenario`.
+ */
+
+interface Aff { foir: number; proposed_emi: number; net_income: number; existing_emi: number }
+interface Dec { outcome: string; max_amount: number; score: number; reason_codes: string[] }
+interface SimOut {
+  baseline: { affordability: Aff; decision: Dec };
+  scenario: { affordability: Aff; decision: Dec; levers: Record<string, number> };
+  delta: { outcome_changed: boolean; outcome: string; max_amount_change: number; foir_change_pct: number; summary: string };
+}
+
+const OUT_COLOR: Record<string, string> = { APPROVE: '#10b981', CONDITIONAL: '#f59e0b', DECLINE: '#ef4444' };
+const inr = (n: number) => '₹' + Number(n || 0).toLocaleString('en-IN');
+const LEVER_LABEL: Record<string, string> = {
+  net_income: 'Monthly income',
+  tenure_months: 'Tenure (months)',
+  requested_amount: 'Requested amount',
+  close_existing_emi: 'Existing EMI closed',
+};
+
+export default function ScenarioCompare() {
+  const theme = useTheme();
+  const { getToolOutput } = useWidgetSDK();
+  const d = getToolOutput<SimOut>();
+  const isDark = theme === 'dark';
+
+  const fg = isDark ? '#f5f5f5' : '#111827';
+  const muted = isDark ? 'rgba(255,255,255,0.55)' : 'rgba(0,0,0,0.55)';
+  const card = isDark ? '#111827' : '#ffffff';
+  const line = isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)';
+
+  if (!d) return <div style={{ padding: 24, textAlign: 'center' }}>Simulating…</div>;
+
+  const col = (title: string, dec: Dec, aff: Aff, highlight: boolean) => {
+    const c = OUT_COLOR[dec.outcome] ?? '#6b7280';
+    const foirPct = Math.round(aff.foir * 100);
+    return (
+      <div style={{ flex: 1, minWidth: 190, padding: 14, borderRadius: 12, background: card, border: `2px solid ${highlight ? c : line}` }}>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: 0.5, color: muted, marginBottom: 8 }}>{title}</div>
+        <div style={{ fontSize: 16, fontWeight: 800, color: c, marginBottom: 6 }}>{dec.outcome}</div>
+        <div style={{ fontSize: 22, fontWeight: 800 }}>{inr(dec.max_amount)}</div>
+        {/* FOIR bar with 55% cap line */}
+        <div style={{ marginTop: 10, fontSize: 11, color: muted }}>FOIR {foirPct}% <span style={{ opacity: 0.7 }}>(cap 55%)</span></div>
+        <div style={{ position: 'relative', height: 8, borderRadius: 999, background: line, marginTop: 4 }}>
+          <div style={{ position: 'absolute', left: 0, top: 0, height: 8, borderRadius: 999, width: `${Math.min(100, foirPct)}%`, background: foirPct > 55 ? '#ef4444' : '#10b981', transition: 'width 0.5s ease' }} />
+          <div style={{ position: 'absolute', left: '55%', top: -2, width: 2, height: 12, background: '#ef4444' }} />
+        </div>
+        <div style={{ marginTop: 8, fontSize: 11, color: muted }}>score {dec.score} · EMI {inr(aff.proposed_emi)}</div>
+      </div>
+    );
+  };
+
+  return (
+    <div style={{ maxWidth: 640, fontFamily: 'system-ui, sans-serif', color: fg }}>
+      {/* levers */}
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 10 }}>
+        {Object.entries(d.scenario.levers).map(([k, v]) => (
+          <span key={k} style={{ fontSize: 11, padding: '4px 10px', borderRadius: 999, background: 'rgba(59,130,246,0.14)', color: '#3b82f6', fontWeight: 600 }}>
+            {LEVER_LABEL[k] ?? k}: {k === 'tenure_months' ? v : inr(v)}
+          </span>
+        ))}
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, alignItems: 'stretch', flexWrap: 'wrap' }}>
+        {col('TODAY', d.baseline.decision, d.baseline.affordability, false)}
+        <div style={{ alignSelf: 'center', fontSize: 22, color: muted }}>→</div>
+        {col('WHAT-IF', d.scenario.decision, d.scenario.affordability, true)}
+      </div>
+
+      <div style={{ marginTop: 12, padding: '10px 14px', borderRadius: 10, background: d.delta.outcome_changed ? 'rgba(16,185,129,0.12)' : (isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.04)'), fontSize: 13, lineHeight: 1.5 }}>
+        {d.delta.outcome_changed ? '✨ ' : ''}{d.delta.summary}
+      </div>
+
+      <div style={{ fontSize: 10, color: muted, marginTop: 8 }}>Same rules, one lever moved — decisions are deterministic and fully explainable.</div>
+    </div>
+  );
+}

--- a/sample-apps/vitta/src/widgets/app/underwriting-result/page.tsx
+++ b/sample-apps/vitta/src/widgets/app/underwriting-result/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useTheme, useWidgetSDK } from '@nitrostack/widgets';
+
+/**
+ * Underwriting Result widget — FOIR gauge + explainable reason checklist.
+ * Renders the Decision from the `underwrite` tool.
+ */
+
+interface Decision {
+  outcome: 'APPROVE' | 'CONDITIONAL' | 'DECLINE';
+  max_amount: number;
+  rate_band: { min: number; max: number };
+  tenure_range: { min: number; max: number };
+  score: number;
+  reason_codes: string[];
+  explanations: string[];
+}
+
+const OUTCOME_STYLE: Record<string, { color: string; bg: string; icon: string; label: string }> = {
+  APPROVE: { color: '#10b981', bg: 'rgba(16,185,129,0.12)', icon: '✓', label: 'Approved' },
+  CONDITIONAL: { color: '#f59e0b', bg: 'rgba(245,158,11,0.12)', icon: '⏸', label: 'Conditional — human review' },
+  DECLINE: { color: '#ef4444', bg: 'rgba(239,68,68,0.12)', icon: '✕', label: 'Not approved right now' },
+};
+
+const inr = (n: number) => '₹' + Number(n || 0).toLocaleString('en-IN');
+
+export default function UnderwritingResult() {
+  const theme = useTheme();
+  const { getToolOutput } = useWidgetSDK();
+  const d = getToolOutput<Decision>();
+  const isDark = theme === 'dark';
+
+  if (!d) return <div style={{ padding: 24, textAlign: 'center' }}>Loading decision…</div>;
+
+  const s = OUTCOME_STYLE[d.outcome] ?? OUTCOME_STYLE.CONDITIONAL;
+  const fg = isDark ? '#f5f5f5' : '#111827';
+  const muted = isDark ? 'rgba(255,255,255,0.55)' : 'rgba(0,0,0,0.55)';
+  const card = isDark ? '#111827' : '#ffffff';
+  const line = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)';
+
+  // score arc 0..100
+  const pct = Math.max(0, Math.min(100, d.score));
+  const R = 52, C = Math.PI * R; // half-circle
+  const dash = (pct / 100) * C;
+
+  return (
+    <div style={{ maxWidth: 460, padding: 20, borderRadius: 16, background: card, color: fg, border: `1px solid ${line}`, boxShadow: '0 8px 28px rgba(0,0,0,0.18)', fontFamily: 'system-ui, sans-serif' }}>
+      {/* header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
+        <div style={{ width: 40, height: 40, borderRadius: 12, background: s.bg, color: s.color, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 20, fontWeight: 700 }}>{s.icon}</div>
+        <div>
+          <div style={{ fontSize: 17, fontWeight: 700, color: s.color }}>{s.label}</div>
+          <div style={{ fontSize: 12, color: muted }}>Rules + scorecard + reason codes — no black box</div>
+        </div>
+      </div>
+
+      {/* gauge + numbers */}
+      <div style={{ display: 'flex', gap: 18, alignItems: 'center', marginBottom: 14 }}>
+        <svg width={128} height={78} viewBox="0 0 128 78">
+          <path d="M 12 70 A 52 52 0 0 1 116 70" fill="none" stroke={line} strokeWidth={12} strokeLinecap="round" />
+          <path d="M 12 70 A 52 52 0 0 1 116 70" fill="none" stroke={s.color} strokeWidth={12} strokeLinecap="round"
+            strokeDasharray={`${dash} ${C}`} style={{ transition: 'stroke-dasharray 0.6s ease' }} />
+          <text x={64} y={58} textAnchor="middle" fontSize={22} fontWeight={800} fill={fg}>{d.score}</text>
+          <text x={64} y={73} textAnchor="middle" fontSize={10} fill={muted}>score / 100 · approve ≥60</text>
+        </svg>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 12, color: muted }}>Eligible amount</div>
+          <div style={{ fontSize: 26, fontWeight: 800 }}>{inr(d.max_amount)}</div>
+          {d.outcome !== 'DECLINE' && (
+            <div style={{ fontSize: 12, color: muted, marginTop: 4 }}>
+              {d.rate_band.min}%–{d.rate_band.max}% p.a. · {d.tenure_range.min}–{d.tenure_range.max} months
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* reason checklist */}
+      <div style={{ borderTop: `1px solid ${line}`, paddingTop: 12 }}>
+        <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: 0.4, color: muted, marginBottom: 8 }}>WHY — EVERY REASON, IN PLAIN WORDS</div>
+        {d.explanations.slice(0, 4).map((e, i) => (
+          <div key={i} style={{ display: 'flex', gap: 8, marginBottom: 6, fontSize: 13, lineHeight: 1.45 }}>
+            <span style={{ color: s.color, fontWeight: 700 }}>{d.outcome === 'APPROVE' ? '✓' : '⚠'}</span>
+            <span>{e}</span>
+          </div>
+        ))}
+        {d.reason_codes.length > 0 && (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 8 }}>
+            {d.reason_codes.map((rc) => (
+              <span key={rc} style={{ fontSize: 10, fontFamily: 'monospace', padding: '3px 8px', borderRadius: 999, background: s.bg, color: s.color }}>{rc}</span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div style={{ marginTop: 12, fontSize: 10, color: muted, display: 'flex', justifyContent: 'space-between' }}>
+        <span>Vitta · explainable underwriting</span>
+        <span>policy v1.7 · scorecard-2026-07</span>
+      </div>
+    </div>
+  );
+}

--- a/sample-apps/vitta/src/widgets/next-env.d.ts
+++ b/sample-apps/vitta/src/widgets/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/sample-apps/vitta/src/widgets/next.config.js
+++ b/sample-apps/vitta/src/widgets/next.config.js
@@ -1,0 +1,45 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['nitrostack'],
+  
+  // Static export for production builds
+  ...(process.env.NODE_ENV === 'production' && {
+    output: 'export',
+    distDir: 'out',
+    images: {
+      unoptimized: true,
+    },
+  }),
+  
+  // Development optimizations to prevent cache corruption
+  ...(process.env.NODE_ENV === 'development' && {
+    // Use memory cache instead of filesystem cache in dev to avoid stale chunks
+    webpack: (config, { isServer }) => {
+      // Disable persistent caching in development to prevent chunk reference errors
+      if (config.cache && config.cache.type === 'filesystem') {
+        config.cache = {
+          type: 'memory',
+        };
+      }
+      
+      // Improve cache busting for new files
+      if (!isServer) {
+        config.cache = false; // Disable cache completely on client in dev
+      }
+      
+      return config;
+    },
+    
+    // Disable build activity indicator which can cause issues
+    devIndicators: {
+      buildActivity: false,
+      buildActivityPosition: 'bottom-right',
+    },
+    
+    // Faster dev server
+    compress: false,
+  }),
+};
+
+export default nextConfig;

--- a/sample-apps/vitta/src/widgets/package-lock.json
+++ b/sample-apps/vitta/src/widgets/package-lock.json
@@ -1,0 +1,1712 @@
+{
+  "name": "calculator-widgets",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "calculator-widgets",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0",
+        "@nitrostack/widgets": "^1.0.8",
+        "next": "^14.2.5",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20",
+        "@types/react": "^18",
+        "@types/react-dom": "^18",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.4.tgz",
+      "integrity": "sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ==",
+      "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nitrostack/widgets": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@nitrostack/widgets/-/widgets-1.0.8.tgz",
+      "integrity": "sha512-/E8MAgOp/rYOyRNydzamxsJAhsBp7Q9A8LYB7m+kqy+o0ubLBsU7rb1EIaIg8JX8KPdxfchxqwo0HxzUWRsYDg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0",
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.35",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/sample-apps/vitta/src/widgets/package.json
+++ b/sample-apps/vitta/src/widgets/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "calculator-widgets",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3001 --port 3001",
+    "build": "next build",
+    "start": "next start -p 3001"
+  },
+  "dependencies": {
+    "next": "^14.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "@nitrostack/widgets": "^1.0.8",
+    "@modelcontextprotocol/ext-apps": ">=0.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "typescript": "^5"
+  }
+}

--- a/sample-apps/vitta/src/widgets/tsconfig.json
+++ b/sample-apps/vitta/src/widgets/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}
+

--- a/sample-apps/vitta/src/widgets/widget-manifest.json
+++ b/sample-apps/vitta/src/widgets/widget-manifest.json
@@ -1,0 +1,120 @@
+{
+  "version": "1.0.0",
+  "widgets": [
+    {
+      "uri": "/underwriting-result",
+      "name": "Underwriting Result",
+      "description": "Explainable decision card: outcome, score gauge, eligible amount, reason checklist",
+      "examples": [
+        {
+          "name": "Conditional (demo pair)",
+          "description": "VITTA1235K demo — CONDITIONAL ₹2.5L, FOIR-driven",
+          "data": {
+            "outcome": "CONDITIONAL",
+            "max_amount": 250000,
+            "rate_band": { "min": 15.99, "max": 18 },
+            "tenure_range": { "min": 12, "max": 48 },
+            "score": 46,
+            "reason_codes": ["FOIR_LIMIT", "HIGH_EXISTING_EMI", "MANUAL_REVIEW"],
+            "explanations": [
+              "Approved for ₹2,50,000 instead of ₹3,00,000 because existing EMIs put your FOIR at 57%.",
+              "Your application needs a brief review by our team before final approval."
+            ]
+          }
+        },
+        {
+          "name": "Approve",
+          "description": "Clean approval",
+          "data": {
+            "outcome": "APPROVE",
+            "max_amount": 300000,
+            "rate_band": { "min": 13.5, "max": 15 },
+            "tenure_range": { "min": 12, "max": 48 },
+            "score": 93,
+            "reason_codes": ["CLEAN_BUREAU", "LOW_UTILISATION"],
+            "explanations": ["Approved for ₹3,00,000 at a FOIR of 21%.", "Your bureau record is clean with no adverse markers."]
+          }
+        }
+      ],
+      "tags": ["underwriting", "decision", "explainability"]
+    },
+    {
+      "uri": "/offer-comparison",
+      "name": "Offer Comparison",
+      "description": "Up to 3 tappable offer cards with recommended badge, APR and total cost upfront",
+      "examples": [
+        {
+          "name": "Three offers (FAST_TRACK)",
+          "description": "Lowest EMI recommended for a medical emergency",
+          "data": {
+            "recommended_offer_id": "VITTA-DEMO-OF2",
+            "offers": [
+              { "offer_id": "VITTA-DEMO-OF2", "amount": 250000, "tenure_months": 48, "roi_annual_pct": 15.99, "emi": 7084, "processing_fee_pct": 1.5, "apr_pct": 17.5, "total_cost": 343782, "valid_till": "2026-08-31T23:59:59+05:30", "recommended": true, "why_recommended": "Lowest monthly EMI (₹7,084) — eases your immediate cash burden for a time-sensitive need." },
+              { "offer_id": "VITTA-DEMO-OF1", "amount": 250000, "tenure_months": 36, "roi_annual_pct": 15.99, "emi": 8788, "processing_fee_pct": 1.5, "apr_pct": 17.44, "total_cost": 320118, "valid_till": "2026-08-31T23:59:59+05:30", "recommended": false }
+            ]
+          }
+        }
+      ],
+      "tags": ["offers", "emi", "comparison"]
+    },
+    {
+      "uri": "/sanction-letter",
+      "name": "Sanction Letter",
+      "description": "Signed sanction letter document card with key numbers, SHA256 hash and download",
+      "examples": [
+        {
+          "name": "Sanctioned",
+          "description": "Demo sanction for the CONDITIONAL path",
+          "data": {
+            "url": "data/letters/VITTA-DEMO.html",
+            "hash": "2d9be8a583faff51aa00000000000000000000000000000000000000000000ff",
+            "valid_till": "2026-08-31T23:59:59+05:30",
+            "letter_fields": {
+              "borrower_name": "Priya Sharma",
+              "sanction_amount": 250000,
+              "roi_annual_pct": 15.99,
+              "apr_pct": 17.5,
+              "emi": 7084,
+              "tenure_months": 48,
+              "total_cost": 343782,
+              "first_emi_date": "2026-08-16",
+              "cooling_off_days": 3
+            }
+          }
+        }
+      ],
+      "tags": ["sanction", "document", "pdf"]
+    },
+    {
+      "uri": "/scenario-compare",
+      "name": "What-If Scenario",
+      "description": "Baseline vs what-if decision side-by-side: FOIR bars with the 55% cap line, outcome flip, amount delta",
+      "examples": [
+        {
+          "name": "Close existing EMIs → approved full amount",
+          "description": "Demo: closing ₹25,000/mo of existing EMIs flips CONDITIONAL to APPROVE",
+          "data": {
+            "baseline": {
+              "affordability": { "foir": 0.573, "proposed_emi": 10546, "net_income": 62000, "existing_emi": 25000 },
+              "decision": { "outcome": "CONDITIONAL", "max_amount": 250000, "score": 46, "reason_codes": ["FOIR_LIMIT"] }
+            },
+            "scenario": {
+              "affordability": { "foir": 0.17, "proposed_emi": 10546, "net_income": 62000, "existing_emi": 0 },
+              "decision": { "outcome": "APPROVE", "max_amount": 300000, "score": 62, "reason_codes": ["CLEAN_BUREAU"] },
+              "levers": { "close_existing_emi": 25000 }
+            },
+            "delta": {
+              "outcome_changed": true,
+              "outcome": "APPROVE",
+              "max_amount_change": 50000,
+              "foir_change_pct": -40.3,
+              "summary": "Outcome moves CONDITIONAL → APPROVE. Eligible amount rises by ₹50,000 to ₹3,00,000. FOIR moves 57% → 17%."
+            }
+          }
+        }
+      ],
+      "tags": ["what-if", "counterfactual", "explainability"]
+    }
+  ],
+  "generatedAt": "2026-07-17T00:00:00.000Z"
+}

--- a/sample-apps/vitta/tests/consent.test.ts
+++ b/sample-apps/vitta/tests/consent.test.ts
@@ -1,0 +1,95 @@
+/**
+ * consent.test.ts — written FIRST, before any gated tool (PLAN.md §5 Phase 1a).
+ * The repo history itself proves the consent gate was not bolted on.
+ *
+ * The gate is the product: pull_bureau / fetch_bank_statements must refuse
+ * without a valid, scoped, time-boxed consent token.
+ */
+import { describe, it, expect } from 'vitest';
+import { issueToken, validConsent, verifyToken, refusal, CONSENT_TTL_SECONDS } from '../src/lib/consent.js';
+
+const T0 = 1_752_700_000; // fixed epoch seconds for deterministic expiry tests
+
+describe('consent gate — the signature feature', () => {
+  it('(a) no token → CONSENT_REQUIRED', () => {
+    const c = validConsent(undefined, 'CREDIT_BUREAU', { now: T0 });
+    expect(c.ok).toBe(false);
+    if (!c.ok) expect(c.code).toBe('CONSENT_REQUIRED');
+    expect(refusal('CONSENT_REQUIRED').error).toBe('CONSENT_REQUIRED');
+  });
+
+  it('(a2) empty string / garbage → CONSENT_REQUIRED or CONSENT_INVALID', () => {
+    expect(validConsent('', 'CREDIT_BUREAU', { now: T0 }).ok).toBe(false);
+    expect(validConsent('not-a-token', 'CREDIT_BUREAU', { now: T0 }).ok).toBe(false);
+  });
+
+  it('(b) expired token (> 900s old) → CONSENT_EXPIRED', () => {
+    const { token } = issueToken({ lead_id: 'L1', version: 'v1', now: T0 });
+    const c = validConsent(token, 'CREDIT_BUREAU', { now: T0 + CONSENT_TTL_SECONDS + 1 });
+    expect(c.ok).toBe(false);
+    if (!c.ok) expect(c.code).toBe('CONSENT_EXPIRED');
+  });
+
+  it('(c) token without required scope → SCOPE_NOT_GRANTED', () => {
+    const { token } = issueToken({ lead_id: 'L1', scopes: ['KYC'], version: 'v1', now: T0 });
+    const c = validConsent(token, 'CREDIT_BUREAU', { now: T0 + 10 });
+    expect(c.ok).toBe(false);
+    if (!c.ok) expect(c.code).toBe('SCOPE_NOT_GRANTED');
+  });
+
+  it('(d) tampered token → CONSENT_INVALID', () => {
+    const { token } = issueToken({ lead_id: 'L1', version: 'v1', now: T0 });
+    const [body, mac] = token.split('.');
+    // flip the last hex char of the signature
+    const flipped = mac.slice(0, -1) + (mac.slice(-1) === 'a' ? 'b' : 'a');
+    const c = validConsent(`${body}.${flipped}`, 'CREDIT_BUREAU', { now: T0 + 10 });
+    expect(c.ok).toBe(false);
+    if (!c.ok) expect(c.code).toBe('CONSENT_INVALID');
+  });
+
+  it('(d2) tampered payload (re-scoped) is rejected — signature covers payload', () => {
+    const { token } = issueToken({ lead_id: 'L1', scopes: ['KYC'], version: 'v1', now: T0 });
+    const [, mac] = token.split('.');
+    const forgedBody = Buffer.from(
+      JSON.stringify({ jti: 'x', lead_id: 'L1', scopes: ['CREDIT_BUREAU'], iat: T0, exp: T0 + 900, version: 'v1' }),
+    )
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    const c = validConsent(`${forgedBody}.${mac}`, 'CREDIT_BUREAU', { now: T0 + 10 });
+    expect(c.ok).toBe(false);
+    if (!c.ok) expect(c.code).toBe('CONSENT_INVALID');
+  });
+
+  it('(e) valid, scoped, unexpired token → passes', () => {
+    const { token } = issueToken({ lead_id: 'L1', scopes: ['CREDIT_BUREAU', 'BANK_STATEMENTS'], version: 'v1', now: T0 });
+    expect(validConsent(token, 'CREDIT_BUREAU', { now: T0 + 60 }).ok).toBe(true);
+    expect(validConsent(token, 'BANK_STATEMENTS', { now: T0 + 60 }).ok).toBe(true);
+  });
+
+  it('(f1) token bound to lead — reusing lead-A token for lead-B → CONSENT_LEAD_MISMATCH', () => {
+    const { token } = issueToken({ lead_id: 'LEAD-A', version: 'v1', now: T0 });
+    // same token, different applicant → must refuse (no cross-applicant data leak)
+    const c = validConsent(token, 'CREDIT_BUREAU', { now: T0 + 60, leadId: 'LEAD-B' });
+    expect(c.ok).toBe(false);
+    if (!c.ok) expect(c.code).toBe('CONSENT_LEAD_MISMATCH');
+    // correct lead still passes
+    expect(validConsent(token, 'CREDIT_BUREAU', { now: T0 + 60, leadId: 'LEAD-A' }).ok).toBe(true);
+  });
+
+  it('(f) revoked token → CONSENT_REVOKED', () => {
+    const { token, payload } = issueToken({ lead_id: 'L1', version: 'v1', now: T0 });
+    const c = validConsent(token, 'CREDIT_BUREAU', { now: T0 + 60, isRevoked: (jti) => jti === payload.jti });
+    expect(c.ok).toBe(false);
+    if (!c.ok) expect(c.code).toBe('CONSENT_REVOKED');
+  });
+
+  it('verifyToken round-trips a fresh token', () => {
+    const { token, payload } = issueToken({ lead_id: 'LEAD-42', version: 'consent-v3', now: T0 });
+    const v = verifyToken(token);
+    expect(v.valid).toBe(true);
+    expect(v.payload?.lead_id).toBe('LEAD-42');
+    expect(v.payload?.jti).toBe(payload.jti);
+  });
+});

--- a/sample-apps/vitta/tests/emi.test.ts
+++ b/sample-apps/vitta/tests/emi.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { computeEmi, principalForEmi } from '../src/lib/emi.js';
+
+describe('EMI math (reducing balance)', () => {
+  it('pins ₹3,00,000 @ 15.99% for 36m (PLAN.md §5 Phase 2 range 10,545–10,650)', () => {
+    const emi = computeEmi(300000, 15.99, 36);
+    expect(emi).toBe(10546);
+    expect(emi).toBeGreaterThanOrEqual(10545);
+    expect(emi).toBeLessThanOrEqual(10650);
+  });
+
+  it('principalForEmi is the inverse of computeEmi (within rounding)', () => {
+    const p = principalForEmi(10546, 15.99, 36);
+    expect(Math.abs(p - 300000)).toBeLessThan(50);
+  });
+
+  it('zero interest → straight division', () => {
+    expect(computeEmi(120000, 0, 12)).toBe(10000);
+  });
+});

--- a/sample-apps/vitta/tests/goldenpath.test.ts
+++ b/sample-apps/vitta/tests/goldenpath.test.ts
@@ -1,0 +1,189 @@
+/**
+ * goldenpath.test.ts — drives the full path in-process for the three seeded
+ * identities, plus the consent-gate probe (judge Path D). PLAN.md §5 Phase 2.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { store } from '../src/lib/store.js';
+import {
+  qualifyLead, recordConsent, verifyKyc, screenFraud, pullBureau, fetchBankStatements,
+  computeAffordabilityStep, underwriteStep, generateOffersStep, createSanctionStep, getAuditTrail, revokeConsent,
+} from '../src/lib/engine.js';
+import type { ConsentRefusal } from '../src/lib/types.js';
+
+function isRefusal(x: unknown): x is ConsentRefusal {
+  return !!x && typeof x === 'object' && (x as any).error === 'CONSENT_REQUIRED';
+}
+
+/** Run intake through consent+kyc+fraud; return {lead_id, consent_token}. */
+function intake(session_id: string, pan: string, mobile: string, city = 'Kochi', purpose = 'medical emergency') {
+  const q = qualifyLead({ session_id, purpose, amount: 300000, tenure_months: 36, employment: 'SALARIED', city });
+  const c = recordConsent({ session_id, lead_id: q.lead_id, consent_text_version: 'consent-v3', accepted: true, channel: 'web' });
+  if (!c.accepted) throw new Error('consent failed');
+  verifyKyc({ session_id, lead_id: q.lead_id, pan, name: 'Test Applicant' });
+  screenFraud({ session_id, lead_id: q.lead_id, identifiers: { mobile, pan } });
+  return { lead_id: q.lead_id, consent_token: c.consent_token, intent_flag: q.intent_flag };
+}
+
+beforeEach(() => store._resetAll());
+
+describe('golden path — three deterministic stories', () => {
+  it('B: CONDITIONAL demo path (VITTA1235K / 9876543222) → ₹2.5L, FOIR ≈ 57%', () => {
+    const s = 'sess-cond';
+    const { lead_id, consent_token, intent_flag } = intake(s, 'VITTA1235K', '9876543222');
+    expect(intent_flag).toBe('FAST_TRACK'); // "medical emergency"
+
+    const bureau = pullBureau({ session_id: s, lead_id, consent_token, pan: 'VITTA1235K' });
+    expect(isRefusal(bureau)).toBe(false);
+    fetchBankStatements({ session_id: s, lead_id, consent_token, months: 12 });
+    const aff = computeAffordabilityStep({ session_id: s, lead_id });
+    expect(Math.round(aff.foir * 100)).toBe(57);
+
+    const decision = underwriteStep({ session_id: s, lead_id });
+    expect(decision.outcome).toBe('CONDITIONAL');
+    expect(decision.max_amount).toBe(250000);
+    expect(decision.reason_codes).toContain('FOIR_LIMIT');
+    expect(decision.explanations.join(' ')).toMatch(/instead of/i);
+
+    const offers = generateOffersStep({ session_id: s, lead_id });
+    expect(offers.offers.length).toBeGreaterThanOrEqual(1);
+    // FAST_TRACK → recommended is the lowest-EMI offer
+    const rec = offers.offers.find((o) => o.offer_id === offers.recommended_offer_id)!;
+    expect(Math.min(...offers.offers.map((o) => o.emi))).toBe(rec.emi);
+
+    const sanction = createSanctionStep({ session_id: s, lead_id, offer_id: offers.recommended_offer_id });
+    expect('hash' in sanction).toBe(true);
+  });
+
+  it('A: APPROVE path (PAN …0) → full amount, offers generated', () => {
+    const s = 'sess-appr';
+    const { lead_id, consent_token } = intake(s, 'AAAPA1230A', '9000000010', 'Mumbai', 'home renovation');
+    pullBureau({ session_id: s, lead_id, consent_token, pan: 'AAAPA1230A' });
+    fetchBankStatements({ session_id: s, lead_id, consent_token });
+    computeAffordabilityStep({ session_id: s, lead_id });
+    const decision = underwriteStep({ session_id: s, lead_id });
+    expect(decision.outcome).toBe('APPROVE');
+    expect(decision.max_amount).toBe(300000);
+    const offers = generateOffersStep({ session_id: s, lead_id });
+    expect(offers.offers.length).toBe(3);
+  });
+
+  it('C: DECLINE path (PAN …9) → adverse-action reasons, no offers', () => {
+    const s = 'sess-dec';
+    const { lead_id, consent_token } = intake(s, 'ZZZPZ1239Z', '9000000010', 'Mumbai', 'home renovation');
+    pullBureau({ session_id: s, lead_id, consent_token, pan: 'ZZZPZ1239Z' });
+    fetchBankStatements({ session_id: s, lead_id, consent_token });
+    computeAffordabilityStep({ session_id: s, lead_id });
+    const decision = underwriteStep({ session_id: s, lead_id });
+    expect(decision.outcome).toBe('DECLINE');
+    expect(decision.reason_codes.length).toBeGreaterThan(0);
+    expect(decision.explanations.length).toBeGreaterThan(0);
+    const offers = generateOffersStep({ session_id: s, lead_id });
+    expect(offers.offers.length).toBe(0);
+  });
+
+  it('DPDP revoke round-trip: record_consent returns jti → revoke → gated tool refuses CONSENT_REVOKED', () => {
+    const s = 'sess-revoke';
+    const { lead_id, consent_token } = intake(s, 'VITTA1235K', '9876543222');
+    // token works before revoke
+    const before = pullBureau({ session_id: s, lead_id, consent_token, pan: 'VITTA1235K' });
+    expect(isRefusal(before)).toBe(false);
+    // record_consent must have exposed a jti for revocation
+    const c = recordConsent({ session_id: s, lead_id, consent_text_version: 'consent-v3', accepted: true, channel: 'web' });
+    expect(c.accepted).toBe(true);
+    if (c.accepted) {
+      expect(typeof c.jti).toBe('string');
+      revokeConsent({ session_id: s, lead_id, jti: c.jti });
+      const after = pullBureau({ session_id: s, lead_id, consent_token: c.consent_token, pan: 'VITTA1235K' });
+      expect(isRefusal(after)).toBe(true);
+      if (isRefusal(after)) expect(after.code).toBe('CONSENT_REVOKED');
+    }
+  });
+
+  it('D: consent-gate probe — pull_bureau with no/garbage token refuses (judge probe)', () => {
+    const s = 'sess-gate';
+    const q = qualifyLead({ session_id: s, purpose: 'x', amount: 300000, tenure_months: 36, employment: 'SALARIED', city: 'Kochi' });
+    const noTok = pullBureau({ session_id: s, lead_id: q.lead_id, consent_token: undefined, pan: 'VITTA1235K' });
+    expect(isRefusal(noTok)).toBe(true);
+    if (isRefusal(noTok)) expect(noTok.code).toBe('CONSENT_REQUIRED');
+    const garbage = fetchBankStatements({ session_id: s, lead_id: q.lead_id, consent_token: 'garbage.token' });
+    expect(isRefusal(garbage)).toBe(true);
+  });
+
+  it('tenure re-negotiation: affordability override at 48m flows into underwrite (agent-found bug)', () => {
+    // A live Claude run exposed this: agent re-ran compute_affordability with
+    // tenure_months=48, but underwrite still used the stale case tenure and
+    // capped at the shorter tenure's amount. Overrides must persist to the case.
+    const s = 'sess-renego';
+    const { lead_id, consent_token } = intake(s, 'VITTA1235K', '9876543222');
+    pullBureau({ session_id: s, lead_id, consent_token, pan: 'VITTA1235K' });
+    fetchBankStatements({ session_id: s, lead_id, consent_token });
+
+    // first pass at 24 months → tight FOIR cap
+    computeAffordabilityStep({ session_id: s, lead_id, tenure_months: 24 });
+    const d24 = underwriteStep({ session_id: s, lead_id });
+    expect(d24.max_amount).toBeLessThan(250000);
+
+    // re-negotiate at 48 months → full ₹3L must be serviceable
+    computeAffordabilityStep({ session_id: s, lead_id, tenure_months: 48 });
+    const d48 = underwriteStep({ session_id: s, lead_id });
+    expect(d48.max_amount).toBe(300000);
+    expect(d48.outcome).toBe('CONDITIONAL'); // score band still needs review
+  });
+
+  it('every offer is itself FOIR-serviceable (agent-found bug #2)', () => {
+    // A shorter-tenure offer at max_amount can breach the FOIR cap that set
+    // max_amount. Demo pair: ₹2.5L @ 24m → EMI 12,237 → FOIR 60% > 55% cap.
+    const s = 'sess-foir-offers';
+    const { lead_id, consent_token } = intake(s, 'VITTA1235K', '9876543222');
+    pullBureau({ session_id: s, lead_id, consent_token, pan: 'VITTA1235K' });
+    fetchBankStatements({ session_id: s, lead_id, consent_token });
+    const aff = computeAffordabilityStep({ session_id: s, lead_id });
+    underwriteStep({ session_id: s, lead_id });
+    const { offers } = generateOffersStep({ session_id: s, lead_id });
+    expect(offers.length).toBeGreaterThanOrEqual(1);
+    for (const o of offers) {
+      const foir = (aff.existing_emi + o.emi) / aff.net_income;
+      expect(foir).toBeLessThanOrEqual(0.55 + 1e-9);
+    }
+    // the 24-month tenure specifically must have been filtered out
+    expect(offers.some((o) => o.tenure_months === 24)).toBe(false);
+  });
+
+  it('audit trail redacts PII — raw demo PAN never stored in clear', () => {
+    const s = 'sess-redact';
+    const { lead_id, consent_token } = intake(s, 'VITTA1235K', '9876543222');
+    pullBureau({ session_id: s, lead_id, consent_token, pan: 'VITTA1235K' });
+    const trail = getAuditTrail({ session_id: s });
+    const blob = JSON.stringify(trail);
+    expect(blob).not.toContain('VITTA1235K');
+    expect(blob).not.toContain('9876543222');
+    expect(trail.count).toBeGreaterThan(0);
+  });
+});
+
+describe('advance_application fast path', () => {
+  it('runs the whole post-consent chain in one call → CONDITIONAL ₹2.5L (demo)', async () => {
+    const { advanceApplication } = await import('../src/lib/engine.js');
+    store._resetAll();
+    const s = 'fastpath';
+    const q = qualifyLead({ session_id: s, purpose: 'medical emergency', amount: 300000, tenure_months: 36, employment: 'SALARIED', city: 'Kochi' });
+    const c = recordConsent({ session_id: s, lead_id: q.lead_id, consent_text_version: 'consent-v3', accepted: true, channel: 'web' });
+    if (!c.accepted) throw new Error('consent');
+    const r: any = advanceApplication({ session_id: s, lead_id: q.lead_id, consent_token: c.consent_token, pan: 'VITTA1235K', name: 'Priya Sharma', mobile: '9876543222' });
+    expect(r.error).toBeUndefined();
+    expect(r.outcome).toBe('CONDITIONAL');
+    expect(r.max_amount).toBe(250000);
+    expect(r.kyc_status).toBe('PASS');
+    expect(r.fraud_verdict).toBe('CLEAR');
+    expect(Math.round(r.foir * 100)).toBe(57);
+  });
+
+  it('fast path still enforces the consent gate (bad token → refusal)', async () => {
+    const { advanceApplication } = await import('../src/lib/engine.js');
+    store._resetAll();
+    const s = 'fastpath-gate';
+    const q = qualifyLead({ session_id: s, purpose: 'x', amount: 300000, tenure_months: 36, employment: 'SALARIED', city: 'Kochi' });
+    const r: any = advanceApplication({ session_id: s, lead_id: q.lead_id, consent_token: 'garbage', pan: 'VITTA1235K', name: 'Priya Sharma', mobile: '9876543222' });
+    expect(r.error).toBe('CONSENT_REQUIRED');
+  });
+});

--- a/sample-apps/vitta/tests/seeds.test.ts
+++ b/sample-apps/vitta/tests/seeds.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { panLastDigit, mobileSuffix, resolveBureau, resolveFraud, resolveCity } from '../src/lib/seeds.js';
+
+describe('deterministic seed mapping (CLAUDE.md rule 5)', () => {
+  it('demo PAN VITTA1235K → last digit 5 → CONDITIONAL bureau profile', () => {
+    expect(panLastDigit('VITTA1235K')).toBe('5');
+    const b = resolveBureau('VITTA1235K');
+    // CONDITIONAL: passes hard negatives but carries high existing EMI
+    expect(b.score).toBeGreaterThanOrEqual(680);
+    expect(b.dpd_max_12m).toBeLessThanOrEqual(30);
+    expect(b.writeoff_24m).toBe(false);
+    expect(b.inquiries_6m).toBeLessThanOrEqual(6);
+    expect(b.active_emi).toBeGreaterThan(20000);
+  });
+
+  it('demo mobile 9876543222 → suffix 22 (stable salaried band)', () => {
+    expect(mobileSuffix('9876543222')).toBe(22);
+  });
+
+  it('PAN ending 0 → APPROVE profile (clean, high score)', () => {
+    const b = resolveBureau('AAAPA1230A');
+    expect(b.score).toBeGreaterThanOrEqual(760);
+    expect(b.writeoff_24m).toBe(false);
+  });
+
+  it('PAN ending 9 → DECLINE profile (subprime + write-off + DPD)', () => {
+    const b = resolveBureau('ZZZPZ1239Z');
+    expect(b.score).toBeLessThan(680);
+    expect(b.writeoff_24m).toBe(true);
+    expect(b.dpd_max_12m).toBeGreaterThan(30);
+  });
+
+  it('fraud REVIEW at mobile suffix 99 (regression path E)', () => {
+    expect(resolveFraud('9000000099').verdict).toBe('REVIEW');
+    expect(resolveFraud('9876543222').verdict).toBe('CLEAR');
+  });
+
+  it('city serviceability', () => {
+    expect(resolveCity('Kochi').served).toBe(true);
+    expect(resolveCity('Atlantis').served).toBe(false);
+  });
+});

--- a/sample-apps/vitta/tests/simulate.test.ts
+++ b/sample-apps/vitta/tests/simulate.test.ts
@@ -1,0 +1,67 @@
+/**
+ * simulate.test.ts — What-If Simulator: deterministic counterfactuals,
+ * no case mutation, demo money-shot pinned.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { store } from '../src/lib/store.js';
+import {
+  qualifyLead, recordConsent, verifyKyc, screenFraud, pullBureau, fetchBankStatements,
+  computeAffordabilityStep, underwriteStep,
+} from '../src/lib/engine.js';
+import { simulateScenario } from '../src/lib/simulate.js';
+
+function runToUnderwrite(session_id: string) {
+  const q = qualifyLead({ session_id, purpose: 'medical emergency', amount: 300000, tenure_months: 36, employment: 'SALARIED', city: 'Kochi' });
+  const c = recordConsent({ session_id, lead_id: q.lead_id, consent_text_version: 'consent-v3', accepted: true, channel: 'web' });
+  if (!c.accepted) throw new Error('consent');
+  verifyKyc({ session_id, lead_id: q.lead_id, pan: 'VITTA1235K', name: 'Priya Sharma' });
+  screenFraud({ session_id, lead_id: q.lead_id, identifiers: { mobile: '9876543222' } });
+  pullBureau({ session_id, lead_id: q.lead_id, consent_token: c.consent_token, pan: 'VITTA1235K' });
+  fetchBankStatements({ session_id, lead_id: q.lead_id, consent_token: c.consent_token });
+  computeAffordabilityStep({ session_id, lead_id: q.lead_id });
+  underwriteStep({ session_id, lead_id: q.lead_id });
+  return q.lead_id;
+}
+
+beforeEach(() => store._resetAll());
+
+describe('what-if simulator', () => {
+  it('baseline CONDITIONAL — closing all ₹25k EMIs flips to APPROVE at full ₹3L', () => {
+    const lead_id = runToUnderwrite('sim-1');
+    const r = simulateScenario({ lead_id, close_existing_emi: 25000 });
+    expect(r.baseline.decision.outcome).toBe('CONDITIONAL');
+    expect(r.scenario.decision.outcome).toBe('APPROVE');
+    expect(r.scenario.decision.max_amount).toBe(300000);
+    expect(r.delta.outcome_changed).toBe(true);
+    expect(r.delta.summary).toMatch(/CONDITIONAL → APPROVE/);
+  });
+
+  it('closing only ₹14k unlocks the FULL ₹3L but keeps human review (CONDITIONAL)', () => {
+    const lead_id = runToUnderwrite('sim-1b');
+    const r = simulateScenario({ lead_id, close_existing_emi: 14000 });
+    expect(r.scenario.decision.outcome).toBe('CONDITIONAL');
+    expect(r.scenario.decision.max_amount).toBe(300000); // amount unlocked
+    expect(r.delta.max_amount_change).toBe(50000);
+  });
+
+  it('higher income lever raises the eligible amount', () => {
+    const lead_id = runToUnderwrite('sim-2');
+    const r = simulateScenario({ lead_id, net_income: 90000 });
+    expect(r.scenario.decision.max_amount).toBeGreaterThan(r.baseline.decision.max_amount);
+    expect(r.scenario.affordability.foir).toBeLessThan(r.baseline.affordability.foir);
+  });
+
+  it('does NOT mutate the stored case (pure counterfactual)', () => {
+    const lead_id = runToUnderwrite('sim-3');
+    const before = JSON.stringify(store.getCase(lead_id)!.decision);
+    simulateScenario({ lead_id, close_existing_emi: 14000, net_income: 90000 });
+    const after = JSON.stringify(store.getCase(lead_id)!.decision);
+    expect(after).toBe(before);
+  });
+
+  it('longer tenure lowers proposed EMI in the scenario', () => {
+    const lead_id = runToUnderwrite('sim-4');
+    const r = simulateScenario({ lead_id, tenure_months: 48 });
+    expect(r.scenario.affordability.proposed_emi).toBeLessThan(r.baseline.affordability.proposed_emi);
+  });
+});

--- a/sample-apps/vitta/tsconfig.json
+++ b/sample-apps/vitta/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022"],
+    "moduleResolution": "node",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/widgets"]
+}
+

--- a/sample-apps/vitta/vitest.config.ts
+++ b/sample-apps/vitta/vitest.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vitest/config';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+/**
+ * Runtime source uses `.js` import specifiers (required for emitted Node ESM).
+ * This plugin maps `./foo.js` → `./foo.ts` so Vitest can resolve TS sources.
+ */
+export default defineConfig({
+  plugins: [
+    {
+      name: 'resolve-js-to-ts',
+      enforce: 'pre',
+      resolveId(source: string, importer?: string) {
+        if (importer && source.endsWith('.js') && (source.startsWith('./') || source.startsWith('../'))) {
+          const tsPath = resolve(dirname(importer), source.replace(/\.js$/, '.ts'));
+          if (existsSync(tsPath)) return tsPath;
+        }
+        return null;
+      },
+    },
+  ],
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Vitta — agentic NBFC lending, with consent enforced in code

Vitta takes an NBFC personal-loan borrower from *"hi"* to a **signed sanction letter** as an MCP server — qualify → consent → KYC → fraud → credit bureau → bank → explainable underwriting → priced offers → sanction → audit.

**Signature idea — consent-as-code:** `pull_bureau` and `fetch_bank_statements` physically refuse to run without a valid, scoped, time-boxed, revocable, **applicant-bound** HMAC consent token. No prompt can talk the AI past it — DPDP compliance enforced at the tool layer, not in a system prompt.

### Highlights
- **All three MCP primitives:** 17 Tools · 5 Resources · 5 Prompts, plus 4 rich React widgets (decision gauge, offer cards, signed letter, what-if compare).
- **Explainable, no black box:** rules + a pre-baked scorecard → reason codes → borrower-friendly text (EN / HI / ML).
- **What-if simulator:** `simulate_scenario` re-runs the *real* underwriting with one changed lever — turns a decline into a roadmap — without mutating the application.
- **Hardened:** survives 5 adversarial probes (cross-lead token reuse → `CONSENT_LEAD_MISMATCH`, forged tokens, scope escalation, social-engineering, PII exfiltration). PII redacted at write-time in an immutable audit trail.
- **100% Nitrostack-native** — scaffolded with the CLI, tested in NitroStudio, deployed on NitroCloud, wired to NitroChat. `advance_application` collapses the post-consent chain into one call for reliable agentic runs.
- **Verified:** 34 unit/golden-path/consent tests · 6/6 edge-path regression · 11/11 live production checks. No real PII, no real financial APIs — all deterministic synthetic mocks.

### Links
- 🌐 **Live demo:** https://vitta-6a5a5835-the-beetles-amrita-university-amritapuri-campus.app.nitrocloud.ai
- 📦 **Original repository:** https://github.com/AnshBajpai05/NitroStack-Hackathon

Built by **Team The Beetles** — 🏆 winner of the Amrita University MCP Hackathon 2026 (BFSI & FinTech track). Added under `sample-apps/vitta/`.