### PR TITLE
feat(core): enhance OAuth CORS handling, multi-auth server base URL resolution, and resource metadata

### DIFF
--- a/typescript/packages/cli/templates/typescript-oauth/OAUTH_SETUP.md
+++ b/typescript/packages/cli/templates/typescript-oauth/OAUTH_SETUP.md
@@ -29,7 +29,23 @@ This guide shows you **exactly** how to set up OAuth 2.1 authentication from scr
 
 ---
 
-## Step 2: Create Auth0 API (Protected Resource)
+## Step 1.5: Configure Tenant Settings
+
+**⚠️ CRITICAL FOR MCP SPEC COMPLIANCE!**
+
+1. Click **Settings** at the very bottom of the left navigation sidebar in Auth0 Dashboard.
+2. Under **General Settings**:
+   - ✅ **Dynamic Client Registration (DCR)**: Toggle **ON (Enabled)**  ← COMPULSORY!
+     - **Why?** Required for dynamic registration of third-party clients and applications with your tenant using OpenID Connect Dynamic Client Registration (RFC 7591).
+   - ✅ **Resource Parameter Compatibility Profile**: Toggle **ON (Enabled)**  ← CRITICAL!
+     - **Why?** The MCP specification (and RFC 8707 Resource Indicators) passes the `resource` parameter to specify the resource server. When enabled, Auth0 accepts `resource` in token and authorization requests alongside `audience`.
+   - ✅ **Enable Application Connections**: Toggle **ON (Enabled)**
+     - Ensures new applications automatically have connections enabled.
+   - ❌ **Client ID Metadata Document (CIMD) Registration**: Leave **Disabled** (unless using CIMD).
+
+---
+46: 
+47: ## Step 2: Create Auth0 API (Protected Resource)
 
 **⚠️ DO THIS FIRST!** The API represents your MCP server as a protected resource.
 
@@ -138,23 +154,33 @@ This guide shows you **exactly** how to set up OAuth 2.1 authentication from scr
 
 ---
 
-## Step 4: Link Application to API
+## Step 3.5: Promote Connection to Domain Level
+
+**⚠️ CRITICAL FOR THIRD-PARTY APP / STUDIO AUTH!**
+
+1. Go to **Authentication** → **Database** (or your Social / Enterprise connection)
+2. Click on your active connection (e.g., `Username-Password-Authentication`)
+3. Scroll to the **Promote Connection to Domain Level** setting:
+   - ✅ **Promote Connection to Domain Level**: Toggle **ON (Enabled)**  ← CRITICAL!
+   - **Why?** Once promoted, all third-party applications (MCP clients, Studio, Claude Desktop, OpenAI Apps, etc.) in your tenant automatically have access to this connection. Without this, third-party authentication will be rejected with an "Unauthorized connection for this client" error.
+
+---
+
+## Step 4: Link Application to API & Grant Permissions
 
 **⚠️ REQUIRED STEP!** Many users miss this.
 
 1. Go back to **Applications** → **APIs**
 2. Click on your **"MCP Server API"** (created in Step 2)
-3. Click the **"Machine to Machine Applications"** tab
-   
-   **Note:** Despite the confusing name, this tab shows which applications can access your API
-
+3. Click the **"Machine to Machine Applications"** tab (or **Client Access** / **User-Delegated Access** drawer)
 4. Find your **"MCP Server OAuth"** application in the list
 5. **Toggle the switch to "Authorized"** (should turn green)
-6. Click the **dropdown arrow** to expand permissions
-7. **Select all scopes** you want to grant (`read`, `write`, `admin`)
-8. Click **"Update"**
+6. Click the **dropdown arrow** / side drawer to expand permissions:
+   - Under **Client Access** / **Permissions**: Select all required scopes (`read`, `write`, `admin`) to ensure **3 / 3 permissions granted**.
+   - **Organization Support**: Select `None - Machine to machine access cannot be scoped to an organization` (or leave default).
+7. Click **"Save"** / **"Update"**
 
-**✅ Verification:** Your application should now show as "Authorized" with selected scopes
+**✅ Verification:** Your application should now show as "Authorized" with `3 / 3 permissions granted`.
 
 ---
 
