### PR TITLE
fix: respect system theme and reduced motion preferences

### DIFF
--- a/typescript/packages/core/src/core/transports/streamable-http.ts
+++ b/typescript/packages/core/src/core/transports/streamable-http.ts
@@ -732,6 +732,17 @@ export class StreamableHttpTransport {
       transition: background 0.3s, color 0.3s;
     }
     
+
+@media (prefers-reduced-motion: reduce) {
+  body,
+  .tool-card {
+    transition: none;
+  }
+
+  .tool-card:hover {
+    transform: none;
+  }
+}
     .wrapper {
       width: 100%;
       max-width: 960px;
@@ -1998,9 +2009,12 @@ url = "${mcpEndpoint}"</pre>
     
     // Set Initial Theme
     (function() {
-      const savedTheme = localStorage.getItem('theme') || 'dark';
-      document.documentElement.className = savedTheme;
-    })();
+    const savedTheme = localStorage.getItem('theme');
+    const preferredTheme =
+      window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+
+    document.documentElement.className = savedTheme || preferredTheme;
+})();
 
     // Dynamically update localhost to current origin if served over HTTP/HTTPS
     (function() {


### PR DESCRIPTION
## Description

Improves dark mode and motion accessibility on the bundled MCP documentation page. The page now respects the user's system color scheme when no theme preference has been saved, while preserving the existing manual theme toggle.

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Internal code change
- [ ] test: Test-only changes
- [ ] chore: Build, CI, or tooling changes

## Related Issues

Closes #23

## Changes Made

- Use `prefers-color-scheme` to select the initial theme when no saved preference exists.
- Respect `prefers-reduced-motion` by disabling non-essential transitions.
- Disable the `.tool-card` hover transform when reduced motion is enabled.
- Preserve saved light/dark theme preferences.

## Testing

- Core test suite passes successfully.
- 50 test suites passed.
- 577 tests passed.