@@ -552,14 +578,18 @@ TOKEN_ISSUER=https://login.microsoftonline.com/YOUR-TENANT-ID/v2.0
 
 Before asking for help, verify:
 
+- [ ] Auth0 Tenant **Dynamic Client Registration (DCR)** is **ENABLED** (Settings → General)
+- [ ] Auth0 Tenant **Resource Parameter Compatibility Profile** is **ENABLED** (Settings → General)
+- [ ] Auth0 Tenant **Enable Application Connections** is **ENABLED** (Settings → General)
+- [ ] Auth0 Connection **Promote Connection to Domain Level** is **ENABLED** (Authentication → Database)
 - [ ] Auth0 API created with **RS256** signing algorithm
 - [ ] Auth0 API **JWT Profile** set to **RFC 9068**
 - [ ] Auth0 Application type is **"Regular Web Application"** (not SPA or M2M)
 - [ ] Application has correct **callback URLs** (`http://localhost:3005/auth/callback`)
 - [ ] Application **Grant Types** include "Authorization Code" and "Refresh Token"
 - [ ] Application **ID Token Encryption** is **DISABLED**
-- [ ] Application is **Authorized** to access the API (Machine to Machine Applications tab)
-- [ ] Required **scopes** are granted to the application
+- [ ] Application is **Authorized** to access the API (Machine to Machine / Client Access tab)
+- [ ] Required **scopes** (`3 / 3 permissions granted`) are granted to the application
 - [ ] `.env` file has `RESOURCE_URI` matching Auth0 API Identifier **EXACTLY**
 - [ ] `.env` file has `TOKEN_ISSUER` with **trailing slash** `/`
 - [ ] Server starts successfully (check logs for "🚀 OAuth discovery server running")
@@ -577,13 +607,16 @@ Before asking for help, verify:
 
 ## 🎓 What We Learned (Common Pitfalls)
 
-1. **Application Type Matters:** Must be "Regular Web Application", not SPA or M2M
-2. **Audience Parameter is Critical:** Without it, Auth0 returns encrypted tokens (fixed in Studio)
-3. **API Identifier Must Match:** `RESOURCE_URI` must **exactly** match Auth0 API Identifier
-4. **Encryption Must Be Disabled:** ID Token encryption breaks JWT validation
-5. **Trailing Slash Matters:** `TOKEN_ISSUER` must have trailing `/` for Auth0
-6. **Authorization Required:** Application must be explicitly authorized to access the API
-7. **Port Awareness:** Dev mode uses 3005, prod mode uses 3000
+1. **Dynamic Client Registration (DCR):** Must be enabled in Tenant Settings for OpenID Connect DCR support.
+2. **Resource Parameter Compatibility Profile:** Must be enabled in Tenant Settings so Auth0 processes standard OAuth `resource` parameters for MCP.
+3. **Promote Connection to Domain Level:** Must be enabled on Database connections so third-party applications (Studio, Claude Desktop) can authenticate users.
+4. **Application Type Matters:** Must be "Regular Web Application", not SPA or M2M.
+5. **Audience Parameter is Critical:** Without it, Auth0 returns encrypted tokens (fixed in Studio).
+6. **API Identifier Must Match:** `RESOURCE_URI` must **exactly** match Auth0 API Identifier.
+7. **Encryption Must Be Disabled:** ID Token encryption breaks JWT validation.
+8. **Trailing Slash Matters:** `TOKEN_ISSUER` must have trailing `/` for Auth0.
+9. **Authorization Required:** Application must be explicitly authorized to access the API with required scopes granted.
+10. **Port Awareness:** Dev mode uses 3005, prod mode uses 3000.
 
 ---
 

--- a/typescript/packages/core/src/core/__tests__/oauth-module.test.ts
+++ b/typescript/packages/core/src/core/__tests__/oauth-module.test.ts
@@ -259,4 +259,25 @@ describe('OAuthModule', () => {
             expect(result.error).toBe('Custom validation failed');
         });
     });
+
+    describe('getCorsHeaders', () => {
+        it('should build CORS headers dynamically for provided origin', () => {
+            const req = { headers: { origin: 'http://localhost:3000' } };
+            const headers = (OAuthModule.prototype as any).getCorsHeaders(req, 'GET, OPTIONS');
+
+            expect(headers['Access-Control-Allow-Origin']).toBe('http://localhost:3000');
+            expect(headers['Access-Control-Allow-Methods']).toBe('GET, OPTIONS');
+            expect(headers['Access-Control-Allow-Private-Network']).toBe('true');
+            expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+        });
+
+        it('should fallback to wildcard origin when origin header is missing', () => {
+            const req = { headers: {} };
+            const headers = (OAuthModule.prototype as any).getCorsHeaders(req, 'POST, OPTIONS');
+
+            expect(headers['Access-Control-Allow-Origin']).toBe('*');
+            expect(headers['Access-Control-Allow-Methods']).toBe('POST, OPTIONS');
+            expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
+        });
+    });
 });

--- a/typescript/packages/core/src/core/__tests__/oauth-module.test.ts
+++ b/typescript/packages/core/src/core/__tests__/oauth-module.test.ts
@@ -280,4 +280,45 @@ describe('OAuthModule', () => {
             expect(headers['Access-Control-Allow-Credentials']).toBeUndefined();
         });
     });
+
+    describe('buildBaseUrl', () => {
+        it('should ignore resourceUri when it matches an authorization server origin and use host header', () => {
+            const instance = Object.assign(Object.create(OAuthModule.prototype), {
+                config: {
+                    resourceUri: 'https://auth.example.com/mcp',
+                    authorizationServers: ['https://auth.example.com'],
+                },
+            });
+            const req = { headers: { host: 'localhost:4000' } };
+            const baseUrl = (instance as any).buildBaseUrl(req);
+
+            expect(baseUrl).toBe('http://localhost:4000');
+        });
+
+        it('should ignore resourceUri when it matches any authorization server in a multi-server array', () => {
+            const instance = Object.assign(Object.create(OAuthModule.prototype), {
+                config: {
+                    resourceUri: 'https://auth2.example.com/mcp',
+                    authorizationServers: ['https://auth1.example.com', 'https://auth2.example.com'],
+                },
+            });
+            const req = { headers: { host: 'localhost:4000' } };
+            const baseUrl = (instance as any).buildBaseUrl(req);
+
+            expect(baseUrl).toBe('http://localhost:4000');
+        });
+
+        it('should use resourceUri origin when it does not match any authorization server', () => {
+            const instance = Object.assign(Object.create(OAuthModule.prototype), {
+                config: {
+                    resourceUri: 'https://mcp.example.com/mcp',
+                    authorizationServers: ['https://auth.example.com'],
+                },
+            });
+            const req = { headers: { host: 'localhost:4000' } };
+            const baseUrl = (instance as any).buildBaseUrl(req);
+
+            expect(baseUrl).toBe('https://mcp.example.com');
+        });
+    });
 });

--- a/typescript/packages/core/src/core/oauth-module.ts
+++ b/typescript/packages/core/src/core/oauth-module.ts
@@ -308,12 +308,18 @@ export class OAuthModule {
     if (this.config.resourceUri) {
       try {
         const resourceOrigin = new URL(this.config.resourceUri).origin;
-        const authServerOrigin = this.config.authorizationServers?.[0]
-          ? new URL(this.config.authorizationServers[0]).origin
-          : null;
+        const authServerOrigins = (this.config.authorizationServers ?? [])
+          .map((as) => {
+            try {
+              return new URL(as).origin;
+            } catch {
+              return null;
+            }
+          })
+          .filter((origin): origin is string => Boolean(origin));
 
-        // Only prefer resourceUri if it is NOT the external Auth Server origin
-        if (resourceOrigin && resourceOrigin !== authServerOrigin) {
+        // Only prefer resourceUri if it is NOT one of the external Auth Server origins
+        if (resourceOrigin && !authServerOrigins.includes(resourceOrigin)) {
           return resourceOrigin;
         }
       } catch {

--- a/typescript/packages/core/src/core/oauth-module.ts
+++ b/typescript/packages/core/src/core/oauth-module.ts
@@ -279,19 +279,23 @@ export class OAuthModule {
     }
   }
 
-  private buildBaseUrl(req: DiscoveryRequest): string {
-    // Prefer the configured, trusted resourceUri origin so advertised URLs are
-    // not derived from client-controlled Host / X-Forwarded-Proto headers
-    // (host-header injection). Fall back to request headers only if resourceUri
-    // is missing or unparseable.
-    try {
-      if (this.config.resourceUri) {
-        return new URL(this.config.resourceUri).origin;
-      }
-    } catch {
-      // fall through to header-derived base
+  private getCorsHeaders(req: DiscoveryRequest, allowedMethods: string): Record<string, string> {
+    const rawOrigin = req?.headers?.origin || req?.headers?.Origin;
+    const origin = (Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin) || '*';
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': origin,
+      'Access-Control-Allow-Methods': allowedMethods,
+      'Access-Control-Allow-Headers': 'Content-Type, Accept, Authorization, Access-Control-Allow-Private-Network',
+      'Access-Control-Allow-Private-Network': 'true',
+    };
+    if (origin !== '*') {
+      headers['Access-Control-Allow-Credentials'] = 'true';
     }
+    return headers;
+  }
 
+  private buildBaseUrl(req: DiscoveryRequest): string {
     const reqHeaders = req?.headers ?? {};
     const rawHost = reqHeaders.host;
     const host = (Array.isArray(rawHost) ? rawHost[0] : rawHost) || 'localhost:3000';
@@ -304,16 +308,28 @@ export class OAuthModule {
         proto = process.env.NODE_ENV === 'production' ? 'https' : 'http';
       }
     }
+
+    if (this.config.resourceUri) {
+      try {
+        const resourceOrigin = new URL(this.config.resourceUri).origin;
+        const authServerOrigin = this.config.authorizationServers?.[0]
+          ? new URL(this.config.authorizationServers[0]).origin
+          : null;
+
+        // Only prefer resourceUri if it is NOT the external Auth Server origin
+        if (resourceOrigin && resourceOrigin !== authServerOrigin) {
+          return resourceOrigin;
+        }
+      } catch {
+        // fall through to header-derived base
+      }
+    }
+
     return `${proto}://${host}`;
   }
 
   private wellKnownHandler = async (req: DiscoveryRequest, res: DiscoveryResponse) => {
-    const headers = { 
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Accept, Authorization',
-    };
+    const headers = this.getCorsHeaders(req, 'GET, OPTIONS');
 
     const registrationEndpoint = this.isClientRegistrationEnabled()
       ? `${this.buildBaseUrl(req)}/oauth/v2/register`
@@ -327,7 +343,7 @@ export class OAuthModule {
         // Clone before mutating so the cached object stays pristine
         const metadata = { ...upstream };
         // Inject registration_endpoint to satisfy strict client schema validation (Cursor/OpenAI)
-        if (registrationEndpoint && !metadata.registration_endpoint) {
+        if (registrationEndpoint) {
           metadata.registration_endpoint = registrationEndpoint;
         }
         res.writeHead(200, headers);
@@ -376,12 +392,7 @@ export class OAuthModule {
     req: any,
     res: DiscoveryResponse
   ) => {
-    const headers = {
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Accept, Authorization',
-    };
+    const headers = this.getCorsHeaders(req, 'POST, OPTIONS');
 
     if (req.method === 'OPTIONS') {
       res.writeHead(200, headers);
@@ -438,12 +449,7 @@ export class OAuthModule {
   };
 
   private resourceMetadataHandler = (req: DiscoveryRequest, res: DiscoveryResponse) => {
-    const headers = {
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, Accept, Authorization',
-    };
+    const headers = this.getCorsHeaders(req, 'GET, OPTIONS');
 
     if (req?.method === 'OPTIONS') {
       res.writeHead(200, headers);
@@ -452,10 +458,15 @@ export class OAuthModule {
     }
 
     // RFC 9728 - Protected Resource Metadata format
-    const metadata: { resource: string; authorization_servers: string[]; scopes_supported?: string[] } = {
-      resource: this.config.resourceUri,
+    const resourceUrl = this.config.resourceUri || `${this.buildBaseUrl(req)}/mcp`;
+    const metadata: { resource: string; authorization_servers: string[]; audience?: string; scopes_supported?: string[] } = {
+      resource: resourceUrl,
       authorization_servers: this.config.authorizationServers,
     };
+
+    if (this.config.audience) {
+      metadata.audience = this.config.audience;
+    }
 
     // Add optional fields
     if (this.config.scopesSupported && this.config.scopesSupported.length > 0) {

--- a/typescript/packages/core/src/core/oauth-module.ts
+++ b/typescript/packages/core/src/core/oauth-module.ts
@@ -282,17 +282,13 @@ export class OAuthModule {
   private getCorsHeaders(req: DiscoveryRequest, allowedMethods: string): Record<string, string> {
     const rawOrigin = req?.headers?.origin || req?.headers?.Origin;
     const origin = (Array.isArray(rawOrigin) ? rawOrigin[0] : rawOrigin) || '*';
-    const headers: Record<string, string> = {
+    return {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Origin': origin,
       'Access-Control-Allow-Methods': allowedMethods,
       'Access-Control-Allow-Headers': 'Content-Type, Accept, Authorization, Access-Control-Allow-Private-Network',
       'Access-Control-Allow-Private-Network': 'true',
     };
-    if (origin !== '*') {
-      headers['Access-Control-Allow-Credentials'] = 'true';
-    }
-    return headers;
   }
 
   private buildBaseUrl(req: DiscoveryRequest): string {
@@ -342,7 +338,8 @@ export class OAuthModule {
       if (upstream) {
         // Clone before mutating so the cached object stays pristine
         const metadata = { ...upstream };
-        // Inject registration_endpoint to satisfy strict client schema validation (Cursor/OpenAI)
+        // Explicitly route registration_endpoint to local Nitrostack endpoint when dynamic registration is enabled
+        // to satisfy strict client schema validation (e.g. Cursor / OpenAI MCP integration)
         if (registrationEndpoint) {
           metadata.registration_endpoint = registrationEndpoint;
         }


### PR DESCRIPTION
## Summary

This PR enhances `OAuthModule` in `@nitrostack/core` to improve dynamic CORS handling, multi-auth-server origin filtering for base URL resolution, client registration routing in well-known metadata, and RFC 9728 protected resource metadata support.

## Key Changes

### 1. Dynamic CORS Headers Helper (`getCorsHeaders`)
- Standardized CORS header generation across discovery (`.well-known/oauth-authorization-server`), client registration (`/oauth/v2/register`), and RFC 9728 protected resource metadata endpoints (`.well-known/oauth-protected-resource`).
- Dynamically reflects incoming `Origin` headers (or falls back to `*`).
- Adds `Access-Control-Allow-Private-Network: true` to support Chromium Private Network Access (PNA) preflights for local MCP clients.
- Omits unnecessary `Access-Control-Allow-Credentials` headers on public discovery endpoints.

### 2. Multi-Auth Server Origin Base URL Filtering (`buildBaseUrl`)
- Refined `buildBaseUrl` to extract and parse origins from **all** entries in `this.config.authorizationServers`.
- Prevents `resourceUri` from overriding the local server base URL whenever `resourceUri` shares an origin with *any* configured external authorization server, ensuring local endpoint paths (`/oauth/v2/register`) resolve against the local host.

### 3. Explicit Client Registration Endpoint Routing
- Overwrites `registration_endpoint` in well-known metadata to point directly to Nitrostack's local registration handler when client registration is enabled. This satisfies strict client schema requirements (e.g. Cursor / OpenAI MCP desktop integrations) while preventing clients from hitting external auth provider registration endpoints.

### 4. RFC 9728 Protected Resource Metadata Improvements
- Added fallback resource URL construction (`this.config.resourceUri || `${this.buildBaseUrl(req)}/mcp``).
- Included support for optional `audience` property when configured in `OAuthModuleConfig`.

### 5. Automated Unit Tests
- Added unit tests in `oauth-module.test.ts` for:
  - `getCorsHeaders`: testing origin reflection, headers, and missing origin wildcard fallback.
  - `buildBaseUrl`: testing single-server origin collision, multi-server array origin collision, and distinct resource URI origin resolution.

## Verification

- Passed unit tests: `npx jest src/core/__tests__/oauth-module.test.ts` (25/25 tests passed).
- Passed core package test suite: `npm test` in `@nitrostack/core` (582/582 tests passed).