### PR TITLE
Add Agentic Commerce Gateway sample app

### DIFF
--- a/sample-apps/agentic-commerce-gateway/.agents/skills/auth-security/SKILL.md
+++ b/sample-apps/agentic-commerce-gateway/.agents/skills/auth-security/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: nitrostack-auth-security
+description: Best practices for implementing JWT, API Keys, OAuth 2.1, and RBAC in a NitroStack application.
+---
+
+## When to Use
+Use this skill when configuring security modules, implementing user authentication, restricting tool access via guards, or handling sensitive tokens.
+
+---
+
+## 1. JSON Web Tokens (JWT)
+To secure tools with JWT authentication:
+
+### Register `JWTModule`:
+```typescript
+import { JWTModule, Module, McpApp } from '@nitrostack/core';
+
+@McpApp({
+  server: { name: 'my-server', version: '1.0.0' }
+})
+@Module({
+  imports: [
+    JWTModule.forRoot({
+      secret: process.env.JWT_SECRET!,
+      expiresIn: '7d',
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### Write a `JWTGuard`:
+```typescript
+import { Guard, ExecutionContext, Injectable, ConfigService } from '@nitrostack/core';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class JWTGuard implements Guard {
+  constructor(private config: ConfigService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const token = this.extractToken(context);
+    if (!token) return false;
+
+    try {
+      const secret = this.config.get('JWT_SECRET');
+      const payload = jwt.verify(token, secret) as any;
+      context.auth = {
+        subject: payload.sub,
+        role: payload.role,
+        token,
+      };
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private extractToken(context: ExecutionContext): string | null {
+    const auth = context.metadata?.authorization;
+    if (auth?.startsWith('Bearer ')) {
+      return auth.substring(7);
+    }
+    return null;
+  }
+}
+```
+
+---
+
+## 2. API Key Authentication
+Use `ApiKeyModule` for service-to-service validation.
+
+### Register `ApiKeyModule`:
+```typescript
+import { ApiKeyModule, Module } from '@nitrostack/core';
+
+@Module({
+  imports: [
+    ApiKeyModule.forRoot({
+      keysEnvPrefix: 'API_KEY', // Reads API_KEY_1, API_KEY_2, etc.
+      headerName: 'x-api-key',
+      hashed: false,
+    }),
+  ]
+})
+export class AppModule {}
+```
+
+### API Key Guard:
+```typescript
+import { Guard, ExecutionContext, ApiKeyModule } from '@nitrostack/core';
+
+export class ApiKeyGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const apiKey = context.metadata?.['x-api-key'] || context.metadata?.apiKey;
+    if (!apiKey) return false;
+
+    const isValid = await ApiKeyModule.validate(apiKey as string);
+    if (isValid) {
+      context.auth = {
+        subject: `apikey_${(apiKey as string).substring(0, 10)}`,
+        scopes: ['*'],
+      };
+      return true;
+    }
+    return false;
+  }
+}
+```
+
+---
+
+## 3. Role-Based Access Control (RBAC)
+Chain guards sequentially to implement user-role authorization.
+
+```typescript
+import { Injectable, Guard, ExecutionContext, UseGuards, Tool, z } from '@nitrostack/core';
+import { JWTGuard } from './jwt.guard.js';
+
+@Injectable()
+export class AdminGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Requires JWTGuard to have populated context.auth first
+    return context.auth?.role === 'admin';
+  }
+}
+
+// Applying chained guards to a tool
+export class SystemTools {
+  @Tool({
+    name: 'reset_database',
+    description: 'Dangerous action: wipes database. Admin only.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(JWTGuard, AdminGuard) // Chain auth first, then role check
+  async resetDatabase() {
+    return { success: true };
+  }
+}
+```

--- a/sample-apps/agentic-commerce-gateway/.agents/skills/mcp-app-architecture/SKILL.md
+++ b/sample-apps/agentic-commerce-gateway/.agents/skills/mcp-app-architecture/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: nitrostack-mcp-app-architecture
+description: Best practices and guidelines for bootstrapping, defining modules, using dependency injection, managing server lifecycles, and handling events in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill whenever you are bootstrapping a new NitroStack MCP server, creating modules, injecting services, or handling application lifecycle events.
+
+## Bootstrapping a NitroStack App
+A NitroStack application is initialized with the `@McpApp` decorator on a root class, accompanied by a root `@Module`.
+
+```typescript
+import { McpApp, Module } from '@nitrostack/core';
+import { DatabaseModule } from './database/database.module.js';
+import { UsersModule } from './users/users.module.js';
+
+@McpApp({
+  module: AppModule,
+  server: {
+    name: 'user-management-server',
+    version: '1.0.0',
+  },
+})
+@Module({
+  imports: [DatabaseModule, UsersModule],
+})
+export class AppModule {}
+```
+
+## Modules
+Modules organize your application structure. Use the `@Module` decorator to define imports, exports, and providers.
+
+* **`imports`**: Other modules whose exported providers should be available in this module.
+* **`providers`**: Services, tools, resources, or prompts that should be instantiated and managed by the DI container within this module.
+* **`exports`**: Providers defined in this module that should be visible to other modules importing this one.
+
+```typescript
+import { Module } from '@nitrostack/core';
+import { UsersService } from './users.service.js';
+import { UsersTools } from './users.tools.js';
+
+@Module({
+  providers: [UsersService, UsersTools],
+  exports: [UsersService],
+})
+
+## Controllers
+Use the `@ControllerDecorator` (or alias it as `@Controller`) to group tools, resources, and prompts together. Controllers are automatically registered as singletons in the DI container.
+
+### Key Controller Options:
+* **`prefix`**: A string prefix applied to every `@Tool` defined in this controller. For example, `@ControllerDecorator('github')` prefixing a tool named `create_issue` exposes it to MCP clients as `github_create_issue`.
+
+```typescript
+import { ControllerDecorator as Controller, Tool, ExecutionContext } from '@nitrostack/core';
+
+@Controller('github')
+export class GitHubController {
+  @Tool({
+    name: 'create_issue',
+    description: 'Create an issue in a repository',
+    inputSchema: z.object({ /* ... */ })
+  })
+  async createIssue(input: any, ctx: ExecutionContext) {
+    // Exposed to clients as "github_create_issue"
+  }
+}
+```
+
+## Dependency Injection (DI)
+NitroStack uses a robust dependency injection container to manage class instances and lifecycles.
+
+### Injection Lifecycles
+1. **Singleton (Default)**: A single instance is shared across the entire application.
+2. **Transient**: A new instance is created every time it is resolved/injected.
+3. **Scoped**: A new instance is created per incoming request or context.
+
+```typescript
+import { Injectable, Scope } from '@nitrostack/core';
+
+@Injectable({ scope: Scope.SINGLETON })
+export class UsersService {
+  constructor(private readonly db: DatabaseService) {}
+  
+  async getUser(id: string) {
+    return this.db.query('SELECT * FROM users WHERE id = $1', [id]);
+  }
+}
+```
+
+## Lifecycles and Hooks
+Implement NestJS-style lifecycle interfaces on modules, controllers, or providers to hook into application state changes:
+
+* **`OnModuleInit`** (`onModuleInit`): Called after modules have initialized but before the server starts listening.
+* **`OnApplicationBootstrap`** (`onApplicationBootstrap`): Called once the server is fully started and listening.
+* **`OnModuleDestroy`** (`onModuleDestroy`): Called when the module or application is shutting down.
+* **`BeforeApplicationShutdown`** (`beforeApplicationShutdown(signal?: string)`): Called before the application starts shutting down. Receives the OS signal (e.g. `SIGINT`).
+* **`OnApplicationShutdown`** (`onApplicationShutdown(signal?: string)`): Called during shutdown. Receives the OS signal.
+
+```typescript
+import { 
+  Injectable, 
+  OnModuleInit, 
+  OnApplicationBootstrap,
+  OnModuleDestroy, 
+  BeforeApplicationShutdown,
+  OnApplicationShutdown 
+} from '@nitrostack/core';
+
+@Injectable()
+export class DatabaseService 
+  implements OnModuleInit, OnApplicationBootstrap, OnModuleDestroy, BeforeApplicationShutdown, OnApplicationShutdown 
+{
+  async onModuleInit() {
+    await this.connect();
+  }
+
+  async onApplicationBootstrap() {
+    console.log('App ready to handle connections.');
+  }
+
+  async onModuleDestroy() {
+    await this.cleanupPendingQueries();
+  }
+
+  async beforeApplicationShutdown(signal?: string) {
+    console.log(`Shutting down soon (signal: ${signal}).`);
+  }
+
+  async onApplicationShutdown(signal?: string) {
+    await this.disconnect();
+  }
+}
+```
+
+---
+
+## Eventing System (`emitEvent` and `@OnEvent`)
+NitroStack includes an internal eventing system to decouple components. A service or tool can emit an event using `emitEvent`, and any injectable class (like a handler service or controller) can subscribe using the `@OnEvent` decorator.
+
+### 1. Emitting Events
+Call `emitEvent` to dispatch an event payload asynchronously.
+
+```typescript
+import { Injectable, emitEvent } from '@nitrostack/core';
+
+@Injectable()
+export class SpaceShipService {
+  async launchShip(shipId: string) {
+    // Process launch...
+    
+    // Dispatch event
+    emitEvent('ship.launched', {
+      shipId,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}
+```
+
+### 2. Listening to Events
+Decorate a method inside any `@Injectable()` class with `@OnEvent('event_pattern')` to register it as an event handler.
+
+```typescript
+import { Injectable, OnEvent } from '@nitrostack/core';
+
+@Injectable({ deps: [] })
+export class FlightLogHandler {
+  @OnEvent('ship.launched')
+  async logLaunch(data: { shipId: string; timestamp: string }) {
+    console.error(`🚀 [EVENT] Ship ${data.shipId} was successfully launched at ${data.timestamp}`);
+  }
+}
+```
+
+> [!NOTE]
+> For the `@OnEvent` decorator to register properly, the containing class must be declared as a provider inside an active module.

--- a/sample-apps/agentic-commerce-gateway/.agents/skills/middleware-pipeline/SKILL.md
+++ b/sample-apps/agentic-commerce-gateway/.agents/skills/middleware-pipeline/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: nitrostack-middleware-pipeline
+description: Best practices for implementing and applying Guards, Interceptors, Middleware, Pipes, and Exception Filters in the NitroStack SDK.
+---
+
+## When to Use
+Use this skill when implementing request validation, authorization checks, response mapping, logging, error handling, or performance tracking on NitroStack tool methods.
+
+---
+
+## 1. Guards (`Guard` and `@UseGuards`)
+Guards determine if a request should be processed by a tool handler based on authentication, authorization, or other conditions.
+
+### Interface:
+```typescript
+import { Guard, ExecutionContext } from '@nitrostack/core';
+
+export interface Guard {
+  canActivate(context: ExecutionContext): boolean | Promise<boolean>;
+}
+```
+
+### Example:
+```typescript
+import { Guard, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class RolesGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const userRoles = context.clientMetadata?.roles || [];
+    return userRoles.includes('admin');
+  }
+}
+```
+
+Apply the guard using `@UseGuards(...)`:
+```typescript
+import { Tool, UseGuards, z } from '@nitrostack/core';
+import { RolesGuard } from './roles.guard.js';
+
+export class AdminTools {
+  @Tool({
+    name: 'delete_system_logs',
+    description: 'Delete all system logs from the server.',
+    inputSchema: z.object({}),
+  })
+  @UseGuards(RolesGuard)
+  async deleteLogs() {
+    return { success: true };
+  }
+}
+```
+
+---
+
+## 2. Interceptors (`InterceptorInterface` and `@UseInterceptors`)
+Interceptors can transform/intercept input arguments or mapped output from a tool method execution.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface InterceptorInterface {
+  intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { InterceptorInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class TimingInterceptor implements InterceptorInterface {
+  async intercept(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    const start = Date.now();
+    const result = await next();
+    const duration = Date.now() - start;
+    context.logger.info(`Execution took ${duration}ms`);
+    return {
+      ...result,
+      _meta: { durationMs: duration }
+    };
+  }
+}
+```
+
+---
+
+## 3. Exception Filters (`ExceptionFilterInterface` and `@UseFilters`)
+Exception filters catch any errors thrown within guards, interceptors, or the tool handlers themselves, mapping them into user-friendly JSON payloads.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext): unknown | Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { ExceptionFilterInterface, ExecutionContext, Injectable } from '@nitrostack/core';
+
+@Injectable()
+export class CustomExceptionFilter implements ExceptionFilterInterface {
+  catch(exception: unknown, context: ExecutionContext) {
+    const message = exception instanceof Error ? exception.message : 'Unknown error';
+    return {
+      error: true,
+      message,
+      timestamp: new Date().toISOString()
+    };
+  }
+}
+```
+
+Apply the filter using `@UseFilters(...)` on a tool method:
+
+```typescript
+import { Tool, UseFilters, z } from '@nitrostack/core';
+import { CustomExceptionFilter } from './custom-exception.filter.js';
+
+export class LoggingTools {
+  @Tool({
+    name: 'generate_report',
+    description: 'Generates system usage reports.',
+    inputSchema: z.object({}),
+  })
+  @UseFilters(CustomExceptionFilter)
+  async generateReport() {
+    throw new Error('Report generation is not implemented yet.');
+  }
+}
+```
+
+---
+
+## 4. Middleware (`MiddlewareInterface`, `@Middleware` and `@UseMiddleware`)
+Middleware executes before the request reaches the tool handler, and can wrap the handler execution by invoking `next()`.
+
+### Interface:
+```typescript
+import { ExecutionContext } from '@nitrostack/core';
+
+export interface MiddlewareInterface {
+  use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown>;
+}
+```
+
+### Example:
+```typescript
+import { Middleware, MiddlewareInterface, ExecutionContext } from '@nitrostack/core';
+
+@Middleware()
+export class LoggingMiddleware implements MiddlewareInterface {
+  async use(context: ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+    context.logger.info(`Entering tool: ${context.toolName}`);
+    try {
+      const result = await next();
+      context.logger.info(`Exiting tool: ${context.toolName}`);
+      return result;
+    } catch (error) {
+      context.logger.error(`Error in tool: ${error}`);
+      throw error;
+    }
+  }
+}
+```
+
+Apply the middleware using `@UseMiddleware(...)` on a tool method:
+```typescript
+import { Tool, UseMiddleware, z } from '@nitrostack/core';
+import { LoggingMiddleware } from './logging.middleware.js';
+
+export class StationTools {
+  @Tool({
+    name: 'fetch_logs',
+    description: 'Fetch station operations logs.',
+    inputSchema: z.object({}),
+  })
+  @UseMiddleware(LoggingMiddleware)
+  async fetchLogs() {
+    return { status: 'operational' };
+  }
+}
+```
+
+---
+
+## 5. Pipes (`PipeInterface`, `@Pipe` and `@UsePipes`)
+Pipes are used to transform or validate input arguments before they reach the tool handler method.
+
+### Interface:
+```typescript
+import { ArgumentMetadata } from '@nitrostack/core';
+
+export interface PipeInterface<T = unknown, R = unknown> {
+  transform(value: T, metadata: ArgumentMetadata): R | Promise<R>;
+}
+```
+
+### Example:
+```typescript
+import { Pipe, PipeInterface, ArgumentMetadata } from '@nitrostack/core';
+
+@Pipe()
+export class TrimPipe implements PipeInterface<Record<string, unknown>, Record<string, unknown>> {
+  transform(value: Record<string, unknown>, metadata: ArgumentMetadata) {
+    const trimmed: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      trimmed[key] = typeof val === 'string' ? val.trim() : val;
+    }
+    return trimmed;
+  }
+}
+```
+
+Apply the pipe using `@UsePipes(...)` on a tool method:
+```typescript
+import { Tool, UsePipes, z } from '@nitrostack/core';
+import { TrimPipe } from './trim.pipe.js';
+
+export class MessagingTools {
+  @Tool({
+    name: 'send_message',
+    description: 'Send a message to other stations.',
+    inputSchema: z.object({ text: z.string() }),
+  })
+  @UsePipes(TrimPipe)
+  async sendMessage(input: { text: string }) {
+    return { sentText: input.text };
+  }
+}
+```

--- a/sample-apps/agentic-commerce-gateway/.agents/skills/tools-resources-prompts/SKILL.md
+++ b/sample-apps/agentic-commerce-gateway/.agents/skills/tools-resources-prompts/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: nitrostack-tools-resources-prompts
+description: Guidelines and patterns for defining Tools, Resources, and Prompts in a NitroStack application with schema validation via Zod, including caching, rate-limiting, and base64 file uploads.
+---
+
+## When to Use
+Use this skill whenever you are defining, editing, or validating tools, resources, or prompts on a NitroStack MCP server.
+
+## Defining Tools with `@Tool`
+An MCP tool exposes a function that an AI client can invoke. Decorate a service or controller method with `@Tool`.
+
+### Key Tool Options:
+* `name`: Kebab-case or snake_case unique identifier.
+* `description`: Detailed description explaining when and how the client should use it.
+* `inputSchema`: A Zod object schema for strict validation of inputs.
+* `outputSchema` (optional): Zod schema validating the output structure.
+
+```typescript
+import { ToolDecorator as Tool, ControllerDecorator as Controller, InitialTool, z, ExecutionContext } from '@nitrostack/core';
+
+@Controller('weather')
+export class WeatherService {
+  @Tool({
+    name: 'get_current_weather',
+    description: 'Get the current weather forecast for a specific city.',
+    inputSchema: z.object({
+      city: z.string().describe('The name of the city, e.g., San Francisco'),
+      unit: z.enum(['celsius', 'fahrenheit']).default('celsius'),
+    }),
+  })
+  @InitialTool() // Auto-invoked when the AI client initializes/starts
+  async getWeather(
+    input: { city: string; unit: 'celsius' | 'fahrenheit' },
+    ctx: ExecutionContext
+  ) {
+    ctx.logger.info(`Fetching weather for ${input.city}`);
+    // implementation
+    return {
+      city: input.city,
+      temp: 22,
+      condition: 'Sunny',
+    };
+  }
+}
+```
+
+## Defining Resources with `@Resource`
+An MCP resource exposes static or dynamic data files/URIs that the AI client can read.
+
+### Key Resource Options:
+* `uri`: URI pattern (e.g., `git://{owner}/{repo}/file` or static `app://config`).
+* `name`: Unique name of the resource.
+* `description`: Explanation of what data this resource provides.
+* `mimeType`: Mime type of the response (e.g., `text/plain`, `application/json`).
+
+```typescript
+import { Resource, ExecutionContext } from '@nitrostack/core';
+
+export class ConfigResources {
+  @Resource({
+    uri: 'app://settings',
+    name: 'Application Settings',
+    description: 'System-wide configuration settings and parameters.',
+    mimeType: 'application/json',
+  })
+  async getSettings(ctx: ExecutionContext) {
+    return {
+      environment: 'development',
+      debugMode: true,
+    };
+  }
+}
+```
+
+## Defining Prompts with `@Prompt`
+An MCP prompt exposes reusable templates or instruction sets that guide LLMs.
+
+### Key Prompt Options:
+* `name`: Name of the prompt.
+* `description`: Describes what task this prompt helps accomplish.
+* `arguments`: Declares parameters the client can supply to customize the prompt template.
+
+```typescript
+import { Prompt, ExecutionContext } from '@nitrostack/core';
+
+export class PromptTemplates {
+  @Prompt({
+    name: 'code_review',
+    description: 'Provide an intensive code review for a given code snippet.',
+    arguments: [
+      { name: 'language', description: 'The programming language, e.g., TypeScript', required: true },
+      { name: 'code', description: 'The code snippet to review', required: true },
+    ],
+  })
+  async getCodeReviewPrompt(
+    args: { language: string; code: string },
+    ctx: ExecutionContext
+  ) {
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: `You are an expert software engineer. Review this ${args.language} code:\n\n${args.code}`,
+        },
+      ],
+    };
+  }
+}
+```
+
+---
+
+## Tool Policies: Caching (`@Cache`) and Rate Limiting (`@RateLimit`)
+You can control tool execution behaviors (such as performance optimization and throttling) using method decorators.
+
+### 1. Caching with `@Cache`
+Use `@Cache` to cache tool execution outputs for a specified duration (TTL in seconds). This reduces database or API overhead for frequent identical requests.
+
+#### Options:
+* `ttl`: Cache time-to-live in seconds (required).
+* `key` (optional): Custom function `(input: any, context?: any) => string` that returns a unique cache key based on inputs. If not defined, a key is auto-generated from serialized input arguments.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, Cache, z } from '@nitrostack/core';
+
+export class StationTools {
+  @Tool({
+    name: 'get_system_status',
+    description: 'Fetch real-time station metrics. Response is cached.',
+    inputSchema: z.object({}),
+  })
+  @Cache({ ttl: 60 }) // Caches status for 60 seconds
+  async getSystemStatus() {
+    return { temperature: 21.5, oxygen: 0.98 };
+  }
+
+  @Tool({
+    name: 'get_crew_status',
+    description: 'Fetch status of a crew member. Cached by crew ID.',
+    inputSchema: z.object({ id: z.string() }),
+  })
+  @Cache({
+    ttl: 300,
+    key: (input) => `crew:status:${input.id}`
+  })
+  async getCrewStatus(input: { id: string }) {
+    // ...
+  }
+}
+```
+
+### 2. Rate Limiting with `@RateLimit`
+Use `@RateLimit` to restrict the number of tool invocations within a specified time window to prevent client abuse.
+
+#### Options:
+* `requests`: Number of allowed requests in the window (required).
+* `window`: Throttling duration window (required). Supports formats like `'1s'`, `'1m'`, `'1h'`.
+* `key` (optional): Custom function `(context: ExecutionContext) => string` to group rate limits. Useful for rate-limiting per user role or API key.
+
+#### Example:
+```typescript
+import { ToolDecorator as Tool, RateLimit, z, ExecutionContext } from '@nitrostack/core';
+
+export class DiagnosticTools {
+  @Tool({
+    name: 'run_deep_diagnostic',
+    description: 'Run intensive diagnostics. Rate limited.',
+    inputSchema: z.object({}),
+  })
+  @RateLimit({ requests: 3, window: '1m' }) // Max 3 requests per minute globally
+  async runDeepDiagnostic() {
+    return { diagnosticReport: 'All systems operational.' };
+  }
+
+  @Tool({
+    name: 'request_supply_drop',
+    description: 'Request inventory supplies. Rate limited per user.',
+    inputSchema: z.object({ item: z.string() }),
+  })
+  @RateLimit({
+    requests: 5,
+    window: '1h',
+    key: (ctx: ExecutionContext) => ctx.auth?.subject || 'anonymous'
+  })
+  async requestSupply(input: { item: string }, ctx: ExecutionContext) {
+    // ...
+  }
+}
+```
+
+---
+
+## Handling File Uploads in Tools
+NitroStack supports file uploads from MCP clients (like NitroStudio) by passing the file as a base64-encoded string inside a tool's input parameters.
+
+### 1. Declaring Input Schema for File Uploads
+To accept an uploaded file, define three Zod fields in your tool's `inputSchema`:
+* `file_name`: The name of the file (e.g. `report.csv`).
+* `file_type`: The MIME type (e.g. `text/csv`).
+* `file_content`: The base64-encoded string containing the file data.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+
+export class FileTools {
+  @Tool({
+    name: 'upload_document',
+    description: 'Upload a text document or image.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async uploadDocument(input: any, ctx: ExecutionContext) {
+    // Processing logic
+  }
+}
+```
+
+### 2. Decoding Base64 Payloads
+File uploads can arrive in two formats depending on the client:
+1. **Data URL format**: `data:image/png;base64,iVBORw0KGgo...`
+2. **Raw Base64 format**: `iVBORw0KGgo...`
+
+Use the following universal decoder pattern to parse either format into a Node `Buffer`:
+
+```typescript
+import * as fs from 'fs';
+import * as path from 'path';
+
+function decodeBase64File(content: string): Buffer {
+  const matches = content.match(/^data:([A-Za-z-+\/]+);base64,(.+)$/);
+  
+  if (matches && matches.length === 3) {
+    // Data URL format - decode matches[2]
+    return Buffer.from(matches[2], 'base64');
+  } else {
+    // Raw base64 format - decode input directly
+    return Buffer.from(content, 'base64');
+  }
+}
+```
+
+### 3. Secure File Saving Example
+Always validate the directory paths to prevent directory traversal attacks when saving files to disk.
+
+```typescript
+import { ToolDecorator as Tool, ExecutionContext, z } from '@nitrostack/core';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads');
+
+export class SecureUploadTools {
+  @Tool({
+    name: 'save_uploaded_file',
+    description: 'Decodes and saves an uploaded file securely.',
+    inputSchema: z.object({
+      file_name: z.string().describe('Name of the uploaded file'),
+      file_type: z.string().describe('MIME type of the uploaded file'),
+      file_content: z.string().describe('Base64 encoded file content'),
+    })
+  })
+  async saveFile(input: any, ctx: ExecutionContext) {
+    // Ensure uploads directory exists
+    if (!fs.existsSync(UPLOAD_DIR)) {
+      fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+    }
+
+    // Secure destination path to prevent path traversal
+    const safeName = path.basename(input.file_name);
+    const filePath = path.join(UPLOAD_DIR, safeName);
+    if (!filePath.startsWith(UPLOAD_DIR)) {
+      throw new Error('Invalid file path detected (path traversal).');
+    }
+
+    // Decode and write to disk
+    const buffer = decodeBase64File(input.file_content);
+    fs.writeFileSync(filePath, buffer);
+
+    ctx.logger.info(`Successfully saved file: ${safeName}`);
+    return { success: true, path: filePath };
+  }
+}
+```

--- a/sample-apps/agentic-commerce-gateway/.agents/skills/ui-widgets/SKILL.md
+++ b/sample-apps/agentic-commerce-gateway/.agents/skills/ui-widgets/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: nitrostack-ui-widgets
+description: Best practices for linking tools to interactive frontend widgets using @Widget and @nitrostack/widgets SDK (including state sync, tool calling, display modes, media queries, and chat actions).
+---
+
+## When to Use
+Use this skill when designing, building, or modifying interactive user interface widgets that display custom React content inside AI clients or NitroStudio.
+
+---
+
+## 1. Backend Definition (`@Widget`)
+To display a React-based widget for a tool's output, decorate the tool method with `@Widget`.
+
+### Options:
+* **String Route**: A simple string representing the route identifier in the frontend React app (e.g. `'product-card'`).
+* **Object Route**: Object including:
+  * `route` (required): The route path.
+  * `domain` (optional): Allowed sandbox domain.
+  * `csp` (optional): Content Security Policy guidelines.
+
+### Example:
+```typescript
+import { Tool, Widget, z } from '@nitrostack/core';
+
+export class CatalogTools {
+  @Tool({
+    name: 'fetch_product',
+    description: 'Get product information by barcode.',
+    inputSchema: z.object({ barcode: z.string() }),
+  })
+  @Widget('product-details') // Maps to the "product-details" frontend component
+  async fetchProduct(input: { barcode: string }) {
+    return {
+      name: 'Super Nitro Energy Drink',
+      price: 2.99,
+      sku: input.barcode,
+    };
+  }
+}
+```
+
+---
+
+## 2. Frontend React Widget (`@nitrostack/widgets`)
+In your React widget frontend application (typically a Next.js client component), use the `useWidgetSDK` hook to receive input data from the client host.
+
+### React Component Example:
+```tsx
+'use client';
+
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+interface ProductData {
+  name: string;
+  price: number;
+  sku: string;
+}
+
+export default function ProductDetailsWidget() {
+  const { isReady, getToolOutput, theme } = useWidgetSDK();
+  const data = getToolOutput<ProductData>();
+
+  if (!isReady) {
+    return <div className="loading">Connecting to host...</div>;
+  }
+
+  if (!data) {
+    return <div className="error">No product data received.</div>;
+  }
+
+  return (
+    <div className={`product-card ${theme === 'dark' ? 'dark' : 'light'}`}>
+      <h3>{data.name}</h3>
+      <p className="price">${data.price.toFixed(2)}</p>
+      <span className="sku">SKU: {data.sku}</span>
+    </div>
+  );
+}
+```
+
+---
+
+## 3. State Management & Synchronization (`useWidgetState`)
+Use `useWidgetState` to manage and persist client-side widget state (e.g. selected tabs, filter values, input states). This state automatically synchronizes with the host application context, persisting it across page re-renders.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetState } from '@nitrostack/widgets';
+
+export default function StationPanelWidget() {
+  const [state, setState] = useWidgetState(() => ({
+    selectedTab: 'overview',
+    showExtendedInfo: false,
+  }));
+
+  return (
+    <div>
+      <button onClick={() => setState({ ...state, selectedTab: 'alerts' })}>
+        View Alerts
+      </button>
+      <p>Current Tab: {state?.selectedTab}</p>
+    </div>
+  );
+}
+```
+
+---
+
+## 4. Calling Core Tools from Widgets (`callTool`)
+You can invoke other backend MCP tools directly from the frontend widget using `callTool`. This is useful for tool chaining or triggering detailed audits.
+
+### Example:
+```tsx
+import React, { useState } from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function SystemDiagnostics() {
+  const { callTool, isReady } = useWidgetSDK();
+  const [isRunning, setIsRunning] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+
+  const runDiagnostic = async () => {
+    if (!isReady) return;
+    setIsRunning(true);
+    try {
+      const response = await callTool('run_diagnostic', { system: 'oxygen_scrubber' });
+      setResult(response.result as string);
+    } catch (err) {
+      setResult('Diagnostic execution failed.');
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <button onClick={runDiagnostic} disabled={isRunning}>
+      {isRunning ? 'Running...' : 'Run Diagnostics'}
+    </button>
+  );
+}
+```
+
+---
+
+## 5. Layout & Display Controls
+Widgets can dynamically request size mode changes (fullscreen, inline, picture-in-picture) and adapt layouts to safe areas (dynamic islands/notches) or maximum height constraints.
+
+### Key Methods:
+* `requestFullscreen()`: Switch host widget display to fullscreen.
+* `requestInline()`: Switch host widget display back to inline.
+* `requestPip()`: Float widget in Picture-in-Picture.
+* `requestClose()`: Dismiss the widget completely.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function StatusBoard() {
+  const { 
+    requestFullscreen, 
+    requestInline, 
+    requestClose,
+    displayMode,   // Reactive property ('fullscreen' | 'inline' | 'pip')
+    maxHeight,     // Reactive maxHeight constraint (in pixels)
+    getSafeArea    // Insets data: { top, right, bottom, left }
+  } = useWidgetSDK();
+
+  const safeArea = getSafeArea() || { top: 0, bottom: 0 };
+
+  return (
+    <div style={{ maxHeight: maxHeight || 400, paddingTop: safeArea.top }}>
+      <h3>Mode: {displayMode}</h3>
+      <button onClick={requestFullscreen}>Fullscreen</button>
+      <button onClick={requestInline}>Collapse</button>
+      <button onClick={requestClose}>Dismiss Widget</button>
+    </div>
+  );
+}
+```
+
+---
+
+## 6. Chat Navigation & Actions
+Widgets can interact with the host chat pane using external browser links and follow-up prompts.
+
+### Key Methods:
+* `openExternal(url)`: Open the target URL safely in the user's primary external browser.
+* `sendFollowUpMessage(prompt)`: Insert a message into the chat flow, automatically submitting it to the LLM agent.
+
+### Example:
+```tsx
+import React from 'react';
+import { useWidgetSDK } from '@nitrostack/widgets';
+
+export default function MissionControl() {
+  const { openExternal, sendFollowUpMessage } = useWidgetSDK();
+
+  return (
+    <div>
+      {/* Open external documentation */}
+      <button onClick={() => openExternal('https://docs.nitrostack.dev')}>
+        Open Manual
+      </button>
+
+      {/* Ask LLM agent directly from the widget */}
+      <button onClick={() => sendFollowUpMessage('Analyze mission failures from last week')}>
+        Ask Agent to Analyze
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 7. Media & Accessibility Queries
+The SDK provides helper utilities to query target client capabilities for styling or accessibility.
+
+### Key Utilities:
+* `prefersReducedMotion()`: Returns `true` if client settings specify reduced motion. Disable animations.
+* `isPrimarilyTouchDevice()`: Returns `true` if the device has a coarse pointer (e.g. touch/mobile). Increase button target sizes.
+* `isHoverAvailable()`: Returns `true` if pointer supports hover states.
+* `prefersDarkColorScheme()`: Returns `true` if the system theme is dark.
+
+### Example:
+```tsx
+import React from 'react';
+import { isPrimarilyTouchDevice, prefersReducedMotion } from '@nitrostack/widgets';
+
+export default function AccessiblePanel() {
+  const isTouch = isPrimarilyTouchDevice();
+  const reducedMotion = prefersReducedMotion();
+
+  return (
+    <div className={reducedMotion ? 'no-animations' : 'smooth-transitions'}>
+      <button style={{ padding: isTouch ? '16px' : '8px' }}>
+        Interactive Button
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 8. Testing Widgets
+* Open your project in **NitroStudio** for visual preview.
+* Invoke the tool from the AI chat or testing pane to verify the widget updates instantly with the returned JSON structure.

--- a/sample-apps/agentic-commerce-gateway/.env.example
+++ b/sample-apps/agentic-commerce-gateway/.env.example
@@ -1,0 +1,13 @@
+# NitroStack Configuration
+NITRO_LOG_LEVEL=info
+NITROSTACK_APP_MODE=universal
+
+# Server Transport Configuration (Optional)
+# =============================================================================
+# MCP_TRANSPORT_TYPE: Toggles transport mode. Values: stdio | http | dual.
+# Defaults to 'stdio' in development and 'dual' in production/NODE_ENV=production.
+# =============================================================================
+# MCP_TRANSPORT_TYPE=stdio
+# PORT=3000
+# HOST=localhost
+# ENABLE_CORS=true

--- a/sample-apps/agentic-commerce-gateway/.gitignore
+++ b/sample-apps/agentic-commerce-gateway/.gitignore
@@ -1,0 +1,72 @@
+# Dependencies
+node_modules/
+src/widgets/node_modules/
+
+# Build outputs
+dist/
+src/widgets/.next/
+src/widgets/out/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids/
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage
+coverage/
+.nyc_output/
+
+# Uploads
+uploads/
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Optional npm cache
+.npm/
+
+# Optional eslint cache
+.eslintcache
+
+# OAuth tokens/secrets (never commit these!)
+*.pem
+*.key
+tokens.json
+
+# Duplicate copies of the NitroStack agent skills that `nitrostack-cli init`
+# writes for every supported editor. The canonical copy is kept in .agents/,
+# which is editor-neutral.
+.antigravity/
+.claude/
+.codex/
+.copilot/
+.cursor/
+.gemini/
+.opencode/
+
+# Added by nitrostack pack
+.git/
+.nitrostudio/

--- a/sample-apps/agentic-commerce-gateway/README.md
+++ b/sample-apps/agentic-commerce-gateway/README.md
@@ -1,0 +1,276 @@
+# Agentic Commerce Gateway
+
+**Stripe Radar for AI shopping agents.** A fraud gateway that sits inside a seller's checkout: it screens the buying agent *before* the sale settles, and verifies every sales receipt field-by-field against the on-chain settlement record.
+
+Built with the **NitroStack TypeScript SDK** · Track: **Fintech** · Demo store: **NovaGear** (mock electronics retailer)
+
+**Live on NitroCloud:** https://agentic-commerce-gateway-6a6cafaa-rudra-srmist.app.nitrocloud.ai
+**MCP endpoint:** `https://agentic-commerce-gateway-6a6cafaa-rudra-srmist.app.nitrocloud.ai/mcp`
+
+---
+
+## The problem
+
+AI shopping agents have started buying on behalf of users through emerging protocols — ACP, AP2, x402, MPP. For a seller, this is a new and awkward class of customer: orders arrive from software you cannot vet, carrying signatures you have no way to check, at volumes no human would ever order.
+
+Sellers get two distinct risks, and existing fraud tools address neither:
+
+1. **Pre-sale** — you cannot tell a legitimate shopping agent from a day-old bot with a forged signature draining your stock.
+2. **Post-sale** — the receipt your checkout issued and the payment that actually settled on-chain may not agree, and nothing reconciles them.
+
+This gateway handles both, so sellers can capture agent-driven revenue without absorbing agent-driven fraud.
+
+## What it does
+
+```
+  Agent order (ACP or x402 payload)
+             │
+             ▼
+   ┌───────────────────┐
+   │    normalize      │  one schema, two wire formats
+   └────────┬──────────┘  evidence path chosen here
+            ▼
+   ┌───────────────────┐
+   │   screen_agent    │  registry lookup · HMAC signature verification
+   └────────┬──────────┘  blocklist · disputes · declared-amount check
+            ▼
+   ┌───────────────────┐
+   │compute_trust_score│  5 weighted signals → conflict detection → verdict
+   └────────┬──────────┘
+            ▼
+   approve ──── hold (seller / >₹40,000) ──── decline
+            │
+            ▼  (after settlement)
+   ┌───────────────────┐
+   │  verify_receipt   │  receipt ⟷ chain, field by field
+   └────────┬──────────┘
+            ▼
+   flag_order · blocklist_agent · get_sales_dashboard
+```
+
+## Why it's agentic
+
+The gateway runs a genuine multi-step investigation on every order rather than summarising one:
+
+1. **Branching evidence paths.** An x402 payload carries a declared settlement amount, a payee and a network; an ACP cart carries none of these. The normalizer records a different evidence trail per protocol, and the x402 path gets an extra check (declared amount vs catalog price) that simply does not exist on the ACP path.
+2. **Real verification, not a flag.** Signatures are HMAC-SHA256 over a canonical payload, checked against the agent's registry key. A forged signature fails because the digest genuinely does not match — quantities and totals are part of the signed material, so tampering breaks it.
+3. **Reasoning over conflicting signals.** Signals that point in opposite directions are surfaced as explicit conflicts instead of being averaged into a number: a cryptographically valid signature attached to a 40-unit bulk order, or high reputation alongside 47 orders in one hour.
+4. **Consequential action.** The verdict is applied — order status changes, the decision is logged, agents get blocklisted, and a blocklisted agent's *next* order is declined at screening.
+5. **Post-sale autonomy.** `verify_receipt` diffs the receipt against the chain, prices the seller's exposure in rupees, and hands back a concrete recommended action.
+
+## MCP surface
+
+### Tools
+
+| Tool | What it does |
+|---|---|
+| `list_products` | NovaGear catalog with prices and normal order quantities |
+| `place_agent_order` | Simulate an incoming agent purchase (ACP- or x402-shaped); replay a fixture or construct one |
+| `screen_agent` | Registry lookup, signature verification, blocklist, disputes, declared-amount check |
+| `compute_trust_score` | Five weighted signals → conflicts → verdict; applies and logs the decision |
+| `verify_receipt` | Field-by-field receipt vs on-chain diff with seller exposure |
+| `flag_order` | Mark an order disputed and attach evidence |
+| `blocklist_agent` | Ban an agent; future orders are declined at screening |
+| `get_sales_dashboard` | Order ledger, settled vs stopped revenue, disputes, blocklist |
+| `reset_demo` | Restore fixture state between demo runs |
+
+### Widgets
+
+| Widget | Bound to | Shows |
+|---|---|---|
+| **Order review card** | `compute_trust_score` | Verdict stamp, trust score, per-signal meters, conflicting evidence, identity checks, expandable decision trail |
+| **Receipt diff view** | `verify_receipt` | Receipt vs chain side by side, mismatched fields in red, seller exposure |
+| **Sales dashboard** | `get_sales_dashboard` | Order ledger split into settled / stopped, disputes, buying agents, blocklist |
+
+### Resources
+
+`novagear://catalog` · `novagear://agent-registry` · `novagear://blocklist`
+
+### Prompts
+
+`triage_agent_order` — full investigation loop for one order
+`audit_settlement` — verify a settled sale and act on any mismatch
+
+## Trust scoring
+
+Five signals, weighted to 100:
+
+| Signal | Weight | Fails when |
+|---|---|---|
+| Signature validity | 35 | HMAC does not verify against the registry key |
+| Registry reputation | 25 | Low reputation, or agent absent from the registry |
+| Order size vs product norms | 20 | Quantity exceeds the SKU's normal ceiling |
+| Order velocity | 12 | Too many orders in the last hour |
+| Account age | 8 | Account younger than a week |
+
+**Verdicts:** ≥70 approve · 45–69 hold · <45 decline.
+
+Four rules override the score outright — a failed signature, a blocklisted agent, an unregistered agent, and a declared amount below catalog price never auto-approve. **Human-in-the-loop:** any order above **₹40,000** is held for the seller regardless of how clean it looks.
+
+## Demo scenarios
+
+Run these from the Studio **Tools** page or through AI Chat.
+
+**1 · Clean sale**
+```
+place_agent_order   { "order_ref": "ord_1001" }
+screen_agent        { "order_id": "ord_1001" }
+compute_trust_score { "order_id": "ord_1001" }
+```
+Established shopper agent buys one keyboard → all checks pass → **98/100, approved**.
+
+**2 · Fraudulent buyer blocked**
+```
+place_agent_order   { "order_ref": "ord_1002" }
+screen_agent        { "order_id": "ord_1002" }
+compute_trust_score { "order_id": "ord_1002" }
+blocklist_agent     { "agent_id": "agt_ghost_nyx", "reason": "Spoofed signature on a 40-unit order" }
+```
+Day-old agent, forged signature, 40 headsets (₹1,99,960) → **4 of 5 signals fail → 10/100, declined**, agent banned. Place another order as that agent and it is declined at screening.
+
+**3 · Tampered receipt caught**
+```
+compute_trust_score { "order_id": "ord_1003" }     # 95/100 — looks clean
+verify_receipt      { "order_id": "ord_1003" }     # the money shot
+flag_order          { "order_id": "ord_1003", "reason": "Receipt disagrees with chain" }
+get_sales_dashboard { }
+```
+The sale passes screening at 95/100. After settlement the receipt claims **one unit at ₹4,999**; the chain records **ten units at ₹49,990**. The diff lights up red, exposure **₹44,991**, order flagged, revenue-protected counter ticks up.
+
+Other orders worth showing: `ord_1004` (reputable agent, bulk order, held by the ₹40,000 threshold), `ord_1005` (valid signature, 47 orders/hour), `ord_1008` (payment settled to the wrong payee).
+
+## Getting started
+
+**Requirements:** Node.js 20.x (18+ minimum), npm.
+
+```bash
+git clone https://github.com/swetank18/Agentic_commerceGateway.git
+cd Agentic_commerceGateway
+npm install          # server dependencies
+npm run build        # installs widget deps if needed, bundles widgets, compiles TypeScript
+npm run dev          # development (STDIO transport)
+npm run start:prod   # production (STDIO + HTTP SSE)
+```
+
+### Test it
+
+```bash
+npm test        # builds, then runs all 3 scenarios against the local server over STDIO
+npm run test:live   # runs the same suite against the deployed NitroCloud server over HTTP
+```
+
+The suite speaks real MCP rather than calling the functions directly, so a green run means the tools work through the protocol: the full tool/resource/prompt surface, all three demo scenarios, the human-review and hold paths, the unknown-order error path, and that `reset_demo` restores fixture state. 31 checks.
+
+### Seller console (browser)
+
+The deployed service serves a seller-facing console next to its MCP endpoint:
+
+**https://agentic-commerce-gateway-6a6cafaa-rudra-srmist.app.nitrocloud.ai/console**
+
+It speaks real MCP over Streamable HTTP straight from the browser — the same wire protocol the test suite uses — so every score, signature check and rupee figure on screen came back from the server. Nothing is canned.
+
+The console calls `/mcp` on whatever origin serves it, so the same page works locally with no edit:
+
+```bash
+MCP_TRANSPORT_TYPE=http PORT=3000 npm run start:prod   # then open http://localhost:3000/console
+```
+
+The endpoint field accepts any other server if you want to point a local page at the deployed gateway.
+
+The console can also be published to any static host — `vercel.json` deploys `console/` as-is. There is no MCP server on such a host, so the console detects that and falls back to the deployed gateway automatically. The gateway itself must stay on NitroCloud: it is a long-running process with in-memory state, which serverless hosting cannot preserve between requests.
+
+Each case runs the real tool chain and prints the documents as the calls land, with the measured round-trip on every step:
+
+| Case | Chain |
+|---|---|
+| 01 · Clean sale | `place_agent_order` → `screen_agent` → `compute_trust_score` → approve |
+| 02 · Fraudulent buyer blocked | …→ decline → `blocklist_agent` |
+| 03 · Tampered receipt caught | …→ `verify_receipt` → `flag_order` → `blocklist_agent` |
+
+Case 03's `flag_order` evidence is built from the field mismatches `verify_receipt` just returned, so the dispute cites the actual diff.
+
+Two query parameters help when recording a demo: `?run=all|clean|fraud|tampered` plays a case on load with no clicking, and `?theme=light|dark` pins the theme (otherwise it follows the OS).
+
+The console is built to the project's design system — the same document primitives, tokens and rules as the MCP widgets, so the two surfaces read as one product.
+
+### Connect it in NitroStudio
+
+1. **Add Server → Nitro Project**, browse to this folder, **Open Project → Studio App Canvas**.
+2. Studio runs the server for you; open **Tools** to execute any tool and see its widget preview.
+3. **AI Chat** drives the full loop — try *"Investigate order ord_1002 and act on your verdict."*
+
+### Deploy to NitroCloud
+
+Create an app on [nitrocloud.ai](https://nitrocloud.ai), then either:
+
+- **Deploy from GitHub (auto-deploy):** app → **MCP → Deployments → Connect Repository**, pick `main`, then **Link Repository & Enable Auto-Deploy**. Every push redeploys.
+- **Deploy from Studio:** App Canvas header → **Link to app…** → **Deploy**.
+
+Wait for status **Live**, then copy the Service URL.
+
+### Connect to ChatGPT
+
+ChatGPT **Settings → Plugins (Apps) → Developer mode**, add a plugin with Server URL `{serviceUrl}/sse`, no auth. (Requires ChatGPT Plus or Pro.)
+
+## Environment variables
+
+None are required — the project runs entirely on bundled fixtures with no external services, no database and no API keys. Optional NitroStack settings (see `.env.example`):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NITRO_LOG_LEVEL` | `info` | Log verbosity |
+| `MCP_TRANSPORT_TYPE` | `stdio` dev / `dual` prod | `stdio`, `http`, or `dual` |
+| `PORT` | `3000` | HTTP transport port |
+| `NITROSTACK_APP_MODE` | `universal` | Client compatibility mode |
+
+## Project structure
+
+```
+src/
+├── index.ts                       bootstrap
+├── app.module.ts                  root module
+├── console/console.route.ts       serves the seller console on GET /console
+├── fixtures/                      mock data (TypeScript modules, not JSON —
+│   ├── products.ts                see note below)
+│   ├── agents.ts                  8 buying agents + reputation registry
+│   ├── orders.ts                  9 orders in ACP and x402 shapes
+│   └── settlements.ts             sales receipts + on-chain records
+├── modules/gateway/
+│   ├── gateway.types.ts           shared domain types
+│   ├── gateway.signing.ts         HMAC signing and verification
+│   ├── gateway.normalize.ts       ACP / x402 → one schema
+│   ├── gateway.store.ts           in-memory state
+│   ├── gateway.screening.ts       identity checks + trust scoring
+│   ├── gateway.verification.ts    receipt ⟷ chain diff
+│   ├── gateway.tools.ts           MCP tools
+│   ├── gateway.resources.ts       MCP resources
+│   └── gateway.prompts.ts         MCP prompts
+└── widgets/app/                   React widgets
+    ├── _shared/ui.tsx             shared visual language
+    ├── order-review/
+    ├── receipt-diff/
+    └── sales-dashboard/
+
+console/
+└── index.html                     seller console — browser MCP client, single file
+
+scripts/
+├── e2e.mjs                        end-to-end suite over real MCP
+└── copy-console.mjs               copies the console into dist/ after tsc
+```
+
+**Why fixtures are `.ts`, not `.json`:** `nitrostack-cli build` compiles the server with `tsc`, which does not copy loose JSON assets into `dist/`. Authoring fixtures as typed modules means they compile into `dist/` alongside the code — no asset-copy step, no runtime path resolution, and no chance of a fixture going missing once deployed. They are also type-checked against the domain types.
+
+## Money handling
+
+All amounts are integers in **minor units (paise)**; `₹8,499.00` is stored as `849900`. Receipt-vs-chain comparison has to be exact — with floating-point rupees, a genuine tampering diff would be indistinguishable from a rounding artefact.
+
+## Honest scope
+
+The order payloads are **protocol-shaped, not live integrations**. Field names and structure mirror ACP and x402 so the normalizer does real work, but nothing here calls a protocol endpoint, and the "on-chain records" are fixtures — no blockchain is read. The cryptography is real (HMAC-SHA256 over canonical payloads), and the scoring and reconciliation logic is real; the transport and the ledger are simulated.
+
+Out of scope by design: real storefront and payments, AP2/MPP support, authentication and multi-seller tenancy.
+
+## License
+
+MIT

--- a/sample-apps/agentic-commerce-gateway/console/index.html
+++ b/sample-apps/agentic-commerce-gateway/console/index.html
@@ -1,0 +1,997 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>NovaGear · Agentic Commerce Gateway — Seller Console</title>
+<style>
+/* ===========================================================================
+   NovaGear Gateway — seller console
+
+   Built to the Agentic Commerce Gateway Design System handoff: tokens, the 8
+   document primitives and the shell chrome are reproduced at their exact
+   values. Corner radius 0 everywhere, no animation, hairline and dashed rules,
+   `3px double` reserved for money totals, `-3deg` stamp, the fixed glyph set.
+
+   The design guide anticipates this surface: "a fourth product surface if this
+   gateway grows an actual seller dashboard beyond the MCP widgets". The order
+   detail is still a document — the same Slip the widgets render — the rest is
+   flat operator chrome around it.
+   =========================================================================== */
+
+/* --- tokens/colors.css --------------------------------------------------- */
+:root{
+--stock:#EDF0F4;--card:#FFFFFF;--ink:#1A1F2B;--ink-soft:#5D6779;--rule:#C7CEDA;--rule-soft:#E1E5EC;
+--clear:#1F6F4A;--hold:#8F5D0C;--danger:#B3261E;
+--clear-wash:rgba(31,111,74,0.08);--hold-wash:rgba(143,93,12,0.08);--danger-wash:rgba(179,38,30,0.08);
+}
+[data-theme="dark"]{
+--stock:#12151A;--card:#181C23;--ink:#E8EBF0;--ink-soft:#96A0AF;--rule:#2B313B;--rule-soft:#212730;
+--clear:#57B586;--hold:#D6A247;--danger:#E4736A;
+--clear-wash:rgba(87,181,134,0.12);--hold-wash:rgba(214,162,71,0.12);--danger-wash:rgba(228,115,106,0.12);
+}
+
+/* --- tokens/typography.css ----------------------------------------------- */
+:root{
+--font-mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,"Liberation Mono",monospace;
+--font-sans:ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+--text-micro:9.5px;--text-2xs:10.5px;--text-xs:11px;--text-sm:12px;--text-sm-plus:12.5px;--text-base:13px;--text-md:13.5px;--text-lg:16px;--text-xl:21px;--text-2xl:26px;--text-display:46px;
+--tracking-micro:0.14em;--tracking-stamp:0.18em;--tracking-label:0.1em;--tracking-mono:0.08em;
+--leading-tight:1.1;--leading-snug:1.35;--leading-normal:1.45;--leading-loose:1.6;
+}
+
+/* --- tokens/spacing.css --------------------------------------------------- */
+:root{
+--space-1:3px;--space-2:4px;--space-3:6px;--space-4:8px;--space-5:10px;--space-6:12px;--space-7:14px;--space-8:16px;--space-9:18px;--space-10:20px;--space-11:24px;
+--radius:0px;
+--shadow-doc:0 1px 2px rgba(16,22,34,0.08),0 8px 24px -12px rgba(16,22,34,0.25);
+}
+
+/* --- tokens/patterns.css -------------------------------------------------- */
+*{box-sizing:border-box}
+body{margin:0;font-family:var(--font-sans);background:var(--stock);color:var(--ink)}
+button:focus-visible,[tabindex]:focus-visible{outline:2px solid currentColor;outline-offset:2px}
+@media (prefers-reduced-motion: reduce){*{transition:none!important;animation:none!important}}
+
+.ds-micro{font-family:var(--font-sans);font-size:var(--text-micro);font-weight:700;letter-spacing:var(--tracking-micro);text-transform:uppercase;color:var(--ink-soft)}
+.ds-stamp{display:inline-block;transform:rotate(-3deg);border:2px solid;padding:5px 12px 4px;font-family:var(--font-mono);font-size:13px;font-weight:700;letter-spacing:var(--tracking-stamp);text-transform:uppercase;white-space:nowrap;line-height:var(--leading-tight);flex-shrink:0}
+.ds-refstrip{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 16px;border-bottom:1px dashed var(--rule);background:var(--stock);flex-wrap:wrap}
+.ds-refstrip-left{font-family:var(--font-mono);font-size:11.5px;letter-spacing:var(--tracking-mono);color:var(--ink)}
+.ds-refstrip-right{font-family:var(--font-mono);font-size:var(--text-2xs);letter-spacing:var(--tracking-label);color:var(--ink-soft)}
+.ds-tickmeter{display:flex;gap:2px;align-items:flex-end;height:14px}
+.ds-tick{flex:1}
+.ds-section{border-top:1px solid var(--rule);padding:14px 16px}
+.ds-section-head{display:flex;align-items:baseline;justify-content:space-between;gap:8px;margin-bottom:10px}
+.ds-section-note{font-family:var(--font-mono);font-size:var(--text-2xs);color:var(--ink-soft)}
+.ds-slip-doc{background:var(--card);border:1px solid var(--rule);box-shadow:var(--shadow-doc)}
+.ds-empty{font-family:var(--font-mono);font-size:12px;color:var(--ink-soft);padding:24px;text-align:center;letter-spacing:0.06em}
+.ds-grid-2{display:grid;grid-template-columns:1fr 1fr;gap:12px 20px}
+.ds-diff{display:grid;grid-template-columns:minmax(0,1fr) 30px minmax(0,1fr);align-items:center}
+.ds-diff > div{min-width:0;word-break:break-all}
+@media (max-width:430px){.ds-grid-2{grid-template-columns:1fr}.ds-diff{grid-template-columns:1fr}.ds-diff-gutter{display:none}}
+
+/* ======================================================= operator chrome == */
+
+.bar{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:12px 16px;background:var(--card);border-bottom:1px solid var(--rule)}
+.bar.sub{background:var(--stock);padding:10px 16px}
+
+.wordmark{font-family:var(--font-mono);font-size:13px;font-weight:700;letter-spacing:0.18em;text-transform:uppercase;color:var(--ink);margin-right:6px}
+.wordmark span{color:var(--ink-soft);font-weight:400;letter-spacing:0.1em}
+
+.chip{background:transparent;border:1px solid var(--rule);color:var(--ink-soft);padding:6px 11px;cursor:pointer;font-family:var(--font-mono);font-size:10.5px;letter-spacing:0.08em;text-transform:uppercase}
+.chip:hover:not(:disabled){color:var(--ink);border-color:var(--ink)}
+.chip:disabled{opacity:0.4;cursor:default}
+.chip.primary{background:var(--ink);color:var(--card);border-color:var(--ink)}
+.chip.primary:hover:not(:disabled){opacity:0.85;color:var(--card)}
+
+.sel{background:var(--card);border:1px solid var(--rule);color:var(--ink);font-family:var(--font-mono);font-size:10.5px;padding:6px 8px;text-transform:uppercase;letter-spacing:0.08em}
+.endpoint{background:var(--card);border:1px solid var(--rule-soft);color:var(--ink);font-family:var(--font-mono);font-size:10.5px;padding:6px 8px;width:210px}
+.right{margin-left:auto;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+
+.status{display:inline-flex;align-items:center;gap:7px;border:1px solid var(--rule-soft);padding:5px 10px;font-family:var(--font-mono);font-size:10.5px;color:var(--ink-soft);letter-spacing:0.08em}
+.status .g{font-weight:700}
+.status[data-state="live"] .g{color:var(--clear)}
+.status[data-state="busy"] .g{color:var(--hold)}
+.status[data-state="down"] .g{color:var(--danger)}
+.status .h{max-width:24ch;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+/* ============================================================ KPI header == */
+
+.kpis{display:grid;grid-template-columns:repeat(auto-fit,minmax(190px,1fr));gap:1px;background:var(--rule);border-bottom:1px solid var(--rule)}
+.kpi{background:var(--card);padding:14px 16px;min-width:0}
+.kpi .n{font-family:var(--font-mono);font-weight:700;font-variant-numeric:tabular-nums;line-height:1.1;margin-top:6px;word-break:break-word}
+.kpi.lead .n{font-size:var(--text-2xl);color:var(--clear)}
+.kpi .n.plain{font-size:var(--text-xl);color:var(--ink)}
+.kpi .sub{font-family:var(--font-mono);font-size:var(--text-2xs);color:var(--ink-soft);margin-top:5px}
+
+.tally{display:flex;gap:12px;flex-wrap:wrap;margin-top:7px;font-family:var(--font-mono);font-size:11.5px}
+.tally b{font-weight:700}
+
+/* ================================================================ layout == */
+
+.grid{display:grid;grid-template-columns:minmax(320px,420px) minmax(0,1fr);align-items:start;gap:0}
+.col-left{border-right:1px solid var(--rule);background:var(--card);min-height:calc(100vh - 160px)}
+.col-right{padding:16px;min-width:0;background:var(--stock)}
+
+.block{border-bottom:1px solid var(--rule)}
+.block-head{display:flex;align-items:baseline;justify-content:space-between;gap:8px;padding:11px 16px;border-bottom:1px solid var(--rule-soft)}
+
+/* order feed — the operator's worklist */
+.row{display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:10px;align-items:baseline;width:100%;text-align:left;background:transparent;border:0;border-bottom:1px solid var(--rule-soft);padding:9px 16px;cursor:pointer;font:inherit;color:var(--ink)}
+.row:hover{background:var(--stock)}
+.row[aria-current="true"]{background:var(--stock);box-shadow:inset 3px 0 0 var(--ink)}
+.row .g{font-family:var(--font-mono);font-weight:700;width:1.1em;text-align:center}
+.row .id{font-family:var(--font-mono);font-size:12px;color:var(--ink)}
+.row .who{font-size:11px;color:var(--ink-soft);display:block;margin-top:2px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.row .amt{font-family:var(--font-mono);font-size:12px;font-variant-numeric:tabular-nums;white-space:nowrap}
+.row[data-s="approved"] .g{color:var(--clear)}
+.row[data-s="held"] .g{color:var(--hold)}
+.row[data-s="declined"] .g,.row[data-s="flagged"] .g{color:var(--danger)}
+.row[data-s="pending"] .g{color:var(--ink-soft)}
+
+.mini{padding:9px 16px;border-bottom:1px solid var(--rule-soft);font-family:var(--font-mono);font-size:11.5px;display:flex;justify-content:space-between;gap:10px}
+.mini:last-child{border-bottom:0}
+.mini .k{color:var(--ink)}
+.mini .v{color:var(--ink-soft);text-align:right}
+.none{padding:14px 16px;font-family:var(--font-mono);font-size:11px;color:var(--ink-soft)}
+
+/* payment alerts */
+.alert{display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:9px;align-items:baseline;padding:8px 16px;border-bottom:1px solid var(--rule-soft);font-family:var(--font-mono);font-size:11.5px;background:var(--danger-wash)}
+.alert:last-child{border-bottom:0}
+.alert .g{font-weight:700}
+.alert .amt{font-variant-numeric:tabular-nums;white-space:nowrap}
+
+/* ============================================== document (the detail pane) */
+
+.doc-wrap{margin:0 auto 16px}
+
+.gw-hero{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;padding:18px 16px 16px}
+.gw-hero-n{font-family:var(--font-mono);font-size:var(--text-display);line-height:1;font-weight:700;letter-spacing:-0.02em;margin:6px 0 8px}
+.gw-hero-n small{font-size:var(--text-lg);color:var(--ink-soft);font-weight:400}
+.gw-hero-band{font-family:var(--font-mono);font-size:11px;letter-spacing:0.12em;text-transform:uppercase;color:var(--ink-soft);margin-top:8px}
+
+.gw-trace{display:grid;grid-template-columns:auto minmax(0,1fr) auto auto;align-items:baseline;gap:10px;padding:5px 0;border-bottom:1px solid var(--rule-soft);font-family:var(--font-mono);font-size:11.5px;color:var(--ink)}
+.gw-trace:last-child{border-bottom:0}
+.gw-trace .t,.gw-trace .ms{color:var(--ink-soft);font-size:var(--text-2xs)}
+.gw-trace .w{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.gw-trace .g{font-weight:700;width:1.1em;text-align:center;color:var(--ink-soft)}
+.gw-trace[data-s="pass"] .g{color:var(--clear)}
+.gw-trace[data-s="fail"] .g{color:var(--danger)}
+.gw-trace[data-s="hold"] .g{color:var(--hold)}
+
+.gw-row{display:flex;justify-content:space-between;gap:12px;padding:6px 0;border-bottom:1px solid var(--rule-soft);font-family:var(--font-mono);font-size:12.5px}
+.gw-row:last-child{border-bottom:0}
+.gw-row .q{color:var(--ink-soft)}
+.gw-row .nm{color:var(--ink-soft);font-family:var(--font-sans);font-size:12px}
+
+.gw-total{display:flex;align-items:baseline;justify-content:space-between;gap:12px;margin-top:8px;padding:10px 0 0;border-top:3px double var(--rule)}
+.gw-total .n{font-family:var(--font-mono);font-size:var(--text-xl);font-weight:700}
+
+.gw-sig{margin-bottom:12px}
+.gw-sig-head{display:flex;justify-content:space-between;align-items:baseline;gap:10px}
+.gw-sig-name{font-family:var(--font-sans);font-size:12.5px;font-weight:600}
+.gw-sig-pts{font-family:var(--font-mono);font-size:11.5px;letter-spacing:0.08em}
+.gw-sig-detail{font-family:var(--font-sans);font-size:11.5px;color:var(--ink-soft);line-height:1.4}
+
+.gw-check{display:flex;gap:9px;padding:5px 0;font-family:var(--font-sans);font-size:12px}
+.gw-check .g{font-family:var(--font-mono);font-weight:700}
+.gw-check .l{font-weight:600}
+.gw-check .d{color:var(--ink-soft)}
+
+.gw-callout{padding:9px 11px;margin-bottom:8px;font-family:var(--font-sans);font-size:12px;line-height:1.45}
+.gw-exposure{margin:0 16px;border-top:1px solid var(--rule);padding:12px 0;display:flex;align-items:baseline;justify-content:space-between;gap:12px}
+.gw-exposure .n{font-family:var(--font-mono);font-size:var(--text-2xl);font-weight:700}
+.gw-foot{border-top:1px dashed var(--rule);background:var(--stock);padding:10px 16px;font-family:var(--font-mono);font-size:11px;color:var(--ink-soft);line-height:1.4}
+.gw-err{font-family:var(--font-mono);font-size:11.5px;line-height:1.5;color:var(--danger);background:var(--danger-wash);border-left:3px solid var(--danger);padding:10px 12px;margin:10px 0;word-break:break-word}
+
+/* seller actions — real tool calls, issued from the document they act on */
+.gw-actions{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
+.gw-act{background:transparent;border:1px solid var(--rule);color:var(--ink-soft);padding:6px 11px;cursor:pointer;font-family:var(--font-mono);font-size:10.5px;letter-spacing:0.08em;text-transform:uppercase}
+.gw-act:hover:not(:disabled){color:var(--ink);border-color:var(--ink)}
+.gw-act:disabled{opacity:0.4;cursor:default}
+.gw-act[data-tone="danger"]{color:var(--danger);border-color:var(--danger)}
+.gw-act[data-tone="hold"]{color:var(--hold);border-color:var(--hold)}
+.gw-act[data-done="true"]{opacity:0.5;cursor:default}
+.gw-act-note{font-family:var(--font-mono);font-size:10.5px;color:var(--ink-soft);margin-top:8px;line-height:1.5}
+
+@media (max-width:900px){
+  .grid{grid-template-columns:1fr}
+  .col-left{border-right:0;border-bottom:1px solid var(--rule);min-height:0}
+  .col-right{padding:12px}
+}
+</style>
+</head>
+<body>
+
+<div class="bar">
+  <span class="wordmark">NovaGear <span>Agentic Commerce Gateway</span></span>
+  <span class="right">
+    <span class="status" id="status" data-state="idle">
+      <span class="g" id="statusGlyph">·</span>
+      <span class="h" id="statusHost">connecting</span>
+    </span>
+    <button class="chip" type="button" id="alertsBtn" aria-pressed="true">⚑ alerts on</button>
+    <button class="chip" type="button" id="theme">☾ dark</button>
+  </span>
+</div>
+
+<div class="bar sub">
+  <button class="chip primary" type="button" id="refresh">↻ Refresh</button>
+  <select class="sel" id="scenario" aria-label="Run a demo scenario">
+    <option value="">Run scenario…</option>
+  </select>
+  <button class="chip" type="button" id="runAll">▶ Run all scenarios</button>
+  <button class="chip" type="button" id="reset">Reset gateway</button>
+  <span class="right">
+    <input class="endpoint" id="endpoint" spellcheck="false" aria-label="MCP endpoint" />
+  </span>
+</div>
+
+<section class="kpis" id="kpis"></section>
+
+<div class="grid">
+  <div class="col-left">
+    <div class="block">
+      <div class="block-head">
+        <span class="ds-micro">Payment alerts</span>
+        <span class="ds-micro" id="alertCount">0</span>
+      </div>
+      <div id="alertList"><div class="none">No alerts raised.</div></div>
+    </div>
+
+    <div class="block">
+      <div class="block-head">
+        <span class="ds-micro">Agent order feed</span>
+        <span class="ds-micro" id="feedNote">—</span>
+      </div>
+      <div id="feed"><div class="none">Connecting…</div></div>
+    </div>
+
+    <div class="block">
+      <div class="block-head">
+        <span class="ds-micro">Blocklist</span>
+        <span class="ds-micro" id="blockNote">0</span>
+      </div>
+      <div id="blocklist"><div class="none">No agents banned.</div></div>
+    </div>
+
+    <div class="block">
+      <div class="block-head"><span class="ds-micro">Decision log</span></div>
+      <div id="decisions"><div class="none">No decisions yet.</div></div>
+    </div>
+  </div>
+
+  <main class="col-right" id="detail" aria-live="polite">
+    <div class="ds-empty">SELECT AN ORDER FROM THE FEED TO INVESTIGATE IT</div>
+  </main>
+</div>
+
+<script>
+'use strict';
+
+/* ===========================================================================
+   MCP client — Streamable HTTP, the same wire protocol scripts/e2e.mjs uses.
+   Replies arrive as SSE frames, so responses are parsed out of `data:` lines.
+   =========================================================================== */
+
+const DEPLOYED = 'https://agentic-commerce-gateway-6a6cafaa-rudra-srmist.app.nitrocloud.ai';
+
+/* The console may be served by the gateway itself (/console), by a static host
+   with no MCP server on it, or opened straight from the filesystem. So the
+   serving origin is only a candidate — tried first, with the deployed service
+   as the fallback. */
+const SAME_ORIGIN = location.protocol.startsWith('http') ? location.origin : null;
+const DEFAULT_BASE = SAME_ORIGIN || DEPLOYED;
+
+const mcp = {
+  base: DEFAULT_BASE,
+  pinned: false,
+  session: null,
+  id: 0,
+  ready: false,
+
+  endpoint() { return this.base.replace(/\/+$/, '') + '/mcp'; },
+
+  parseSse(text) {
+    return text.split('\n').map(l => l.trim()).filter(l => l.startsWith('data:'))
+      .flatMap(l => { try { return [JSON.parse(l.slice(5).trim())]; } catch { return []; } });
+  },
+
+  async send(method, params, isNotification) {
+    const body = isNotification
+      ? { jsonrpc: '2.0', method, params }
+      : { jsonrpc: '2.0', id: ++this.id, method, params };
+    const headers = { 'Content-Type': 'application/json', 'Accept': 'application/json, text/event-stream' };
+    if (this.session) headers['Mcp-Session-Id'] = this.session;
+
+    const res = await fetch(this.endpoint(), { method: 'POST', headers, body: JSON.stringify(body) });
+    const sid = res.headers.get('mcp-session-id');
+    if (sid) this.session = sid;
+    if (isNotification) return null;
+
+    const text = await res.text();
+    if (!res.ok) throw new Error('HTTP ' + res.status + ' — ' + text.slice(0, 160));
+    const msgs = this.parseSse(text);
+    const msg = msgs.find(m => m.id === body.id) || msgs[0];
+    if (!msg) throw new Error('no response for ' + method);
+    return msg;
+  },
+
+  candidates() {
+    if (this.pinned) return [this.base];
+    if (SAME_ORIGIN && SAME_ORIGIN !== DEPLOYED) return [SAME_ORIGIN, DEPLOYED];
+    return [DEPLOYED];
+  },
+
+  async connect() {
+    let lastError;
+    for (const base of this.candidates()) {
+      this.base = base;
+      this.session = null;
+      this.ready = false;
+      try {
+        const init = await this.send('initialize', {
+          protocolVersion: '2024-11-05', capabilities: {},
+          clientInfo: { name: 'gateway-console', version: '2.0.0' },
+        });
+        if (init.error) throw new Error(JSON.stringify(init.error));
+        await this.send('notifications/initialized', {}, true);
+        this.ready = true;
+        return init.result;
+      } catch (e) { lastError = e; }
+    }
+    throw lastError || new Error('no reachable MCP endpoint');
+  },
+
+  unwrap(res) {
+    if (res.error) throw new Error(res.error.message || JSON.stringify(res.error));
+    const r = res.result || {};
+    if (r.isError) {
+      const t = (r.content || []).find(c => c.type === 'text');
+      throw new Error(t ? t.text : 'tool reported an error');
+    }
+    if (r.structuredContent) return r.structuredContent;
+    const text = (r.content || []).find(c => c.type === 'text');
+    if (!text) return r;
+    try { return JSON.parse(text.text); } catch { return text.text; }
+  },
+
+  async call(name, args) {
+    if (!this.ready) await this.connect();
+    return this.unwrap(await this.send('tools/call', { name, arguments: args || {} }));
+  },
+};
+
+/* ============================================================== scenarios == */
+/* The scripted demo chains. The feed makes every order investigable, so these
+   exist for the narrated walkthrough rather than as the only way in.         */
+
+const SCENARIOS = [
+  { id: 'clean',     no: '01', name: 'Clean sale',              order: 'ord_1001' },
+  { id: 'fraud',     no: '02', name: 'Fraudulent buyer blocked', order: 'ord_1002',
+    then: [{ tool: 'blocklist_agent', label: 'ban agent from store',
+             args: { agent_id: 'agt_ghost_nyx', reason: 'Spoofed signature on a 40-unit order' } }] },
+  { id: 'tampered',  no: '03', name: 'Tampered receipt caught',  order: 'ord_1003',
+    then: [{ tool: 'flag_order', label: 'raise dispute', fromDiffs: true },
+           { tool: 'blocklist_agent', label: 'ban agent from store',
+             args: { agent_id: 'agt_relay_lyra', reason: 'Tampered settlement record on ord_1003' } }] },
+  { id: 'threshold', no: '04', name: 'Held for a human',         order: 'ord_1009' },
+  { id: 'velocity',  no: '05', name: 'Velocity abuse held',      order: 'ord_1005' },
+  { id: 'payee',     no: '06', name: 'Payee redirect caught',    order: 'ord_1008' },
+];
+
+/* =============================================================== helpers == */
+
+const $ = (id) => document.getElementById(id);
+const esc = (s) => String(s ?? '').replace(/[&<>"']/g, c => (
+  { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+const clock = () => new Date().toLocaleTimeString('en-GB', { hour12: false });
+const wait = (ms) => new Promise(r => setTimeout(r, ms));
+
+const el = (tag, cls, html) => {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (html !== undefined) n.innerHTML = html;
+  return n;
+};
+
+const inr = (minor) => new Intl.NumberFormat('en-IN', {
+  style: 'currency', currency: 'INR', minimumFractionDigits: 2,
+}).format((minor || 0) / 100);
+
+const toneOfVerdict = (v) => (v === 'approve' ? 'clear' : v === 'hold' ? 'hold' : 'danger');
+const toneOfStatus  = (s) => (s === 'pass' ? 'clear' : s === 'warn' ? 'hold' : 'danger');
+
+/* The fixed glyph set — no emoji, ever. */
+const GLYPH = { pass: '✓', fail: '✗', hold: '‖', flag: '⚑', pending: '·', eq: '=', ne: '≠' };
+const STATUS_GLYPH = { approved: GLYPH.pass, held: GLYPH.hold, declined: GLYPH.fail,
+                       flagged: GLYPH.flag, pending: GLYPH.pending };
+
+const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+const BEAT = reduceMotion ? 0 : 200;
+
+let busy = false;
+let selected = null;
+
+/* --- DS primitives, as DOM ------------------------------------------------ */
+
+function micro(text) { return `<div class="ds-micro">${esc(text)}</div>`; }
+
+function stamp(label, tone) {
+  const c = `var(--${tone})`;
+  return `<div class="ds-stamp" style="border-color:${c};color:${c};` +
+         `box-shadow:0 0 0 1px var(--card), 0 0 0 3px ${c}">${esc(label)}</div>`;
+}
+
+function tickMeter(value, max, tone, segments) {
+  const segs = segments || 25;
+  const filled = Math.round((Math.max(0, Math.min(value, max)) / max) * segs);
+  let out = '<div class="ds-tickmeter" aria-hidden="true">';
+  for (let i = 0; i < segs; i++) {
+    out += `<div class="ds-tick" style="height:${i % 5 === 0 ? 14 : 10}px;` +
+           `background:${i < filled ? `var(--${tone})` : 'var(--rule-soft)'}"></div>`;
+  }
+  return out + '</div>';
+}
+
+function field(label, value, opts) {
+  const o = opts || {};
+  return `<div class="ds-field">${micro(label)}` +
+         `<div style="font-family:var(--font-${o.mono === false ? 'sans' : 'mono'});font-size:13px;` +
+         `line-height:1.35;word-break:break-word;` +
+         `color:${o.tone ? `var(--${o.tone})` : 'var(--ink)'}">${esc(value)}</div></div>`;
+}
+
+function section(doc, title, note) {
+  const s = el('section', 'ds-section');
+  s.appendChild(el('div', 'ds-section-head',
+    micro(title) + (note ? `<span class="ds-section-note">${esc(note)}</span>` : '')));
+  doc.insertBefore(s, doc.querySelector('.gw-foot'));
+  return s;
+}
+
+/* --- the document shell --------------------------------------------------- */
+
+function newDocument(refLeft, refRight, maxWidth) {
+  const wrap = el('div', 'doc-wrap');
+  wrap.style.maxWidth = (maxWidth || 560) + 'px';
+  const doc = el('article', 'ds-slip-doc');
+  doc.innerHTML =
+    `<div class="ds-refstrip"><div class="ds-refstrip-left">${refLeft}</div>` +
+    `<div class="ds-refstrip-right">${esc(refRight)}</div></div>` +
+    `<div class="gw-hero-slot"></div><div class="gw-foot">NEXT — awaiting gateway response.</div>`;
+  wrap.appendChild(doc);
+  $('detail').appendChild(wrap);
+  return doc;
+}
+
+const setFooter = (doc, text) => { if (text) doc.querySelector('.gw-foot').textContent = 'NEXT — ' + text; };
+const setHero = (doc, html) => { doc.querySelector('.gw-hero-slot').innerHTML = html; };
+
+function traceSection(doc) {
+  const found = doc.querySelector('.gw-trace-body');
+  if (found) return found;
+  const sec = section(doc, 'Live trace', 'real MCP round-trips');
+  const body = el('div', 'gw-trace-body');
+  sec.appendChild(body);
+  return body;
+}
+
+function traceStep(doc, label) {
+  const body = traceSection(doc);
+  const line = el('div', 'gw-trace');
+  line.dataset.s = 'pending';
+  line.innerHTML = `<span class="t">${clock()}</span><span class="w">${esc(label)}</span>` +
+                   `<span class="ms"></span><span class="g">${GLYPH.pending}</span>`;
+  body.appendChild(line);
+  return (status, ms) => {
+    line.dataset.s = status;
+    line.querySelector('.ms').textContent = ms + 'ms';
+    line.querySelector('.g').textContent =
+      status === 'pass' ? GLYPH.pass : status === 'fail' ? GLYPH.fail : GLYPH.hold;
+  };
+}
+
+/* --- per-tool document sections ------------------------------------------- */
+
+function renderOrder(doc, d) {
+  const s = section(doc, 'Buyer');
+  s.appendChild(el('div', 'ds-grid-2',
+    field('Agent', d.agentDisplayName, { mono: false }) + field('Agent ID', d.agentId) +
+    field('Protocol', `${String(d.protocol).toUpperCase()} v${d.protocolVersion}`) +
+    field('Order total', d.total)));
+
+  const cart = section(doc, 'Cart', `${(d.items || []).length} line item(s)`);
+  (d.items || []).forEach(i => cart.appendChild(el('div', 'gw-row',
+    `<span><span class="q">${i.qty}× </span>${esc(i.sku)}<span class="nm"> ${esc(i.name || '')}</span></span>` +
+    `<span>${esc(i.lineTotal || inr(i.lineTotalMinor))}</span>`)));
+  cart.appendChild(el('div', 'gw-total', micro('Order total') + `<span class="n">${esc(d.total)}</span>`));
+
+  if (d.evidencePath && d.evidencePath.length) {
+    const ev = section(doc, 'Evidence path', String(d.protocol).toUpperCase());
+    ev.appendChild(el('div', null,
+      `<div style="font-family:var(--font-mono);font-size:11.5px;line-height:1.6;color:var(--ink-soft)">` +
+      d.evidencePath.map(e => esc(e)).join('<br>') + `</div>`));
+  }
+  setFooter(doc, d.nextStep);
+}
+
+function renderScreening(doc, d) {
+  const s = section(doc, 'Identity checks', `${d.failedChecks} of ${(d.checks || []).length} failed`);
+  (d.checks || []).forEach(c => s.appendChild(el('div', 'gw-check',
+    `<span class="g" style="color:var(--${c.passed ? 'clear' : 'danger'})">${c.passed ? GLYPH.pass : GLYPH.fail}</span>` +
+    `<span><span class="l">${esc(c.label)}</span><span class="d"> — ${esc(c.detail)}</span></span>`)));
+  setFooter(doc, d.nextStep);
+}
+
+function renderScore(doc, d) {
+  const tone = toneOfVerdict(d.verdict);
+  setHero(doc,
+    `<div class="gw-hero"><div style="min-width:0;flex:1">` + micro('Trust score') +
+    `<div class="gw-hero-n" style="color:var(--${tone})">${d.score}<small>/100</small></div>` +
+    tickMeter(d.score, 100, tone) +
+    `<div class="gw-hero-band">${esc(d.band)} · ${d.failedSignals} of ${(d.signals || []).length} signals failed</div>` +
+    `</div>` + stamp(d.verdict, tone) + `</div>`);
+
+  const s = section(doc, 'Risk signals', 'points awarded / weight');
+  (d.signals || []).forEach(g => {
+    const t = toneOfStatus(g.status);
+    s.appendChild(el('div', 'gw-sig',
+      `<div class="gw-sig-head"><span class="gw-sig-name">${esc(g.label)}</span>` +
+      `<span class="gw-sig-pts" style="color:var(--${t})">${g.points}/${g.max} ${esc(String(g.status).toUpperCase())}</span></div>` +
+      `<div style="margin:5px 0 4px">${tickMeter(g.points, g.max, t, 16)}</div>` +
+      `<div class="gw-sig-detail">${esc(g.detail)}</div>`));
+  });
+
+  if (d.conflicts && d.conflicts.length) {
+    const c = section(doc, 'Conflicting evidence', String(d.conflicts.length));
+    d.conflicts.forEach(x => {
+      const box = el('div', 'gw-callout', esc(x));
+      box.style.background = 'var(--hold-wash)';
+      box.style.borderLeft = '3px solid var(--hold)';
+      c.appendChild(box);
+    });
+  }
+
+  if (d.hitlRequired && d.verdict === 'hold') {
+    section(doc, 'Human review').appendChild(el('div', null,
+      `<div style="font-family:var(--font-sans);font-size:12px;line-height:1.45">Order total exceeds the ` +
+      `${esc(d.hitlThreshold)} threshold. A person signs off before this sale settles, regardless of score.</div>`));
+  }
+
+  if (d.reasoning && d.reasoning.length) {
+    section(doc, 'Gateway reasoning').appendChild(el('div', null,
+      `<div style="font-family:var(--font-sans);font-size:12px;line-height:1.5;color:var(--ink-soft)">` +
+      d.reasoning.map(x => esc(x)).join('<br><br>') + `</div>`));
+  }
+  setFooter(doc, d.nextStep);
+}
+
+function renderVerify(doc, d) {
+  const tone = d.verified ? 'clear' : 'danger';
+  const bad = (d.diffs || []).filter(x => !x.match).length;
+
+  setHero(doc,
+    `<div class="gw-hero"><div style="min-width:0;flex:1">` +
+    micro(d.verified ? 'Settlement consistent' : 'Settlement discrepancy') +
+    `<div style="font-family:var(--font-sans);font-size:13.5px;line-height:1.45;margin-top:6px">${esc(d.summary || '')}</div>` +
+    `</div>` + stamp(d.verified ? 'Verified' : 'Mismatch', tone) + `</div>`);
+
+  const s = section(doc, 'Field comparison', `${bad} of ${(d.diffs || []).length} disagree`);
+  const head = el('div', 'ds-diff');
+  head.style.cssText = 'padding-bottom:6px;border-bottom:1px solid var(--rule);margin-bottom:2px';
+  head.innerHTML = micro('Receipt claims') + '<div class="ds-diff-gutter"></div>' + micro('Chain records');
+  s.appendChild(head);
+
+  (d.diffs || []).forEach(row => {
+    const b = !row.match;
+    const wrap = el('div');
+    wrap.style.cssText = `background:${b ? 'var(--danger-wash)' : 'transparent'};border-bottom:1px solid var(--rule-soft);padding:9px 0`;
+    wrap.innerHTML =
+      `<div style="font-family:var(--font-sans);font-size:11px;font-weight:600;color:var(--${b ? 'danger' : 'ink-soft'});` +
+      `margin-bottom:4px;padding-left:${b ? 9 : 0}px;${b ? 'border-left:3px solid var(--danger)' : ''}">${esc(row.field)}</div>` +
+      `<div class="ds-diff" style="padding-left:${b ? 12 : 0}px">` +
+      `<div style="font-family:var(--font-mono);font-size:13px;color:var(--${b ? 'danger' : 'ink'});font-weight:${b ? 700 : 400}">${esc(row.receiptValue)}</div>` +
+      `<div class="ds-diff-gutter" aria-hidden="true" style="font-family:var(--font-mono);font-size:15px;font-weight:700;` +
+      `text-align:center;color:var(--${b ? 'danger' : 'rule'})">${b ? GLYPH.ne : GLYPH.eq}</div>` +
+      `<div style="font-family:var(--font-mono);font-size:13px;color:var(--${b ? 'danger' : 'ink'});font-weight:${b ? 700 : 400}">${esc(row.chainValue)}</div></div>`;
+    s.appendChild(wrap);
+  });
+
+  /* Seller exposure — a money total, so it carries the 3px double rule. */
+  const ex = el('div', 'gw-exposure');
+  ex.style.borderBottom = `3px double var(--${d.verified ? 'rule' : 'danger'})`;
+  ex.innerHTML = micro('Seller exposure') +
+    `<div class="n" style="color:var(--${d.verified ? 'ink-soft' : 'danger'})">${esc(d.exposure)}</div>`;
+  doc.insertBefore(ex, doc.querySelector('.gw-foot'));
+
+  if (d.chain) {
+    section(doc, 'Settlement record').appendChild(el('div', null,
+      `<div style="font-family:var(--font-mono);font-size:11.5px;line-height:1.6;color:var(--ink-soft)">` +
+      `<div style="word-break:break-all"><span style="color:var(--ink)">tx</span> ${esc(d.chain.txHash)}</div>` +
+      `<div><span style="color:var(--ink)">network</span> ${esc(d.chain.network)}</div>` +
+      `<div><span style="color:var(--ink)">settled</span> ${esc(d.chain.settledAt)}</div></div>`));
+  }
+
+  if (d.recommendedAction) {
+    const box = el('div', 'gw-callout', esc(d.recommendedAction));
+    box.style.background = `var(--${tone}-wash)`;
+    box.style.borderLeft = `3px solid var(--${tone})`;
+    box.style.marginBottom = '0';
+    section(doc, 'Recommended action').appendChild(box);
+  }
+  setFooter(doc, d.nextStep);
+}
+
+function renderFlag(doc, d) {
+  const s = section(doc, 'Dispute raised', d.exposure);
+  s.appendChild(el('div', 'gw-check',
+    `<span class="g" style="color:var(--danger)">${GLYPH.flag}</span>` +
+    `<span><span class="l">${esc(d.orderId)} marked ${esc(d.status)}</span><span class="d"> — ${esc(d.reason)}</span></span>`));
+  (d.evidence || []).forEach(e => s.appendChild(el('div', 'gw-row', `<span class="q">${esc(e)}</span>`)));
+  setFooter(doc, d.nextStep);
+}
+
+function renderBlocklistDoc(doc, d) {
+  const s = section(doc, 'Store blocklist', `${d.blocklistSize} on list`);
+  s.appendChild(el('div', 'gw-check',
+    `<span class="g" style="color:var(--danger)">${GLYPH.fail}</span>` +
+    `<span><span class="l">${esc(d.displayName || d.agentId)} banned</span><span class="d"> — ${esc(d.reason)}</span></span>`));
+  setFooter(doc, d.nextStep);
+}
+
+/* ============================================================ alert rail == */
+
+let alertsOn = true;
+const alertRows = [];
+
+function raiseAlert(glyph, tone, text, amount) { alertRows.unshift({ glyph, tone, text, amount }); drawAlerts(); }
+function clearAlerts() { alertRows.length = 0; drawAlerts(); }
+
+function drawAlerts() {
+  const list = $('alertList');
+  $('alertCount').textContent = String(alertRows.length);
+  list.innerHTML = '';
+  if (!alertsOn) { list.appendChild(el('div', 'none', 'Alerts muted.')); return; }
+  if (!alertRows.length) { list.appendChild(el('div', 'none', 'No alerts raised.')); return; }
+  alertRows.forEach(a => list.appendChild(el('div', 'alert',
+    `<span class="g" style="color:var(--${a.tone})">${a.glyph}</span><span>${esc(a.text)}</span>` +
+    `<span class="amt" style="color:var(--${a.tone})">${esc(a.amount || '')}</span>`)));
+}
+
+function alertFor(tool, d) {
+  if (tool === 'compute_trust_score') {
+    if (d.verdict === 'decline') raiseAlert(GLYPH.fail, 'danger', `${d.orderId} declined — ${d.agentDisplayName}, ${d.score}/100`, d.orderTotal);
+    else if (d.verdict === 'hold') raiseAlert(GLYPH.hold, 'hold', `${d.orderId} held for seller review — ${d.score}/100`, d.orderTotal);
+  }
+  if (tool === 'verify_receipt' && !d.verified)
+    raiseAlert(GLYPH.flag, 'danger', `${d.orderId} settlement mismatch — ${d.mismatchCount} field(s)`, d.exposure);
+  if (tool === 'flag_order') raiseAlert(GLYPH.flag, 'danger', `${d.orderId} marked disputed`, d.exposure);
+}
+
+/* ======================================================== seller actions == */
+
+function actionBar(doc, ctx) {
+  if (!ctx.orderId || !ctx.agentId) return;
+  const s = section(doc, 'Seller actions', 'live tool calls');
+  const bar = el('div', 'gw-actions');
+  const note = el('div', 'gw-act-note');
+
+  const mk = (label, tone, run) => {
+    const b = el('button', 'gw-act', esc(label));
+    b.type = 'button';
+    if (tone) b.dataset.tone = tone;
+    b.addEventListener('click', () => guard(async () => {
+      b.disabled = true;
+      try {
+        note.innerHTML += `› ${esc(await run())}<br>`;
+        b.dataset.done = 'true';
+      } catch (e) {
+        b.disabled = false;
+        note.innerHTML += `› <span style="color:var(--danger)">${esc(e.message)}</span><br>`;
+      }
+      await refresh();
+    }));
+    bar.appendChild(b);
+  };
+
+  mk('⚑ Flag order', 'danger', async () => {
+    const d = await mcp.call('flag_order', {
+      order_id: ctx.orderId,
+      reason: 'Flagged by seller from the gateway console',
+      evidence: ctx.evidence || [],
+    });
+    alertFor('flag_order', d);
+    return `${d.orderId} marked ${d.status} — exposure ${d.exposure}`;
+  });
+
+  mk('✗ Blocklist agent', 'danger', async () => {
+    const d = await mcp.call('blocklist_agent', {
+      agent_id: ctx.agentId, reason: 'Blocked by seller from the gateway console',
+    });
+    raiseAlert(GLYPH.fail, 'danger', `${d.displayName} banned from the store`, `${d.blocklistSize} on list`);
+    return `${d.displayName} banned — ${d.blocklistSize} agent(s) on the blocklist`;
+  });
+
+  mk('‖ Re-screen order', 'hold', async () => {
+    const d = await mcp.call('compute_trust_score', { order_id: ctx.orderId });
+    alertFor('compute_trust_score', d);
+    return `${d.orderId} re-scored ${d.score}/100 → ${d.verdict}`;
+  });
+
+  s.appendChild(bar);
+  s.appendChild(note);
+}
+
+/* ============================================================== dashboard == */
+
+function renderKpis(d) {
+  const c = d.counts || {};
+  $('kpis').innerHTML =
+    `<div class="kpi lead">${micro('Revenue protected')}` +
+      `<div class="n">${esc(d.revenueProtected)}</div>` +
+      `<div class="sub">stopped before it left NovaGear</div></div>` +
+    `<div class="kpi">${micro('Approved revenue')}` +
+      `<div class="n plain">${esc(d.approvedRevenue)}</div>` +
+      `<div class="sub">${c.approved || 0} order(s) cleared to settle</div></div>` +
+    `<div class="kpi">${micro('Agent orders')}` +
+      `<div class="n plain">${d.totalOrders}</div>` +
+      `<div class="tally">` +
+        `<span style="color:var(--clear)">${GLYPH.pass} <b>${c.approved || 0}</b></span>` +
+        `<span style="color:var(--hold)">${GLYPH.hold} <b>${c.held || 0}</b></span>` +
+        `<span style="color:var(--danger)">${GLYPH.fail} <b>${c.declined || 0}</b></span>` +
+        `<span style="color:var(--danger)">${GLYPH.flag} <b>${c.flagged || 0}</b></span>` +
+        `<span style="color:var(--ink-soft)">${GLYPH.pending} <b>${c.pending || 0}</b></span>` +
+      `</div></div>` +
+    `<div class="kpi">${micro('Human review threshold')}` +
+      `<div class="n plain">${esc(d.hitlThreshold)}</div>` +
+      `<div class="sub">orders above this always hold</div></div>`;
+}
+
+function renderFeed(d) {
+  const feed = $('feed');
+  feed.innerHTML = '';
+  $('feedNote').textContent = `${(d.feed || []).length} orders`;
+  (d.feed || []).forEach(o => {
+    const b = el('button', 'row');
+    b.type = 'button';
+    b.dataset.s = o.status;
+    b.setAttribute('aria-current', String(selected === o.orderId));
+    b.innerHTML =
+      `<span class="g">${STATUS_GLYPH[o.status] || GLYPH.pending}</span>` +
+      `<span><span class="id">${esc(o.orderId)}</span>` +
+      `<span class="who">${esc(o.agentDisplayName)} · ${esc(String(o.protocol).toUpperCase())} · ${esc(o.items)}</span></span>` +
+      `<span class="amt">${esc(o.total)}</span>`;
+    b.addEventListener('click', () => guard(() => investigate(o.orderId)));
+    feed.appendChild(b);
+  });
+}
+
+function renderSideBlocklist(d) {
+  const box = $('blocklist');
+  $('blockNote').textContent = String((d.blocklist || []).length);
+  box.innerHTML = '';
+  if (!(d.blocklist || []).length) { box.appendChild(el('div', 'none', 'No agents banned.')); return; }
+  d.blocklist.forEach(b => box.appendChild(el('div', 'mini',
+    `<span class="k" style="color:var(--danger)">${GLYPH.fail} ${esc(b.displayName || b.agentId)}</span>` +
+    `<span class="v">${esc(b.reason)}</span>`)));
+}
+
+function renderDecisions(d) {
+  const box = $('decisions');
+  box.innerHTML = '';
+  if (!(d.decisions || []).length) { box.appendChild(el('div', 'none', 'No decisions yet.')); return; }
+  d.decisions.forEach(x => {
+    const tone = toneOfVerdict(x.verdict);
+    box.appendChild(el('div', 'mini',
+      `<span class="k">${esc(x.orderId)} <span style="color:var(--${tone})">${esc(x.verdict)}</span></span>` +
+      `<span class="v">${x.score}/100 · ${esc(String(x.decidedAt).slice(11, 19))}</span>`));
+  });
+}
+
+async function refresh() {
+  const d = await mcp.call('get_sales_dashboard', {});
+  renderKpis(d);
+  renderFeed(d);
+  renderSideBlocklist(d);
+  renderDecisions(d);
+  return d;
+}
+
+/* =========================================================== investigate == */
+/* Clicking an order runs the real chain against it. compute_trust_score applies
+   its own verdict, so the feed status changes as a result — the gateway acting,
+   not the console pretending. */
+
+async function investigate(orderId, extra) {
+  selected = orderId;
+  $('detail').innerHTML = '';
+  const ctx = { orderId };
+  let doc = null;
+
+  const step = async (label, tool, args, statusOf) => {
+    const settle = doc ? traceStep(doc, label) : null;
+    const t0 = performance.now();
+    let data;
+    try {
+      data = await mcp.call(tool, args);
+    } catch (e) {
+      if (settle) settle('fail', Math.round(performance.now() - t0));
+      if (doc) section(doc, 'Call failed', tool).appendChild(el('div', 'gw-err', esc(e.message)));
+      throw e;
+    }
+    const ms = Math.round(performance.now() - t0);
+    if (settle) settle(statusOf ? statusOf(data) : 'pass', ms);
+    if (BEAT) await wait(BEAT);
+    return { data, ms };
+  };
+
+  // 1. the order itself — opens the screening document
+  const t0 = performance.now();
+  const order = await mcp.call('place_agent_order', { order_ref: orderId });
+  ctx.agentId = order.agentId;
+  doc = newDocument(
+    `<strong>${esc(order.orderId)}</strong><span style="color:var(--ink-soft)"> · ` +
+    `${esc(String(order.protocol).toUpperCase())} · NOVAGEAR</span>`,
+    'AGENT ORDER SCREENING', 560);
+  traceStep(doc, 'normalize payload')('pass', Math.round(performance.now() - t0));
+  renderOrder(doc, order);
+  if (BEAT) await wait(BEAT);
+
+  // 2. identity screening
+  const scr = await step('screen agent identity', 'screen_agent', { order_id: orderId },
+    d => (d.failedChecks > 0 ? 'fail' : 'pass'));
+  renderScreening(doc, scr.data);
+
+  // 3. score, decide, and apply
+  const sc = await step('score and decide', 'compute_trust_score', { order_id: orderId },
+    d => (d.verdict === 'approve' ? 'pass' : d.verdict === 'hold' ? 'hold' : 'fail'));
+  alertFor('compute_trust_score', sc.data);
+  renderScore(doc, sc.data);
+  actionBar(doc, ctx);
+
+  // 4. settled orders also get a receipt document
+  let receiptDoc = null;
+  try {
+    const t1 = performance.now();
+    const ver = await mcp.call('verify_receipt', { order_id: orderId });
+    ctx.agentId = ver.agentId || ctx.agentId;
+    ctx.evidence = (ver.diffs || []).filter(x => !x.match)
+      .map(x => `${x.field}: receipt ${x.receiptValue} vs chain ${x.chainValue}`);
+    receiptDoc = newDocument(
+      `<strong>${esc(ver.orderId)}</strong><span style="color:var(--ink-soft)"> · ${esc(ver.agentDisplayName || '')}</span>`,
+      'RECEIPT vs ON-CHAIN RECORD', 620);
+    traceStep(receiptDoc, 'diff receipt vs chain')(ver.verified ? 'pass' : 'fail', Math.round(performance.now() - t1));
+    alertFor('verify_receipt', ver);
+    renderVerify(receiptDoc, ver);
+    actionBar(receiptDoc, ctx);
+  } catch {
+    // Unsettled orders have no receipt to diff — not an error, just not applicable.
+  }
+
+  // 5. scripted follow-up actions, when run from a scenario
+  for (const act of (extra || [])) {
+    const target = receiptDoc || doc;
+    const args = act.fromDiffs
+      ? { order_id: orderId, reason: 'Receipt amount does not match on-chain settlement', evidence: ctx.evidence || [] }
+      : act.args;
+    const r = await step(act.label, act.tool, args, () => 'hold');
+    alertFor(act.tool, r.data);
+    if (act.tool === 'flag_order') renderFlag(target, r.data);
+    if (act.tool === 'blocklist_agent') renderBlocklistDoc(target, r.data);
+  }
+
+  await refresh();
+}
+
+/* ================================================================ chrome == */
+
+function setStatus(state, host) {
+  $('status').dataset.state = state;
+  $('statusGlyph').textContent =
+    state === 'live' ? GLYPH.pass : state === 'down' ? GLYPH.fail : state === 'busy' ? GLYPH.hold : GLYPH.pending;
+  if (host) $('statusHost').textContent = host;
+}
+
+function setBusy(state) {
+  busy = state;
+  document.querySelectorAll('.chip, .sel, .row, .gw-act').forEach(b => {
+    if (b.dataset.done !== 'true') b.disabled = state;
+  });
+  if (state) setStatus('busy');
+}
+
+async function guard(fn) {
+  if (busy) return;
+  setBusy(true);
+  try { await fn(); setStatus('live'); }
+  catch (e) { setStatus('down', 'error — check endpoint'); console.error(e); }
+  finally { setBusy(false); }
+}
+
+/* ================================================================== boot == */
+
+async function connect() {
+  await mcp.connect();
+  $('endpoint').value = mcp.base;
+  setStatus('live', new URL(mcp.endpoint()).host);
+  await refresh();
+}
+
+function boot() {
+  const sel = $('scenario');
+  SCENARIOS.forEach(s => {
+    const o = document.createElement('option');
+    o.value = s.id;
+    o.textContent = `Case ${s.no} · ${s.name}`;
+    sel.appendChild(o);
+  });
+
+  sel.addEventListener('change', (e) => {
+    const s = SCENARIOS.find(x => x.id === e.target.value);
+    e.target.value = '';
+    if (s) guard(() => investigate(s.order, s.then));
+  });
+
+  $('refresh').addEventListener('click', () => guard(refresh));
+
+  $('runAll').addEventListener('click', () => guard(async () => {
+    await mcp.call('reset_demo', {});
+    clearAlerts();
+    for (const s of SCENARIOS) await investigate(s.order, s.then);
+  }));
+
+  $('reset').addEventListener('click', () => guard(async () => {
+    await mcp.call('reset_demo', {});
+    clearAlerts();
+    selected = null;
+    $('detail').innerHTML = '<div class="ds-empty">GATEWAY RESET — SELECT AN ORDER TO INVESTIGATE IT</div>';
+    await refresh();
+  }));
+
+  $('endpoint').addEventListener('change', (e) => {
+    const typed = e.target.value.trim();
+    mcp.pinned = !!typed;
+    mcp.base = typed || DEFAULT_BASE;
+    mcp.ready = false;
+    mcp.session = null;
+    guard(connect);
+  });
+
+  const alertBtn = $('alertsBtn');
+  alertBtn.addEventListener('click', () => {
+    alertsOn = !alertsOn;
+    alertBtn.setAttribute('aria-pressed', String(alertsOn));
+    alertBtn.textContent = alertsOn ? '⚑ alerts on' : '⚑ alerts off';
+    drawAlerts();
+  });
+
+  const themeBtn = $('theme');
+  const applyTheme = (dark) => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+    themeBtn.textContent = dark ? '☀ light' : '☾ dark';
+  };
+  const wantTheme = new URLSearchParams(location.search).get('theme');
+  let dark = wantTheme ? wantTheme === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches;
+  applyTheme(dark);
+  themeBtn.addEventListener('click', () => { dark = !dark; applyTheme(dark); });
+
+  drawAlerts();
+  setStatus('idle', 'connecting…');
+
+  guard(async () => {
+    await connect();
+    // ?run=all | <scenario id> — plays on load, for a demo recording or kiosk.
+    const want = new URLSearchParams(location.search).get('run');
+    if (!want) return;
+    await mcp.call('reset_demo', {});
+    clearAlerts();
+    const queue = want === 'all' ? SCENARIOS : SCENARIOS.filter(s => s.id === want);
+    for (const s of queue) await investigate(s.order, s.then);
+  });
+}
+
+boot();
+</script>
+</body>
+</html>

--- a/sample-apps/agentic-commerce-gateway/package-lock.json
+++ b/sample-apps/agentic-commerce-gateway/package-lock.json
@@ -1,0 +1,4577 @@
+{
+  "name": "agentic-commerce-gateway",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agentic-commerce-gateway",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0",
+        "@nitrostack/core": "^1.0.14",
+        "dotenv": "^16.3.1",
+        "zod": "^3.22.4"
+      },
+      "devDependencies": {
+        "@nitrostack/cli": "^1.0.15",
+        "@types/node": "^22.10.0",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.5.tgz",
+      "integrity": "sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@nitrostack/cli": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@nitrostack/cli/-/cli-1.0.15.tgz",
+      "integrity": "sha512-xyIbeAj2/Tpd2khh6Xq1l8y1rbrxQ0t1/c3836g9WrWqC8aNFIKoUvTLuPEZoF4x4ATyjPoZ2NIK90pywuuCRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "archiver": "^7.0.1",
+        "chalk": "^5.3.0",
+        "chokidar": "^3.6.0",
+        "commander": "^12.1.0",
+        "esbuild": "^0.24.0",
+        "fs-extra": "^11.3.2",
+        "inquirer": "^9.3.7",
+        "open": "^10.1.0",
+        "ora": "^8.1.1",
+        "posthog-node": "^5.21.2"
+      },
+      "bin": {
+        "cli": "dist/index.js",
+        "nitrostack-cli": "dist/index.js",
+        "nitrostack-pack": "dist/pack/standalone.js"
+      }
+    },
+    "node_modules/@nitrostack/core": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@nitrostack/core/-/core-1.0.14.tgz",
+      "integrity": "sha512-FfG5rOxZwAztHiwPqRPj3xjgoiiPa1A06y2BBqGRlNAkK8R5izImD/f3zhvo1OrGKtoDC/qEw2iykKK24UR/FA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.4",
+        "bcryptjs": "^2.4.3",
+        "cors": "^2.8.5",
+        "dotenv": "^17.2.3",
+        "express": "^4.21.2",
+        "jose": "^6.1.0",
+        "jsonwebtoken": "^9.0.2",
+        "reflect-metadata": "^0.2.1",
+        "uuid": "^11.0.5",
+        "winston": "^3.17.0",
+        "ws": "^8.18.3",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/@nitrostack/core/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/@nitrostack/core/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/@nitrostack/core/node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.46.0.tgz",
+      "integrity": "sha512-9w/bzHkf8V26YDAk7bO+Y2M0O9LMJg53lw3TOpirWRY77CEq4EQ3FkrtxP6BM48qaeZ/ILmRcfz+u1jjeTLetg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.399.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.399.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.399.0.tgz",
+      "integrity": "sha512-/WDwBzqIPko8VJ1B+0rlso2XQEz9+2sqtsY9Tqy3p1GhgTqsFakcz/PmMpAnA321LTEZVRcO6x5hAwABV4yrDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.33",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
+      "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/inquirer": {
+      "version": "9.3.8",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.3.8.tgz",
+      "integrity": "sha512-pFGGdaHrmRKMh4WoDDSowddgjT1Vkl90atobmTeSmcPGdYiwikch/m/Ef5wRaiamHejtw0cUUMMerzDUXCci2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/external-editor": "^1.0.2",
+        "@inquirer/figures": "^1.0.3",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "1.0.0",
+        "ora": "^5.4.1",
+        "run-async": "^3.0.0",
+        "rxjs": "^7.8.1",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.5.tgz",
+      "integrity": "sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/posthog-node": {
+      "version": "5.47.0",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.47.0.tgz",
+      "integrity": "sha512-dp8h6rdfu9WzFSbJJxsuplmjgDFUsVFce1QPmlhWF/Fy/XWf56JRx4AZNzXRrKVb1F1p+2yWg6adLZEKcvBOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.46.0"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/sample-apps/agentic-commerce-gateway/package.json
+++ b/sample-apps/agentic-commerce-gateway/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "agentic-commerce-gateway",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Agentic Commerce Gateway - fraud screening for AI shopping agents",
+  "scripts": {
+    "dev": "nitrostack-cli dev",
+    "build": "nitrostack-cli build && node scripts/copy-console.mjs",
+    "start": "npm run build && nitrostack-cli start",
+    "start:prod": "nitrostack-cli start",
+    "upgrade": "nitrostack-cli upgrade",
+    "install:all": "nitrostack-cli install",
+    "widget": "npm --prefix src/widgets",
+    "test": "npm run build && node scripts/e2e.mjs",
+    "test:live": "node scripts/e2e.mjs --url https://agentic-commerce-gateway-6a6cafaa-rudra-srmist.app.nitrocloud.ai"
+  },
+  "dependencies": {
+    "dotenv": "^16.3.1",
+    "@nitrostack/core": "^1.0.14",
+    "zod": "^3.22.4",
+    "@modelcontextprotocol/ext-apps": ">=0.1.0"
+  },
+  "devDependencies": {
+    "@nitrostack/cli": "^1.0.15",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.3.3"
+  },
+  "author": "NovaGear",
+  "nitrostack": {
+    "skillsVersion": "1.0.0"
+  }
+}

--- a/sample-apps/agentic-commerce-gateway/scripts/copy-console.mjs
+++ b/sample-apps/agentic-commerce-gateway/scripts/copy-console.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * Copies the seller console into `dist/` after the TypeScript build.
+ *
+ * `tsc` only emits compiled modules, so a loose .html asset would never reach
+ * `dist/` on its own — the same reason the fixtures are authored as .ts. The
+ * console is a single self-contained file, so a copy is enough; it lands beside
+ * its compiled route handler, which resolves it relative to `import.meta.url`.
+ */
+
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const src = path.join(ROOT, 'console', 'index.html');
+const destDir = path.join(ROOT, 'dist', 'console');
+
+mkdirSync(destDir, { recursive: true });
+copyFileSync(src, path.join(destDir, 'index.html'));
+
+console.log('✓ Console copied to dist/console/index.html');

--- a/sample-apps/agentic-commerce-gateway/scripts/e2e.mjs
+++ b/sample-apps/agentic-commerce-gateway/scripts/e2e.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * End-to-end test for the Agentic Commerce Gateway.
+ *
+ * Speaks real MCP to the server and runs the three demo scenarios, so a green
+ * run means the tools actually work through the protocol — not just that the
+ * functions return.
+ *
+ *   node scripts/e2e.mjs                 # local build over STDIO
+ *   node scripts/e2e.mjs --url <base>    # deployed server over Streamable HTTP
+ *
+ * Exits non-zero if any check fails.
+ */
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const urlFlag = process.argv.indexOf('--url');
+const BASE_URL = urlFlag !== -1 ? process.argv[urlFlag + 1] : null;
+
+// ---------------------------------------------------------------- transports
+
+/** Talks to a local `node dist/index.js` over newline-delimited JSON-RPC. */
+function stdioTransport() {
+  const server = spawn('node', ['dist/index.js'], {
+    cwd: ROOT,
+    env: { ...process.env, NODE_ENV: 'development', MCP_TRANSPORT_TYPE: 'stdio' },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const pending = new Map();
+  let buf = '';
+  let markReady;
+  const ready = new Promise((r) => { markReady = r; });
+
+  server.stdout.on('data', (chunk) => {
+    buf += chunk.toString();
+    let i;
+    while ((i = buf.indexOf('\n')) !== -1) {
+      const line = buf.slice(0, i).trim();
+      buf = buf.slice(i + 1);
+      if (!line) continue;
+      let msg;
+      try { msg = JSON.parse(line); } catch { continue; }
+      if (msg.id !== undefined && pending.has(msg.id)) {
+        pending.get(msg.id)(msg);
+        pending.delete(msg.id);
+      }
+    }
+  });
+
+  // The stdio transport attaches after bootstrap; sending earlier drops the message.
+  server.stderr.on('data', (c) => {
+    if (c.toString().includes('started successfully')) markReady();
+  });
+
+  let nextId = 1;
+  return {
+    label: 'local build (STDIO)',
+    async start() {
+      await Promise.race([ready, new Promise((r) => setTimeout(r, 20000))]);
+      await new Promise((r) => setTimeout(r, 300));
+    },
+    async send(method, params, isNotification = false) {
+      if (isNotification) {
+        server.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n');
+        return null;
+      }
+      const id = nextId++;
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`timeout on ${method}`)), 30000);
+        pending.set(id, (m) => { clearTimeout(timer); resolve(m); });
+        server.stdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
+      });
+    },
+    stop() { server.kill('SIGTERM'); },
+  };
+}
+
+/** Talks to a deployed server over Streamable HTTP; replies arrive as SSE frames. */
+function httpTransport(base) {
+  const endpoint = base.replace(/\/+$/, '') + '/mcp';
+  let sessionId = null;
+  let nextId = 1;
+
+  const parseSse = (text) =>
+    text
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.startsWith('data:'))
+      .flatMap((l) => {
+        try { return [JSON.parse(l.slice(5).trim())]; } catch { return []; }
+      });
+
+  return {
+    label: `deployed server (${endpoint})`,
+    async start() {},
+    async send(method, params, isNotification = false) {
+      const body = isNotification
+        ? { jsonrpc: '2.0', method, params }
+        : { jsonrpc: '2.0', id: nextId++, method, params };
+      const headers = {
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      };
+      if (sessionId) headers['Mcp-Session-Id'] = sessionId;
+
+      const res = await fetch(endpoint, { method: 'POST', headers, body: JSON.stringify(body) });
+      const sid = res.headers.get('mcp-session-id');
+      if (sid) sessionId = sid;
+      if (isNotification) return null;
+
+      const text = await res.text();
+      const msgs = parseSse(text);
+      const msg = msgs.find((m) => m.id === body.id) ?? msgs[0];
+      if (!msg) throw new Error(`no response for ${method}: ${text.slice(0, 200)}`);
+      return msg;
+    },
+    stop() {},
+  };
+}
+
+// ------------------------------------------------------------------ harness
+
+const t = BASE_URL ? httpTransport(BASE_URL) : stdioTransport();
+
+function payload(res) {
+  if (res.error) throw new Error(`RPC error: ${JSON.stringify(res.error)}`);
+  if (res.result?.structuredContent) return res.result.structuredContent;
+  const text = res.result?.content?.find((c) => c.type === 'text')?.text;
+  if (!text) return res.result;
+  try { return JSON.parse(text); } catch { return text; }
+}
+
+const fails = [];
+function check(label, cond, detail = '') {
+  console.log(`   ${cond ? '\x1b[32m✓\x1b[0m' : '\x1b[31m✗\x1b[0m'} ${label}${detail ? ` — ${detail}` : ''}`);
+  if (!cond) fails.push(label);
+}
+
+const call = async (name, args) => payload(await t.send('tools/call', { name, arguments: args }));
+
+async function main() {
+  await t.start();
+
+  const init = await t.send('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'gateway-e2e', version: '1.0.0' },
+  });
+  console.log(`\nTarget: ${t.label}`);
+  console.log(`Server: ${init.result?.serverInfo?.name} ${init.result?.serverInfo?.version}\n`);
+  await t.send('notifications/initialized', {}, true);
+
+  console.log('── SURFACE ──');
+  const tools = (await t.send('tools/list', {})).result.tools.map((x) => x.name).sort();
+  const expected = [
+    'blocklist_agent', 'compute_trust_score', 'flag_order', 'get_sales_dashboard',
+    'list_products', 'place_agent_order', 'reset_demo', 'screen_agent', 'verify_receipt',
+  ];
+  check('all 9 tools registered', expected.every((e) => tools.includes(e)), `${tools.length} tools`);
+
+  const resources = ((await t.send('resources/list', {})).result?.resources ?? []).map((r) => r.uri);
+  check('3 widget resources served', resources.filter((u) => u.startsWith('ui://widget/')).length === 3);
+  check('3 gateway resources served', resources.filter((u) => u.startsWith('novagear://')).length === 3);
+  check('2 prompts registered', ((await t.send('prompts/list', {})).result?.prompts ?? []).length === 2);
+
+  await call('reset_demo', {});
+
+  const cat = await call('list_products', {});
+  check('catalog has 8 SKUs', cat.count === 8);
+
+  console.log('\n── SCENARIO 1: clean sale ──');
+  const o1 = await call('place_agent_order', { order_ref: 'ord_1001' });
+  check('ACP payload normalized', o1.protocol === 'acp', `${o1.orderId} ${o1.total}`);
+  const s1 = await call('screen_agent', { order_id: 'ord_1001' });
+  check('signature verifies', s1.signatureValid === true);
+  check('no failed identity checks', s1.failedChecks === 0);
+  const t1 = await call('compute_trust_score', { order_id: 'ord_1001' });
+  check('approved', t1.verdict === 'approve', `score ${t1.score}/100`);
+
+  console.log('\n── SCENARIO 2: fraudulent buyer blocked ──');
+  const o2 = await call('place_agent_order', { order_ref: 'ord_1002' });
+  check('x402 payload normalized', o2.protocol === 'x402', `${o2.orderId} ${o2.total}`);
+  const s2 = await call('screen_agent', { order_id: 'ord_1002' });
+  check('spoofed signature rejected', s2.signatureValid === false);
+  const t2 = await call('compute_trust_score', { order_id: 'ord_1002' });
+  check('declined', t2.verdict === 'decline', `score ${t2.score}/100`);
+  check('multiple risk signals failed', t2.failedSignals >= 3, `${t2.failedSignals} of 5 failed`);
+  const b2 = await call('blocklist_agent', {
+    agent_id: 'agt_ghost_nyx', reason: 'Spoofed signature on a 40-unit order',
+  });
+  check('agent blocklisted', b2.blocked === true);
+
+  const o2b = await call('place_agent_order', {
+    protocol: 'acp', agent_id: 'agt_ghost_nyx', items: [{ sku: 'NG-MS-01', qty: 1 }],
+  });
+  const t2b = await call('compute_trust_score', { order_id: o2b.orderId });
+  check("blocklist stops that agent's next order", t2b.verdict === 'decline');
+
+  console.log('\n── SCENARIO 3: tampered receipt caught ──');
+  const t3 = await call('compute_trust_score', { order_id: 'ord_1003' });
+  check('sale passes screening', t3.verdict === 'approve', `score ${t3.score}/100`);
+  const v3 = await call('verify_receipt', { order_id: 'ord_1003' });
+  check('mismatch detected', v3.verified === false, `${v3.mismatchCount} fields disagree`);
+  check('exposure priced exactly', v3.exposureMinor === 4499100, v3.exposure);
+  const amount = v3.diffs.find((d) => d.field === 'amount');
+  check('amount diff surfaced', amount && !amount.match, `${amount?.receiptValue} vs ${amount?.chainValue}`);
+  const f3 = await call('flag_order', {
+    order_id: 'ord_1003',
+    reason: 'Receipt disagrees with the on-chain settlement',
+    evidence: ['amount mismatch', 'quantity mismatch'],
+  });
+  check('order flagged', f3.status === 'flagged', f3.exposure);
+  check('clean settlement still verifies', (await call('verify_receipt', { order_id: 'ord_1001' })).verified === true);
+
+  console.log('\n── HOLDS AND EDGE CASES ──');
+  check('high-value order held for a human', (await call('compute_trust_score', { order_id: 'ord_1009' })).verdict === 'hold');
+  check('velocity abuse held', (await call('compute_trust_score', { order_id: 'ord_1005' })).verdict === 'hold');
+  check('unregistered agent not auto-approved', (await call('compute_trust_score', { order_id: 'ord_1006' })).verdict !== 'approve');
+  check('signed underpayment held', (await call('compute_trust_score', { order_id: 'ord_1008' })).verdict === 'hold');
+  check('payee redirect caught', (await call('verify_receipt', { order_id: 'ord_1008' })).verified === false);
+
+  const bad = await t.send('tools/call', { name: 'screen_agent', arguments: { order_id: 'ord_9999' } });
+  check(
+    'unknown order rejected cleanly',
+    bad.result?.isError === true || bad.error !== undefined ||
+      JSON.stringify(bad.result ?? '').toLowerCase().includes('unknown order'),
+  );
+
+  console.log('\n── DASHBOARD ──');
+  const dash = await call('get_sales_dashboard', {});
+  check('revenue protected counted', dash.revenueProtectedMinor > 0, dash.revenueProtected);
+  check('disputed order listed', dash.flagged.length === 1);
+  check('blocklist populated', dash.blocklist.length >= 1);
+
+  const reset = await call('reset_demo', {});
+  check('reset restores fixtures', reset.orders === 9);
+  check('reset clears blocklist', (await call('get_sales_dashboard', {})).blocklist.length === 0);
+
+  console.log('\n' + '─'.repeat(60));
+  if (fails.length) {
+    console.log(`\x1b[31mFAILED (${fails.length}):\x1b[0m ${fails.join('; ')}`);
+    process.exitCode = 1;
+  } else {
+    console.log('\x1b[32mALL CHECKS PASSED\x1b[0m');
+    process.exitCode = 0;
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error('\nE2E ERROR:', e.message);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    t.stop();
+    // The SDK keeps handles open; exit once results are reported.
+    setTimeout(() => process.exit(process.exitCode ?? 0), 250).unref();
+  });

--- a/sample-apps/agentic-commerce-gateway/src/app.module.ts
+++ b/sample-apps/agentic-commerce-gateway/src/app.module.ts
@@ -1,0 +1,33 @@
+import { McpApp, Module, ConfigModule } from '@nitrostack/core';
+import { GatewayModule } from './modules/gateway/gateway.module.js';
+import { SystemHealthCheck } from './health/system.health.js';
+
+/**
+ * Agentic Commerce Gateway — root module.
+ *
+ * Sits in a seller's checkout: screens the buying agent before a sale settles,
+ * and verifies every sales receipt against the on-chain settlement record.
+ */
+@McpApp({
+  module: AppModule,
+  server: {
+    name: 'agentic-commerce-gateway',
+    version: '1.0.0'
+  },
+  logging: {
+    level: 'info'
+  }
+})
+@Module({
+  name: 'app',
+  description: 'Root application module',
+  imports: [
+    ConfigModule.forRoot(),
+    GatewayModule
+  ],
+  providers: [
+    // Health Checks
+    SystemHealthCheck,
+  ]
+})
+export class AppModule {}

--- a/sample-apps/agentic-commerce-gateway/src/console/console.route.ts
+++ b/sample-apps/agentic-commerce-gateway/src/console/console.route.ts
@@ -1,0 +1,87 @@
+/**
+ * Serves the seller console over the gateway's own HTTP transport.
+ *
+ * The console is a browser MCP client: it talks to `/mcp` on this same origin,
+ * so hosting it here means the deployed service ships both the protocol surface
+ * and a human-usable view of it, with no second deployment and no CORS hop.
+ *
+ * Registered only when an HTTP transport exists — under STDIO-only development
+ * there is nothing to attach to, and that is not an error.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Where to look for the console, in order:
+ *   1. beside this module in `dist/console/` — put there by the build step
+ *   2. the source tree, for the case where `tsc` ran without `npm run build`
+ * Both are derived from this module's own location, never an absolute path.
+ */
+const CONSOLE_CANDIDATES = [
+  path.join(HERE, 'index.html'),
+  path.join(HERE, '..', '..', 'console', 'index.html'),
+];
+
+export const CONSOLE_PATH = '/console';
+
+interface HttpTransportLike {
+  getApp?(): {
+    get(path: string, handler: (req: unknown, res: ConsoleResponse) => void): void;
+  };
+}
+
+interface ConsoleResponse {
+  setHeader(name: string, value: string): void;
+  status(code: number): ConsoleResponse;
+  send(body: string): void;
+}
+
+interface ServerLike {
+  getHttpTransport?(): HttpTransportLike | undefined;
+}
+
+/**
+ * Attaches GET /console. Returns true when the route was registered, so the
+ * caller can decide whether to advertise the URL.
+ */
+export function registerConsoleRoute(server: ServerLike): boolean {
+  const transport = server.getHttpTransport?.();
+  const app = transport?.getApp?.();
+  if (!app) return false;
+
+  // Read once at startup: the file is immutable for the life of the process,
+  // and failing here is better than failing on a judge's first request.
+  let html: string | undefined;
+  for (const candidate of CONSOLE_CANDIDATES) {
+    try {
+      html = readFileSync(candidate, 'utf8');
+      break;
+    } catch {
+      // try the next location
+    }
+  }
+
+  if (!html) {
+    console.error(
+      `⚠️  Seller console asset not found (looked in: ${CONSOLE_CANDIDATES.join(', ')}) — ` +
+        'run "npm run build" to copy it into dist/.',
+    );
+    return false;
+  }
+
+  const handler = (_req: unknown, res: ConsoleResponse) => {
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.status(200).send(html);
+  };
+
+  // Both spellings, so a trailing slash does not 404 in front of an audience.
+  app.get(CONSOLE_PATH, handler);
+  app.get(`${CONSOLE_PATH}/`, handler);
+
+  return true;
+}

--- a/sample-apps/agentic-commerce-gateway/src/fixtures/agents.ts
+++ b/sample-apps/agentic-commerce-gateway/src/fixtures/agents.ts
@@ -1,0 +1,117 @@
+import type { AgentRecord } from '../modules/gateway/gateway.types.js';
+
+/**
+ * Mock buying-agent registry (doubles as `registry.json` from the plan —
+ * reputation, age, dispute history and the signing key all live here so there
+ * is a single source of truth per agent).
+ *
+ * `signingKey` is a mock registry-held secret. Screening recomputes the HMAC
+ * over the canonical order payload and compares it to the signature the agent
+ * presented, so a spoofed signature genuinely fails verification rather than
+ * being hardcoded as "invalid".
+ */
+export const AGENTS: AgentRecord[] = [
+  {
+    agentId: 'agt_shopper_atlas',
+    displayName: 'Atlas Shopping Assistant',
+    operator: 'Atlas AI',
+    registered: true,
+    reputation: 92,
+    accountAgeDays: 420,
+    lifetimeOrders: 341,
+    disputes: 0,
+    ordersLastHour: 2,
+    signingKey: 'sk_atlas_9f2c7a41',
+    wallet: '0xA71a5C0f2b9E4d13aB77c4E9f0D2b8351cE6A904',
+  },
+  {
+    agentId: 'agt_concierge_vega',
+    displayName: 'Vega Personal Concierge',
+    operator: 'Vega Labs',
+    registered: true,
+    reputation: 88,
+    accountAgeDays: 263,
+    lifetimeOrders: 168,
+    disputes: 1,
+    ordersLastHour: 1,
+    signingKey: 'sk_vega_3d81b6e0',
+    wallet: '0xB92c4F17aD5e8B03cE64a1D7f9C820b5E37D4118',
+  },
+  {
+    agentId: 'agt_bulk_orion',
+    displayName: 'Orion Procurement Bot',
+    operator: 'Orion Supply Co.',
+    registered: true,
+    reputation: 74,
+    accountAgeDays: 184,
+    lifetimeOrders: 96,
+    disputes: 2,
+    ordersLastHour: 4,
+    signingKey: 'sk_orion_c40f7e29',
+    wallet: '0xC13d8A26bE9f7C41dA05b3E8a2F91c6D74B05e3F',
+  },
+  {
+    agentId: 'agt_relay_lyra',
+    displayName: 'Lyra Checkout Relay',
+    operator: 'Lyra Systems',
+    registered: true,
+    reputation: 81,
+    accountAgeDays: 151,
+    lifetimeOrders: 122,
+    disputes: 1,
+    ordersLastHour: 3,
+    signingKey: 'sk_lyra_7be23d05',
+    wallet: '0xD45e1B93cF20a7E68b14D9c3A05f2E789C61a802',
+  },
+  {
+    agentId: 'agt_probe_zeta',
+    displayName: 'Zeta Comparison Agent',
+    operator: 'Zeta Retail Tools',
+    registered: true,
+    reputation: 58,
+    accountAgeDays: 61,
+    lifetimeOrders: 44,
+    disputes: 3,
+    ordersLastHour: 6,
+    signingKey: 'sk_zeta_1a9c4f77',
+    wallet: '0xE56f2C04dA31b8F79c25E0d4B16a3F8c05D719A3',
+  },
+  {
+    agentId: 'agt_shadow_umbra',
+    displayName: 'Umbra Checkout Agent',
+    operator: 'unknown',
+    registered: false,
+    reputation: 0,
+    accountAgeDays: 31,
+    lifetimeOrders: 7,
+    disputes: 1,
+    ordersLastHour: 5,
+    signingKey: 'sk_umbra_unregistered',
+  },
+  {
+    agentId: 'agt_swarm_kilo',
+    displayName: 'Kilo Rapid Buyer',
+    operator: 'Kilo Net',
+    registered: true,
+    reputation: 31,
+    accountAgeDays: 9,
+    lifetimeOrders: 210,
+    disputes: 11,
+    ordersLastHour: 47,
+    signingKey: 'sk_kilo_88b0d2fa',
+    wallet: '0xF67a3D15eB42c9086d36F1e5C27b4A9d16E82B04',
+  },
+  {
+    agentId: 'agt_ghost_nyx',
+    displayName: 'Nyx Buyer',
+    operator: 'unverified',
+    registered: true,
+    reputation: 12,
+    accountAgeDays: 1,
+    lifetimeOrders: 3,
+    disputes: 2,
+    ordersLastHour: 9,
+    signingKey: 'sk_nyx_5c73e910',
+    wallet: '0x0189bE47cF63a2D50e91C8f4A76b3D25c04E1f78',
+  },
+];

--- a/sample-apps/agentic-commerce-gateway/src/fixtures/orders.ts
+++ b/sample-apps/agentic-commerce-gateway/src/fixtures/orders.ts
@@ -1,0 +1,234 @@
+/**
+ * Incoming agent orders in two protocol shapes.
+ *
+ * These are **protocol-shaped fixtures, not live integrations** — the field
+ * names mirror ACP / x402 payloads so the normalizer does real work, but no
+ * network call is made anywhere in this project.
+ *
+ * `signature: SIGN_VALID` is a sentinel: the store replaces it at load time
+ * with a genuine HMAC over the canonical payload using the agent's registry
+ * key. Any other value is a forged signature that will fail verification.
+ */
+
+export const SIGN_VALID = '__SIGN_WITH_REGISTRY_KEY__';
+
+/** NovaGear's settlement address. */
+export const NOVAGEAR_PAYEE = '0x9A4fD21bC7e05a83F16D4e92B0c7A15d38E6b204';
+
+export interface AcpPayload {
+  protocol: 'acp';
+  acp_version: string;
+  order_ref: string;
+  agent: {
+    id: string;
+    display_name: string;
+    signature: string;
+    nonce: string;
+  };
+  cart: {
+    currency: string;
+    items: Array<{ sku: string; quantity: number }>;
+  };
+  buyer_context: {
+    intent: string;
+    session_id: string;
+  };
+}
+
+export interface X402Payload {
+  protocol: 'x402';
+  x402_version: number;
+  order_ref: string;
+  payer: {
+    agent_id: string;
+    wallet: string;
+    signature: string;
+    nonce: string;
+  };
+  payment_required: {
+    /** Amount the agent *claims* it owes. Cross-checked against the catalog. */
+    amount_minor: number;
+    currency: string;
+    network: string;
+    payee: string;
+  };
+  line_items: Array<{ sku: string; qty: number }>;
+}
+
+export type RawOrderPayload = AcpPayload | X402Payload;
+
+export const ORDERS: RawOrderPayload[] = [
+  // Scenario 1 — clean sale from an established shopper agent.
+  {
+    protocol: 'acp',
+    acp_version: '0.3',
+    order_ref: 'ord_1001',
+    agent: {
+      id: 'agt_shopper_atlas',
+      display_name: 'Atlas Shopping Assistant',
+      signature: SIGN_VALID,
+      nonce: 'nc_8f31a0',
+    },
+    cart: {
+      currency: 'INR',
+      items: [{ sku: 'NG-KB-01', quantity: 1 }],
+    },
+    buyer_context: { intent: 'purchase', session_id: 'sess_atlas_4471' },
+  },
+
+  // Scenario 2 — day-old agent, forged signature, 40 units of one SKU.
+  {
+    protocol: 'x402',
+    x402_version: 1,
+    order_ref: 'ord_1002',
+    payer: {
+      agent_id: 'agt_ghost_nyx',
+      wallet: '0x0189bE47cF63a2D50e91C8f4A76b3D25c04E1f78',
+      signature: 'b3f5c1d9e7a20486fd35c9b1027e4a6d8c05f31e92b7a4d06c18e5f3907b2a4c',
+      nonce: 'nc_ff0021',
+    },
+    payment_required: {
+      amount_minor: 19996000,
+      currency: 'INR',
+      network: 'base-sepolia',
+      payee: NOVAGEAR_PAYEE,
+    },
+    line_items: [{ sku: 'NG-HS-01', qty: 40 }],
+  },
+
+  // Scenario 3 — looks clean at screening; the tampering shows up post-settlement.
+  {
+    protocol: 'x402',
+    x402_version: 1,
+    order_ref: 'ord_1003',
+    payer: {
+      agent_id: 'agt_relay_lyra',
+      wallet: '0xD45e1B93cF20a7E68b14D9c3A05f2E789C61a802',
+      signature: SIGN_VALID,
+      nonce: 'nc_2ab7c4',
+    },
+    payment_required: {
+      amount_minor: 499900,
+      currency: 'INR',
+      network: 'base-sepolia',
+      payee: NOVAGEAR_PAYEE,
+    },
+    line_items: [{ sku: 'NG-HS-01', qty: 1 }],
+  },
+
+  // Conflicting signals — reputable agent, but a bulk order well past SKU norms.
+  {
+    protocol: 'acp',
+    acp_version: '0.3',
+    order_ref: 'ord_1004',
+    agent: {
+      id: 'agt_bulk_orion',
+      display_name: 'Orion Procurement Bot',
+      signature: SIGN_VALID,
+      nonce: 'nc_71c3de',
+    },
+    cart: {
+      currency: 'INR',
+      items: [{ sku: 'NG-DK-01', quantity: 12 }],
+    },
+    buyer_context: { intent: 'bulk_purchase', session_id: 'sess_orion_0192' },
+  },
+
+  // Velocity abuse — valid signature, but 47 orders in the last hour.
+  {
+    protocol: 'x402',
+    x402_version: 1,
+    order_ref: 'ord_1005',
+    payer: {
+      agent_id: 'agt_swarm_kilo',
+      wallet: '0xF67a3D15eB42c9086d36F1e5C27b4A9d16E82B04',
+      signature: SIGN_VALID,
+      nonce: 'nc_5d90b1',
+    },
+    payment_required: {
+      amount_minor: 1049700,
+      currency: 'INR',
+      network: 'base-sepolia',
+      payee: NOVAGEAR_PAYEE,
+    },
+    line_items: [{ sku: 'NG-WC-01', qty: 3 }],
+  },
+
+  // Unregistered agent — no registry entry to score against.
+  {
+    protocol: 'acp',
+    acp_version: '0.3',
+    order_ref: 'ord_1006',
+    agent: {
+      id: 'agt_shadow_umbra',
+      display_name: 'Umbra Checkout Agent',
+      signature: SIGN_VALID,
+      nonce: 'nc_c40a77',
+    },
+    cart: {
+      currency: 'INR',
+      items: [{ sku: 'NG-KB-02', quantity: 2 }],
+    },
+    buyer_context: { intent: 'purchase', session_id: 'sess_umbra_5510' },
+  },
+
+  // Clean multi-item sale.
+  {
+    protocol: 'acp',
+    acp_version: '0.3',
+    order_ref: 'ord_1007',
+    agent: {
+      id: 'agt_concierge_vega',
+      display_name: 'Vega Personal Concierge',
+      signature: SIGN_VALID,
+      nonce: 'nc_9e14b2',
+    },
+    cart: {
+      currency: 'INR',
+      items: [
+        { sku: 'NG-HS-02', quantity: 1 },
+        { sku: 'NG-MS-01', quantity: 1 },
+      ],
+    },
+    buyer_context: { intent: 'purchase', session_id: 'sess_vega_7734' },
+  },
+
+  // Declared x402 amount understates the catalog total by ₹1,000.
+  {
+    protocol: 'x402',
+    x402_version: 1,
+    order_ref: 'ord_1008',
+    payer: {
+      agent_id: 'agt_probe_zeta',
+      wallet: '0xE56f2C04dA31b8F79c25E0d4B16a3F8c05D719A3',
+      signature: SIGN_VALID,
+      nonce: 'nc_3f8ac6',
+    },
+    payment_required: {
+      amount_minor: 1579400,
+      currency: 'INR',
+      network: 'base-sepolia',
+      payee: NOVAGEAR_PAYEE,
+    },
+    line_items: [{ sku: 'NG-MS-01', qty: 6 }],
+  },
+
+  // High-value order from a trusted agent — clears screening but trips the
+  // human-in-the-loop threshold (> ₹40,000).
+  {
+    protocol: 'acp',
+    acp_version: '0.3',
+    order_ref: 'ord_1009',
+    agent: {
+      id: 'agt_shopper_atlas',
+      display_name: 'Atlas Shopping Assistant',
+      signature: SIGN_VALID,
+      nonce: 'nc_b70d35',
+    },
+    cart: {
+      currency: 'INR',
+      items: [{ sku: 'NG-HS-02', quantity: 5 }],
+    },
+    buyer_context: { intent: 'purchase', session_id: 'sess_atlas_9902' },
+  },
+];

--- a/sample-apps/agentic-commerce-gateway/src/fixtures/products.ts
+++ b/sample-apps/agentic-commerce-gateway/src/fixtures/products.ts
@@ -1,0 +1,75 @@
+import type { Product } from '../modules/gateway/gateway.types.js';
+
+/**
+ * NovaGear catalog. Prices are in paise (₹8,499 -> 849900).
+ *
+ * `typicalQty` / `maxNormalQty` are what make the order-size anomaly signal
+ * meaningful: 40 headsets is only suspicious relative to a SKU that normally
+ * sells one at a time.
+ */
+export const PRODUCTS: Product[] = [
+  {
+    sku: 'NG-KB-01',
+    name: 'Nova Mechanical Keyboard TKL',
+    category: 'keyboards',
+    priceMinor: 849900,
+    typicalQty: 1,
+    maxNormalQty: 3,
+  },
+  {
+    sku: 'NG-KB-02',
+    name: 'Nova Compact 65% Keyboard',
+    category: 'keyboards',
+    priceMinor: 629900,
+    typicalQty: 1,
+    maxNormalQty: 3,
+  },
+  {
+    sku: 'NG-HS-01',
+    name: 'NovaSound H500 Headset',
+    category: 'headsets',
+    priceMinor: 499900,
+    typicalQty: 1,
+    maxNormalQty: 4,
+  },
+  {
+    sku: 'NG-HS-02',
+    name: 'NovaSound Pro ANC Headset',
+    category: 'headsets',
+    priceMinor: 1299900,
+    typicalQty: 1,
+    maxNormalQty: 2,
+  },
+  {
+    sku: 'NG-WC-01',
+    name: 'NovaView 1080p Webcam',
+    category: 'webcams',
+    priceMinor: 349900,
+    typicalQty: 1,
+    maxNormalQty: 5,
+  },
+  {
+    sku: 'NG-WC-02',
+    name: 'NovaView 4K Streamcam',
+    category: 'webcams',
+    priceMinor: 999900,
+    typicalQty: 1,
+    maxNormalQty: 2,
+  },
+  {
+    sku: 'NG-MS-01',
+    name: 'NovaGlide Wireless Mouse',
+    category: 'accessories',
+    priceMinor: 279900,
+    typicalQty: 1,
+    maxNormalQty: 6,
+  },
+  {
+    sku: 'NG-DK-01',
+    name: 'NovaDock USB-C Hub',
+    category: 'accessories',
+    priceMinor: 549900,
+    typicalQty: 1,
+    maxNormalQty: 4,
+  },
+];

--- a/sample-apps/agentic-commerce-gateway/src/fixtures/settlements.ts
+++ b/sample-apps/agentic-commerce-gateway/src/fixtures/settlements.ts
@@ -1,0 +1,104 @@
+import type { OnChainRecord, SalesReceipt } from '../modules/gateway/gateway.types.js';
+import { NOVAGEAR_PAYEE } from './orders.js';
+
+/**
+ * Sales receipts issued by NovaGear's checkout, paired with the (mock)
+ * on-chain settlement records for the same orders.
+ *
+ * Two of these disagree with the chain on purpose — that disagreement is the
+ * whole point of `verify_receipt`.
+ */
+
+/** Address that ord_1008's funds were actually routed to. */
+const ATTACKER_PAYEE = '0x7cE0b41a92D5f36A08c1e4B7d590F62a3C84e015';
+
+export const RECEIPTS: SalesReceipt[] = [
+  {
+    orderId: 'ord_1001',
+    agentId: 'agt_shopper_atlas',
+    amountMinor: 849900,
+    currency: 'INR',
+    payee: NOVAGEAR_PAYEE,
+    items: [{ sku: 'NG-KB-01', qty: 1 }],
+    issuedAt: '2026-07-31T09:14:22.000Z',
+  },
+  {
+    // Receipt claims a single ₹4,999 headset...
+    orderId: 'ord_1003',
+    agentId: 'agt_relay_lyra',
+    amountMinor: 499900,
+    currency: 'INR',
+    payee: NOVAGEAR_PAYEE,
+    items: [{ sku: 'NG-HS-01', qty: 1 }],
+    issuedAt: '2026-07-31T10:02:47.000Z',
+  },
+  {
+    orderId: 'ord_1007',
+    agentId: 'agt_concierge_vega',
+    amountMinor: 1579800,
+    currency: 'INR',
+    payee: NOVAGEAR_PAYEE,
+    items: [
+      { sku: 'NG-HS-02', qty: 1 },
+      { sku: 'NG-MS-01', qty: 1 },
+    ],
+    issuedAt: '2026-07-31T10:31:05.000Z',
+  },
+  {
+    orderId: 'ord_1008',
+    agentId: 'agt_probe_zeta',
+    amountMinor: 1579400,
+    currency: 'INR',
+    payee: NOVAGEAR_PAYEE,
+    items: [{ sku: 'NG-MS-01', qty: 6 }],
+    issuedAt: '2026-07-31T11:08:33.000Z',
+  },
+];
+
+export const ONCHAIN_RECORDS: OnChainRecord[] = [
+  {
+    orderId: 'ord_1001',
+    txHash: '0x4a91c7e35b08d2f6a17e94c0b53d8e26f10a7c495b3d80e6f2a91c47b085d3e2',
+    network: 'base-sepolia',
+    amountMinor: 849900,
+    currency: 'INR',
+    payee: NOVAGEAR_PAYEE,
+    items: [{ sku: 'NG-KB-01', qty: 1 }],
+    settledAt: '2026-07-31T09:14:31.000Z',
+  },
+  {
+    // ...the chain says ten of them, at 10x the money.
+    orderId: 'ord_1003',
+    txHash: '0x8d13f60a2c94e7b5013da8f27c46b9e0518a3d7f92c6b04e15a8d3f70b29c641',
+    network: 'base-sepolia',
+    amountMinor: 4999000,
+    currency: 'INR',
+    payee: NOVAGEAR_PAYEE,
+    items: [{ sku: 'NG-HS-01', qty: 10 }],
+    settledAt: '2026-07-31T10:02:58.000Z',
+  },
+  {
+    orderId: 'ord_1007',
+    txHash: '0x2f70b9d418ae35c026f81b4d97a05e3c6482d1f0a95c73be08d4f261a37c0b95',
+    network: 'base-sepolia',
+    amountMinor: 1579800,
+    currency: 'INR',
+    payee: NOVAGEAR_PAYEE,
+    items: [
+      { sku: 'NG-HS-02', qty: 1 },
+      { sku: 'NG-MS-01', qty: 1 },
+    ],
+    settledAt: '2026-07-31T10:31:14.000Z',
+  },
+  {
+    // Right amount, wrong destination — the funds never reached NovaGear.
+    orderId: 'ord_1008',
+    txHash: '0x6b28e0c74f931da05c83b6e2170f4a9d35c81e07b24af960d1c53e8a7f240b13',
+    network: 'base-sepolia',
+    amountMinor: 1579400,
+    currency: 'INR',
+    payee: ATTACKER_PAYEE,
+    items: [{ sku: 'NG-MS-01', qty: 6 }],
+    settledAt: '2026-07-31T11:08:41.000Z',
+  },
+];

--- a/sample-apps/agentic-commerce-gateway/src/health/system.health.ts
+++ b/sample-apps/agentic-commerce-gateway/src/health/system.health.ts
@@ -1,0 +1,55 @@
+import { HealthCheck, HealthCheckInterface, HealthCheckResult } from '@nitrostack/core';
+
+/**
+ * System Health Check
+ * 
+ * Monitors system resources and uptime
+ */
+@HealthCheck({ 
+  name: 'system', 
+  description: 'System resource and uptime check',
+  interval: 30 // Check every 30 seconds
+})
+export class SystemHealthCheck implements HealthCheckInterface {
+  private startTime: number;
+
+  constructor() {
+    this.startTime = Date.now();
+  }
+
+  async check(): Promise<HealthCheckResult> {
+    try {
+      const memoryUsage = process.memoryUsage();
+      const uptime = Date.now() - this.startTime;
+      const uptimeSeconds = Math.floor(uptime / 1000);
+      
+      // Convert memory to MB
+      const memoryUsedMB = Math.round(memoryUsage.heapUsed / 1024 / 1024);
+      const memoryTotalMB = Math.round(memoryUsage.heapTotal / 1024 / 1024);
+      
+      // Consider unhealthy if memory usage is > 90%
+      const memoryPercent = (memoryUsage.heapUsed / memoryUsage.heapTotal) * 100;
+      const isHealthy = memoryPercent < 90;
+      
+      return {
+        status: isHealthy ? 'up' : 'degraded',
+        message: isHealthy 
+          ? 'System is healthy' 
+          : 'High memory usage detected',
+        details: {
+          uptime: `${uptimeSeconds}s`,
+          memory: `${memoryUsedMB}MB / ${memoryTotalMB}MB (${Math.round(memoryPercent)}%)`,
+          pid: process.pid,
+          nodeVersion: process.version,
+        },
+      };
+    } catch (error: any) {
+      return {
+        status: 'down',
+        message: 'System health check failed',
+        details: error.message,
+      };
+    }
+  }
+}
+

--- a/sample-apps/agentic-commerce-gateway/src/index.ts
+++ b/sample-apps/agentic-commerce-gateway/src/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Agentic Commerce Gateway — MCP Server
+ *
+ * Stripe Radar for AI shopping agents: screens the buying agent before a sale
+ * settles, and verifies every sales receipt against the on-chain record.
+ *
+ * Main entry point for the MCP server.
+ * Uses the @McpApp decorator pattern for clean, NestJS-style architecture.
+ * 
+ * Transport Configuration:
+ * - Development (NODE_ENV=development): STDIO only
+ * - Production (NODE_ENV=production): Dual transport (STDIO + HTTP SSE)
+ */
+
+import 'dotenv/config';
+import { McpApplicationFactory } from '@nitrostack/core';
+import { AppModule } from './app.module.js';
+import { CONSOLE_PATH, registerConsoleRoute } from './console/console.route.js';
+
+/**
+ * Bootstrap the application
+ */
+async function bootstrap() {
+  // Create and start the MCP server
+  const server = await McpApplicationFactory.create(AppModule);
+  await server.start();
+
+  // Serve the seller console alongside the MCP endpoint (HTTP transports only).
+  if (registerConsoleRoute(server)) {
+    console.error(`🖥️  Seller console available at ${CONSOLE_PATH}`);
+  }
+}
+
+// Start the application
+bootstrap().catch((error) => {
+  console.error('❌ Failed to start server:', error);
+  process.exit(1);
+});

--- a/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.module.ts
+++ b/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nitrostack/core';
+import { GatewayTools } from './gateway.tools.js';
+import { GatewayResources } from './gateway.resources.js';
+import { GatewayPrompts } from './gateway.prompts.js';
+
+@Module({
+  name: 'gateway',
+  description:
+    'Agentic Commerce Gateway — screens AI buying agents before a sale settles and verifies receipts against the on-chain record',
+  controllers: [GatewayTools, GatewayResources, GatewayPrompts],
+})
+export class GatewayModule {}

--- a/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.normalize.ts
+++ b/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.normalize.ts
@@ -1,0 +1,127 @@
+import type { NormalizedOrder, Product } from './gateway.types.js';
+import type { AcpPayload, RawOrderPayload, X402Payload } from '../../fixtures/orders.js';
+
+/**
+ * Protocol normalization.
+ *
+ * The gateway supports two wire formats with different field names, different
+ * nesting, and different amounts of information (x402 carries a declared
+ * settlement amount and a payee; ACP carries neither). Everything downstream —
+ * screening, scoring, verification — consumes only `NormalizedOrder`, so the
+ * evidence path is chosen exactly once, here.
+ */
+
+export class UnknownSkuError extends Error {
+  constructor(sku: string) {
+    super(`Unknown SKU "${sku}" — not in the NovaGear catalog`);
+    this.name = 'UnknownSkuError';
+  }
+}
+
+function isX402(payload: RawOrderPayload): payload is X402Payload {
+  return payload.protocol === 'x402';
+}
+
+function buildItems(
+  lines: Array<{ sku: string; qty: number }>,
+  catalog: Map<string, Product>,
+) {
+  return lines.map((line) => {
+    const product = catalog.get(line.sku);
+    if (!product) throw new UnknownSkuError(line.sku);
+    return {
+      sku: product.sku,
+      name: product.name,
+      qty: line.qty,
+      unitPriceMinor: product.priceMinor,
+      lineTotalMinor: product.priceMinor * line.qty,
+    };
+  });
+}
+
+export function normalizeOrder(
+  payload: RawOrderPayload,
+  catalog: Map<string, Product>,
+  receivedAt = new Date().toISOString(),
+): NormalizedOrder {
+  const evidencePath: string[] = [];
+
+  if (isX402(payload)) {
+    evidencePath.push('protocol=x402 → settlement-bearing payload');
+
+    const items = buildItems(payload.line_items, catalog);
+    const catalogTotal = items.reduce((sum, i) => sum + i.lineTotalMinor, 0);
+    const declaredTotal = payload.payment_required.amount_minor;
+
+    evidencePath.push(
+      `catalog repriced ${items.length} line item(s) → ${catalogTotal} minor units`,
+    );
+
+    if (declaredTotal !== catalogTotal) {
+      evidencePath.push(
+        `⚠ declared amount ${declaredTotal} ≠ catalog total ${catalogTotal} (delta ${
+          declaredTotal - catalogTotal
+        })`,
+      );
+    } else {
+      evidencePath.push('declared amount matches catalog total');
+    }
+
+    evidencePath.push(`payee ${payload.payment_required.payee} on ${payload.payment_required.network}`);
+
+    return {
+      orderId: payload.order_ref,
+      protocol: 'x402',
+      protocolVersion: String(payload.x402_version),
+      agentId: payload.payer.agent_id,
+      // x402 payloads carry no display name; resolved from the registry later.
+      agentDisplayName: payload.payer.agent_id,
+      items,
+      currency: payload.payment_required.currency,
+      // The agent's declared total is what it signed, so that is what we carry
+      // forward; the catalog delta is recorded as evidence above.
+      totalMinor: declaredTotal,
+      signature: payload.payer.signature,
+      nonce: payload.payer.nonce,
+      receivedAt,
+      status: 'pending',
+      payee: payload.payment_required.payee,
+      network: payload.payment_required.network,
+      wallet: payload.payer.wallet,
+      evidencePath,
+    };
+  }
+
+  const acp = payload as AcpPayload;
+  evidencePath.push('protocol=acp → cart-shaped payload, no settlement block');
+
+  const items = buildItems(
+    acp.cart.items.map((i) => ({ sku: i.sku, qty: i.quantity })),
+    catalog,
+  );
+  const total = items.reduce((sum, i) => sum + i.lineTotalMinor, 0);
+
+  evidencePath.push(`catalog priced ${items.length} cart line(s) → ${total} minor units`);
+  evidencePath.push(`buyer intent "${acp.buyer_context.intent}"`);
+
+  return {
+    orderId: acp.order_ref,
+    protocol: 'acp',
+    protocolVersion: acp.acp_version,
+    agentId: acp.agent.id,
+    agentDisplayName: acp.agent.display_name,
+    items,
+    currency: acp.cart.currency,
+    totalMinor: total,
+    signature: acp.agent.signature,
+    nonce: acp.agent.nonce,
+    receivedAt,
+    status: 'pending',
+    evidencePath,
+  };
+}
+
+/** Catalog total, ignoring whatever the agent declared. */
+export function catalogTotalMinor(order: NormalizedOrder): number {
+  return order.items.reduce((sum, i) => sum + i.lineTotalMinor, 0);
+}

--- a/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.prompts.ts
+++ b/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.prompts.ts
@@ -1,0 +1,62 @@
+import { PromptDecorator as Prompt, ExecutionContext } from '@nitrostack/core';
+
+/**
+ * Reusable instruction sets that drive the gateway's investigation loop.
+ */
+export class GatewayPrompts {
+  @Prompt({
+    name: 'triage_agent_order',
+    description:
+      'Run the full fraud investigation on an incoming agent order and act on the verdict',
+    arguments: [
+      { name: 'order_id', description: 'The order to investigate, e.g. ord_1002', required: true },
+    ],
+  })
+  async triageAgentOrder(args: { order_id: string }, ctx: ExecutionContext) {
+    ctx.logger.info('Building triage prompt', { orderId: args.order_id });
+
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: `You are the fraud gateway for the NovaGear store. Investigate order ${args.order_id} before it settles.
+
+Steps:
+1. Call screen_agent for ${args.order_id} and read every check, not just the summary.
+2. Call compute_trust_score for ${args.order_id}.
+3. Reason explicitly about any entries in "conflicts" — a valid signature does not make a bulk-drain order legitimate, and high reputation does not excuse abnormal velocity.
+4. Act on the verdict:
+   - decline -> call blocklist_agent if the evidence shows intent, not just a low score.
+   - hold -> explain to the seller exactly which signal sent it to human review.
+   - approve -> say what would have changed your mind.
+5. Finish with a two-line summary the seller can act on.`,
+        },
+      ],
+    };
+  }
+
+  @Prompt({
+    name: 'audit_settlement',
+    description: 'Verify a settled sale against the chain and act on any mismatch',
+    arguments: [
+      { name: 'order_id', description: 'The settled order to audit, e.g. ord_1003', required: true },
+    ],
+  })
+  async auditSettlement(args: { order_id: string }, ctx: ExecutionContext) {
+    ctx.logger.info('Building settlement audit prompt', { orderId: args.order_id });
+
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: `Audit the settlement for order ${args.order_id}.
+
+1. Call verify_receipt for ${args.order_id}.
+2. Report every mismatched field with both values side by side, and state the rupee exposure.
+3. If there is any critical mismatch, call flag_order with the specific field diffs as evidence, then blocklist_agent for the agent on the receipt.
+4. Call get_sales_dashboard and report the updated "revenue protected" figure.`,
+        },
+      ],
+    };
+  }
+}

--- a/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.resources.ts
+++ b/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.resources.ts
@@ -1,0 +1,76 @@
+import { ResourceDecorator as Resource, ExecutionContext } from '@nitrostack/core';
+import { formatMinor, store } from './gateway.store.js';
+
+/**
+ * Read-only views over gateway state, for clients that want the raw data
+ * rather than a tool call.
+ */
+export class GatewayResources {
+  @Resource({
+    uri: 'novagear://catalog',
+    name: 'NovaGear Catalog',
+    description: 'Full product catalog with prices and normal order quantities',
+    mimeType: 'application/json',
+  })
+  async getCatalog(uri: string, ctx: ExecutionContext) {
+    ctx.logger.info('Serving catalog resource');
+    const products = [...store.products.values()].map((p) => ({
+      ...p,
+      price: formatMinor(p.priceMinor),
+    }));
+
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: 'application/json',
+          text: JSON.stringify({ store: 'NovaGear', currency: 'INR', products }, null, 2),
+        },
+      ],
+    };
+  }
+
+  @Resource({
+    uri: 'novagear://agent-registry',
+    name: 'Agent Reputation Registry',
+    description: 'Mock registry of buying agents: reputation, account age, dispute history',
+    mimeType: 'application/json',
+  })
+  async getRegistry(uri: string, ctx: ExecutionContext) {
+    ctx.logger.info('Serving agent registry resource');
+
+    // Signing keys are registry-internal and never leave the gateway.
+    const agents = [...store.agents.values()].map(({ signingKey, ...rest }) => rest);
+
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: 'application/json',
+          text: JSON.stringify({ count: agents.length, agents }, null, 2),
+        },
+      ],
+    };
+  }
+
+  @Resource({
+    uri: 'novagear://blocklist',
+    name: 'Store Blocklist',
+    description: 'Agents currently banned from the NovaGear store',
+    mimeType: 'application/json',
+  })
+  async getBlocklist(uri: string, ctx: ExecutionContext) {
+    ctx.logger.info('Serving blocklist resource');
+    const blocklist = [...store.blocklist.values()];
+
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: 'application/json',
+          text: JSON.stringify({ count: blocklist.length, blocklist }, null, 2),
+        },
+      ],
+    };
+  }
+}

--- a/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.screening.ts
+++ b/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.screening.ts
@@ -1,0 +1,361 @@
+import { verifySignature } from './gateway.signing.js';
+import { catalogTotalMinor } from './gateway.normalize.js';
+import { formatMinor, store, HITL_THRESHOLD_MINOR } from './gateway.store.js';
+import type {
+  NormalizedOrder,
+  ScoreSignal,
+  ScreeningCheck,
+  ScreeningResult,
+  TrustScoreResult,
+  Verdict,
+} from './gateway.types.js';
+
+/**
+ * Signal weights. They sum to 100 so the score reads as a percentage, and each
+ * one is reported separately so a seller can see *which* signal sank an order
+ * rather than just a number.
+ */
+const WEIGHTS = {
+  signature: 35,
+  reputation: 25,
+  orderSize: 20,
+  velocity: 12,
+  accountAge: 8,
+} as const;
+
+const APPROVE_AT = 70;
+const HOLD_AT = 45;
+
+/**
+ * Stage 1 — identity. Verifies the presented signature against the registry key
+ * and pulls the agent's standing. Produces pass/fail checks, not a score.
+ */
+export function screenAgent(order: NormalizedOrder): ScreeningResult {
+  const checks: ScreeningCheck[] = [];
+  const agent = store.agents.get(order.agentId);
+  const registered = Boolean(agent?.registered);
+
+  checks.push({
+    id: 'registry_lookup',
+    label: 'Agent registry lookup',
+    passed: registered,
+    detail: agent
+      ? registered
+        ? `${agent.displayName} (${agent.operator}) found in registry, reputation ${agent.reputation}/100`
+        : `${agent.displayName} is present but not a registered operator — no reputation to draw on`
+      : `No registry entry for ${order.agentId}`,
+  });
+
+  let signatureValid = false;
+  if (agent) {
+    signatureValid = verifySignature(
+      {
+        protocol: order.protocol,
+        agentId: order.agentId,
+        nonce: order.nonce,
+        items: order.items.map((i) => ({ sku: i.sku, qty: i.qty })),
+        totalMinor: order.totalMinor,
+        currency: order.currency,
+      },
+      agent.signingKey,
+      order.signature,
+    );
+  }
+
+  checks.push({
+    id: 'signature_valid',
+    label: 'Payload signature',
+    passed: signatureValid,
+    detail: signatureValid
+      ? `HMAC over the canonical ${order.protocol.toUpperCase()} payload matches the registry key`
+      : agent
+        ? `Signature ${order.signature.slice(0, 16)}… does not verify against ${order.agentId}'s registry key — spoofed or replayed`
+        : 'No registry key available to verify against',
+  });
+
+  const blocklisted = store.isBlocklisted(order.agentId);
+  checks.push({
+    id: 'not_blocklisted',
+    label: 'Blocklist status',
+    passed: !blocklisted,
+    detail: blocklisted
+      ? `Agent is blocklisted: ${store.blocklist.get(order.agentId)?.reason}`
+      : 'Agent is not blocklisted',
+  });
+
+  const disputes = agent?.disputes ?? 0;
+  checks.push({
+    id: 'dispute_history',
+    label: 'Dispute history',
+    passed: disputes <= 2,
+    detail: `${disputes} prior dispute(s) across ${agent?.lifetimeOrders ?? 0} lifetime order(s)`,
+  });
+
+  // x402 declares what it intends to pay; ACP does not, so this check only
+  // exists on one evidence path.
+  if (order.protocol === 'x402') {
+    const catalog = catalogTotalMinor(order);
+    const matches = catalog === order.totalMinor;
+    checks.push({
+      id: 'amount_declaration',
+      label: 'Declared amount vs catalog',
+      passed: matches,
+      detail: matches
+        ? `Declared ${formatMinor(order.totalMinor, order.currency)} matches catalog pricing`
+        : `Declared ${formatMinor(order.totalMinor, order.currency)} but catalog prices this cart at ${formatMinor(catalog, order.currency)} — underpayment of ${formatMinor(catalog - order.totalMinor, order.currency)}`,
+    });
+  }
+
+  const failedChecks = checks.filter((c) => !c.passed).length;
+
+  return {
+    orderId: order.orderId,
+    agentId: order.agentId,
+    agentDisplayName: order.agentDisplayName,
+    registered,
+    signatureValid,
+    blocklisted,
+    checks,
+    failedChecks,
+    summary:
+      failedChecks === 0
+        ? `All ${checks.length} identity checks passed for ${order.agentDisplayName}`
+        : `${failedChecks} of ${checks.length} identity checks failed for ${order.agentDisplayName}`,
+  };
+}
+
+/** Worst per-SKU quantity ratio against that SKU's normal ceiling. */
+function orderSizeRatio(order: NormalizedOrder): { ratio: number; worstSku: string } {
+  let ratio = 0;
+  let worstSku = order.items[0]?.sku ?? 'n/a';
+  for (const item of order.items) {
+    const product = store.products.get(item.sku);
+    if (!product) continue;
+    const r = item.qty / product.maxNormalQty;
+    if (r > ratio) {
+      ratio = r;
+      worstSku = item.sku;
+    }
+  }
+  return { ratio, worstSku };
+}
+
+/**
+ * Stage 2 — scoring. Weighs the screening output plus behavioural signals, then
+ * reasons over the combination: a strong positive sitting next to a strong
+ * negative is recorded as an explicit conflict rather than silently averaged
+ * away.
+ */
+export function computeTrustScore(
+  order: NormalizedOrder,
+  screening: ScreeningResult,
+): TrustScoreResult {
+  const agent = store.agents.get(order.agentId);
+  const signals: ScoreSignal[] = [];
+  const conflicts: string[] = [];
+  const reasoning: string[] = [];
+
+  // --- Signature ---
+  signals.push({
+    id: 'signature',
+    label: 'Signature validity',
+    points: screening.signatureValid ? WEIGHTS.signature : 0,
+    max: WEIGHTS.signature,
+    status: screening.signatureValid ? 'pass' : 'fail',
+    detail: screening.signatureValid
+      ? 'Payload signature verifies against the registry key'
+      : 'Payload signature does not verify — identity is not proven',
+  });
+
+  // --- Reputation ---
+  const registered = screening.registered;
+  const reputation = agent?.reputation ?? 0;
+  const repPoints = registered ? Math.round((reputation / 100) * WEIGHTS.reputation) : 2;
+  signals.push({
+    id: 'reputation',
+    label: 'Registry reputation',
+    points: repPoints,
+    max: WEIGHTS.reputation,
+    status: !registered ? 'fail' : reputation >= 70 ? 'pass' : reputation >= 45 ? 'warn' : 'fail',
+    detail: registered
+      ? `Reputation ${reputation}/100 over ${agent?.lifetimeOrders ?? 0} lifetime orders`
+      : 'Agent is not in the reputation registry — treated as unknown',
+  });
+
+  // --- Order size anomaly ---
+  const { ratio, worstSku } = orderSizeRatio(order);
+  const worstProduct = store.products.get(worstSku);
+  let sizePoints: number;
+  let sizeStatus: ScoreSignal['status'];
+  if (ratio <= 1) {
+    sizePoints = WEIGHTS.orderSize;
+    sizeStatus = 'pass';
+  } else if (ratio <= 2) {
+    sizePoints = 12;
+    sizeStatus = 'warn';
+  } else if (ratio <= 4) {
+    sizePoints = 6;
+    sizeStatus = 'warn';
+  } else {
+    sizePoints = 0;
+    sizeStatus = 'fail';
+  }
+  const worstQty = order.items.find((i) => i.sku === worstSku)?.qty ?? 0;
+  signals.push({
+    id: 'order_size',
+    label: 'Order size vs product norms',
+    points: sizePoints,
+    max: WEIGHTS.orderSize,
+    status: sizeStatus,
+    detail:
+      ratio <= 1
+        ? `${worstQty}× ${worstSku} is within normal purchase size`
+        : `${worstQty}× ${worstSku} is ${ratio.toFixed(1)}× the normal ceiling of ${worstProduct?.maxNormalQty ?? '?'} for that SKU`,
+  });
+
+  // --- Velocity ---
+  const velocity = agent?.ordersLastHour ?? 0;
+  let velPoints: number;
+  let velStatus: ScoreSignal['status'];
+  if (velocity <= 5) {
+    velPoints = WEIGHTS.velocity;
+    velStatus = 'pass';
+  } else if (velocity <= 15) {
+    velPoints = 7;
+    velStatus = 'warn';
+  } else if (velocity <= 30) {
+    velPoints = 3;
+    velStatus = 'warn';
+  } else {
+    velPoints = 0;
+    velStatus = 'fail';
+  }
+  signals.push({
+    id: 'velocity',
+    label: 'Order velocity',
+    points: velPoints,
+    max: WEIGHTS.velocity,
+    status: velStatus,
+    detail: `${velocity} order(s) placed in the last hour`,
+  });
+
+  // --- Account age ---
+  const age = agent?.accountAgeDays ?? 0;
+  let agePoints: number;
+  let ageStatus: ScoreSignal['status'];
+  if (age >= 90) {
+    agePoints = WEIGHTS.accountAge;
+    ageStatus = 'pass';
+  } else if (age >= 30) {
+    agePoints = 5;
+    ageStatus = 'warn';
+  } else if (age >= 7) {
+    agePoints = 2;
+    ageStatus = 'warn';
+  } else {
+    agePoints = 0;
+    ageStatus = 'fail';
+  }
+  signals.push({
+    id: 'account_age',
+    label: 'Account age',
+    points: agePoints,
+    max: WEIGHTS.accountAge,
+    status: ageStatus,
+    detail: `Agent account is ${age} day(s) old`,
+  });
+
+  const score = signals.reduce((sum, s) => sum + s.points, 0);
+
+  // --- Conflict detection: signals pointing in opposite directions ---
+  if (screening.signatureValid && sizeStatus === 'fail') {
+    conflicts.push(
+      `Signature is cryptographically valid, yet the order is ${ratio.toFixed(1)}× normal size for ${worstSku} — a real key does not make a bulk-drain order legitimate.`,
+    );
+  }
+  if (reputation >= 70 && velStatus === 'fail') {
+    conflicts.push(
+      `Reputation is high (${reputation}/100) but the agent has placed ${velocity} orders this hour — reputation may be stale or the account compromised.`,
+    );
+  }
+  if (reputation >= 70 && sizeStatus !== 'pass') {
+    conflicts.push(
+      `Established agent (${reputation}/100) placing an unusually large order — plausible business procurement, but outside its own historical pattern.`,
+    );
+  }
+  if (age < 14 && (agent?.lifetimeOrders ?? 0) > 50) {
+    conflicts.push(
+      `Account is ${age} day(s) old but claims ${agent?.lifetimeOrders} lifetime orders — the history is inconsistent with the age.`,
+    );
+  }
+  if (screening.signatureValid && screening.checks.some((c) => c.id === 'amount_declaration' && !c.passed)) {
+    conflicts.push(
+      'Signature verifies, but the signed amount is below catalog price — the agent correctly signed an underpayment.',
+    );
+  }
+
+  // --- Verdict ---
+  let verdict: Verdict;
+  if (screening.blocklisted) {
+    verdict = 'decline';
+    reasoning.push('Agent is on the store blocklist — declined without further scoring.');
+  } else if (!screening.signatureValid) {
+    verdict = 'decline';
+    reasoning.push('Signature verification failed; identity is unproven, so the sale cannot settle safely.');
+  } else if (score >= APPROVE_AT) {
+    verdict = 'approve';
+    reasoning.push(`Trust score ${score}/100 clears the approval bar of ${APPROVE_AT}.`);
+  } else if (score >= HOLD_AT) {
+    verdict = 'hold';
+    reasoning.push(`Trust score ${score}/100 sits between ${HOLD_AT} and ${APPROVE_AT} — routed to the seller instead of auto-approving.`);
+  } else {
+    verdict = 'decline';
+    reasoning.push(`Trust score ${score}/100 is below the ${HOLD_AT} floor.`);
+  }
+
+  // A signed underpayment is never auto-approved.
+  const declarationFailed = screening.checks.some(
+    (c) => c.id === 'amount_declaration' && !c.passed,
+  );
+  if (verdict === 'approve' && declarationFailed) {
+    verdict = 'hold';
+    reasoning.push('Declared settlement amount is below catalog price — held for seller review rather than approved.');
+  }
+
+  // An agent with no registry entry has no reputation to stand on, so it never
+  // clears automatically however benign the rest of the order looks.
+  if (verdict === 'approve' && !screening.registered) {
+    verdict = 'hold';
+    reasoning.push('Agent is not in the reputation registry — routed to the seller instead of auto-approving an unknown buyer.');
+  }
+
+  // Human-in-the-loop: high-value orders always get a human, however clean.
+  const hitlRequired = order.totalMinor > HITL_THRESHOLD_MINOR;
+  if (hitlRequired && verdict === 'approve') {
+    verdict = 'hold';
+    reasoning.push(
+      `Order total ${formatMinor(order.totalMinor, order.currency)} exceeds the ${formatMinor(HITL_THRESHOLD_MINOR)} human-review threshold — held for the seller even though screening passed.`,
+    );
+  }
+
+  for (const c of conflicts) reasoning.push(`Conflict: ${c}`);
+
+  const band: TrustScoreResult['band'] =
+    score >= APPROVE_AT ? 'low-risk' : score >= HOLD_AT ? 'elevated' : 'high-risk';
+
+  return {
+    orderId: order.orderId,
+    agentId: order.agentId,
+    agentDisplayName: order.agentDisplayName,
+    score,
+    band,
+    verdict,
+    signals,
+    failedSignals: signals.filter((s) => s.status === 'fail').length,
+    conflicts,
+    reasoning,
+    hitlRequired,
+    orderTotalMinor: order.totalMinor,
+    currency: order.currency,
+  };
+}

--- a/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.signing.ts
+++ b/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.signing.ts
@@ -1,0 +1,57 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { Protocol } from './gateway.types.js';
+
+/**
+ * Mock payload signing for buying agents.
+ *
+ * This is deliberately a real HMAC rather than a hardcoded "valid"/"invalid"
+ * flag: screening recomputes the digest from the canonical order fields, so a
+ * tampered quantity or a forged key fails verification for the right reason.
+ * The registry-held `signingKey` stands in for the agent's real protocol key.
+ */
+
+export interface SignablePayload {
+  protocol: Protocol;
+  agentId: string;
+  nonce: string;
+  items: Array<{ sku: string; qty: number }>;
+  totalMinor: number;
+  currency: string;
+}
+
+/**
+ * Canonical string form. Field order is fixed and quantities are sorted by SKU
+ * so the same logical order always produces the same digest.
+ */
+export function canonicalize(payload: SignablePayload): string {
+  const items = [...payload.items]
+    .sort((a, b) => a.sku.localeCompare(b.sku))
+    .map((i) => `${i.sku}:${i.qty}`)
+    .join(',');
+
+  return [
+    `protocol=${payload.protocol}`,
+    `agent=${payload.agentId}`,
+    `nonce=${payload.nonce}`,
+    `items=${items}`,
+    `total=${payload.totalMinor}`,
+    `currency=${payload.currency}`,
+  ].join('|');
+}
+
+export function signPayload(payload: SignablePayload, signingKey: string): string {
+  return createHmac('sha256', signingKey).update(canonicalize(payload)).digest('hex');
+}
+
+/** Constant-time comparison; tolerates malformed/short forged signatures. */
+export function verifySignature(
+  payload: SignablePayload,
+  signingKey: string,
+  presented: string,
+): boolean {
+  const expected = signPayload(payload, signingKey);
+  const a = Buffer.from(expected, 'utf8');
+  const b = Buffer.from(presented ?? '', 'utf8');
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}

--- a/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.store.ts
+++ b/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.store.ts
@@ -1,0 +1,166 @@
+import { AGENTS } from '../../fixtures/agents.js';
+import { PRODUCTS } from '../../fixtures/products.js';
+import { ORDERS, SIGN_VALID, type RawOrderPayload } from '../../fixtures/orders.js';
+import { ONCHAIN_RECORDS, RECEIPTS } from '../../fixtures/settlements.js';
+import { signPayload } from './gateway.signing.js';
+import { normalizeOrder } from './gateway.normalize.js';
+import type {
+  AgentRecord,
+  NormalizedOrder,
+  OnChainRecord,
+  OrderStatus,
+  Product,
+  SalesReceipt,
+  Verdict,
+} from './gateway.types.js';
+
+/** Orders above this total always go to a human, however good the agent looks. */
+export const HITL_THRESHOLD_MINOR = 4000000; // ₹40,000
+
+export interface DecisionLogEntry {
+  orderId: string;
+  agentId: string;
+  agentDisplayName: string;
+  verdict: Verdict;
+  score: number;
+  totalMinor: number;
+  currency: string;
+  reason: string;
+  decidedAt: string;
+}
+
+export interface FlagRecord {
+  orderId: string;
+  reason: string;
+  evidence: string[];
+  exposureMinor: number;
+  flaggedAt: string;
+}
+
+export interface BlocklistEntry {
+  agentId: string;
+  displayName: string;
+  reason: string;
+  blockedAt: string;
+}
+
+/**
+ * In-memory state for the gateway.
+ *
+ * Fixtures are plain TypeScript modules rather than JSON on disk: they compile
+ * straight into `dist/` alongside the server, so there is no asset-copy step
+ * and no runtime path resolution to get wrong once deployed.
+ */
+class GatewayStore {
+  readonly products = new Map<string, Product>();
+  readonly agents = new Map<string, AgentRecord>();
+  readonly orders = new Map<string, NormalizedOrder>();
+  readonly receipts = new Map<string, SalesReceipt>();
+  readonly onchain = new Map<string, OnChainRecord>();
+
+  readonly decisions: DecisionLogEntry[] = [];
+  readonly flags = new Map<string, FlagRecord>();
+  readonly blocklist = new Map<string, BlocklistEntry>();
+
+  constructor() {
+    this.reset();
+  }
+
+  /** Rebuilds all state from fixtures. Also exposed as the `reset_demo` tool. */
+  reset(): void {
+    this.products.clear();
+    this.agents.clear();
+    this.orders.clear();
+    this.receipts.clear();
+    this.onchain.clear();
+    this.decisions.length = 0;
+    this.flags.clear();
+    this.blocklist.clear();
+
+    for (const p of PRODUCTS) this.products.set(p.sku, p);
+    for (const a of AGENTS) this.agents.set(a.agentId, a);
+    for (const r of RECEIPTS) this.receipts.set(r.orderId, r);
+    for (const c of ONCHAIN_RECORDS) this.onchain.set(c.orderId, c);
+
+    for (const raw of ORDERS) {
+      const order = this.ingest(raw, '2026-07-31T09:00:00.000Z');
+      this.orders.set(order.orderId, order);
+    }
+  }
+
+  /**
+   * Normalizes a raw payload and resolves the `SIGN_VALID` sentinel into a real
+   * HMAC using the agent's registry key, so fixture orders that are supposed to
+   * be legitimate actually verify.
+   */
+  ingest(raw: RawOrderPayload, receivedAt?: string): NormalizedOrder {
+    const order = normalizeOrder(raw, this.products, receivedAt);
+
+    const agent = this.agents.get(order.agentId);
+    if (agent) {
+      order.agentDisplayName = agent.displayName;
+      // Only registered agents have a registry-held key to sign against. An
+      // unregistered agent's payload is left unverifiable on purpose — there is
+      // nothing to check it against.
+      if (order.signature === SIGN_VALID && agent.registered) {
+        order.signature = signPayload(
+          {
+            protocol: order.protocol,
+            agentId: order.agentId,
+            nonce: order.nonce,
+            items: order.items.map((i) => ({ sku: i.sku, qty: i.qty })),
+            totalMinor: order.totalMinor,
+            currency: order.currency,
+          },
+          agent.signingKey,
+        );
+      }
+    }
+    if (order.signature === SIGN_VALID) {
+      // No registry key to sign with — leave it unverifiable.
+      order.signature = 'unsigned';
+    }
+
+    return order;
+  }
+
+  getOrderOrThrow(orderId: string): NormalizedOrder {
+    const order = this.orders.get(orderId);
+    if (!order) {
+      const known = [...this.orders.keys()].join(', ');
+      throw new Error(`Unknown order "${orderId}". Known orders: ${known}`);
+    }
+    return order;
+  }
+
+  getAgentOrThrow(agentId: string): AgentRecord {
+    const agent = this.agents.get(agentId);
+    if (!agent) throw new Error(`Unknown agent "${agentId}"`);
+    return agent;
+  }
+
+  setStatus(orderId: string, status: OrderStatus): void {
+    const order = this.orders.get(orderId);
+    if (order) order.status = status;
+  }
+
+  isBlocklisted(agentId: string): boolean {
+    return this.blocklist.has(agentId);
+  }
+
+  recordDecision(entry: DecisionLogEntry): void {
+    this.decisions.unshift(entry);
+  }
+}
+
+export const store = new GatewayStore();
+
+/** ₹ formatting from minor units, e.g. 849900 -> "₹8,499.00". */
+export function formatMinor(minor: number, currency = 'INR'): string {
+  const symbol = currency === 'INR' ? '₹' : `${currency} `;
+  const major = minor / 100;
+  return `${symbol}${major.toLocaleString('en-IN', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}

--- a/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.tools.ts
+++ b/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.tools.ts
@@ -1,0 +1,632 @@
+import { ToolDecorator as Tool, Widget, ExecutionContext, z } from '@nitrostack/core';
+import { formatMinor, store, HITL_THRESHOLD_MINOR } from './gateway.store.js';
+import { computeTrustScore, screenAgent } from './gateway.screening.js';
+import { verifyReceipt } from './gateway.verification.js';
+import { catalogTotalMinor } from './gateway.normalize.js';
+import {
+  NOVAGEAR_PAYEE,
+  SIGN_VALID,
+  type AcpPayload,
+  type RawOrderPayload,
+  type X402Payload,
+} from '../../fixtures/orders.js';
+
+let orderCounter = 2000;
+
+/**
+ * The gateway's MCP surface.
+ *
+ * The intended agentic chain is:
+ *   place_agent_order → screen_agent → compute_trust_score → (flag_order |
+ *   blocklist_agent) → verify_receipt → get_sales_dashboard
+ *
+ * Each tool is independently runnable from the Studio Tools page so the demo
+ * never depends on the model chaining them correctly.
+ */
+export class GatewayTools {
+  // ---------------------------------------------------------------- catalog
+
+  @Tool({
+    name: 'list_products',
+    description:
+      'List the NovaGear storefront catalog (keyboards, headsets, webcams, accessories) with prices and the normal purchase quantity for each SKU. Call this first to see what an agent can buy.',
+    inputSchema: z.object({
+      category: z
+        .string()
+        .optional()
+        .describe('Optional category filter: keyboards, headsets, webcams, accessories'),
+    }),
+    examples: {
+      request: { category: 'headsets' },
+      response: {
+        store: 'NovaGear',
+        count: 2,
+        products: [
+          {
+            sku: 'NG-HS-01',
+            name: 'NovaSound H500 Headset',
+            price: '₹4,999.00',
+            typicalQty: 1,
+            maxNormalQty: 4,
+          },
+        ],
+      },
+    },
+  })
+  async listProducts(input: { category?: string }, ctx: ExecutionContext) {
+    ctx.logger.info('Listing NovaGear catalog', { category: input.category });
+
+    const products = [...store.products.values()]
+      .filter((p) => !input.category || p.category === input.category)
+      .map((p) => ({
+        sku: p.sku,
+        name: p.name,
+        category: p.category,
+        priceMinor: p.priceMinor,
+        price: formatMinor(p.priceMinor),
+        typicalQty: p.typicalQty,
+        maxNormalQty: p.maxNormalQty,
+      }));
+
+    return {
+      store: 'NovaGear',
+      currency: 'INR',
+      count: products.length,
+      products,
+    };
+  }
+
+  // ------------------------------------------------------------ order intake
+
+  @Tool({
+    name: 'place_agent_order',
+    description:
+      'Simulate an incoming AI-agent purchase at NovaGear checkout. Accepts an ACP-shaped or x402-shaped payload and normalizes it into the gateway schema. Either replay a fixture order with order_ref, or construct a new one with agent_id + items. Returns the normalized order and the evidence path taken.',
+    inputSchema: z.object({
+      order_ref: z
+        .string()
+        .optional()
+        .describe('Replay an existing fixture order, e.g. ord_1002. Ignores the other fields.'),
+      protocol: z
+        .enum(['acp', 'x402'])
+        .optional()
+        .describe('Payload shape for a newly constructed order'),
+      agent_id: z.string().optional().describe('Buying agent placing the order, e.g. agt_ghost_nyx'),
+      items: z
+        .array(z.object({ sku: z.string(), qty: z.number().int().positive() }))
+        .optional()
+        .describe('Line items for a newly constructed order'),
+      spoof_signature: z
+        .boolean()
+        .optional()
+        .describe('Present a forged signature instead of a valid one (fraud simulation)'),
+      declared_amount_minor: z
+        .number()
+        .int()
+        .optional()
+        .describe('x402 only: override the declared settlement amount, in paise'),
+    }),
+    examples: {
+      request: { protocol: 'x402', agent_id: 'agt_ghost_nyx', items: [{ sku: 'NG-HS-01', qty: 40 }], spoof_signature: true },
+      response: {
+        orderId: 'ord_2001',
+        protocol: 'x402',
+        agentDisplayName: 'Nyx Buyer',
+        total: '₹1,99,960.00',
+        status: 'pending',
+        nextStep: 'Call screen_agent with this orderId',
+      },
+    },
+  })
+  async placeAgentOrder(
+    input: {
+      order_ref?: string;
+      protocol?: 'acp' | 'x402';
+      agent_id?: string;
+      items?: Array<{ sku: string; qty: number }>;
+      spoof_signature?: boolean;
+      declared_amount_minor?: number;
+    },
+    ctx: ExecutionContext,
+  ) {
+    // Replay path — the order already exists in the fixture set.
+    if (input.order_ref) {
+      const existing = store.getOrderOrThrow(input.order_ref);
+      ctx.logger.info('Replaying fixture order', { orderId: existing.orderId });
+      return {
+        orderId: existing.orderId,
+        protocol: existing.protocol,
+        protocolVersion: existing.protocolVersion,
+        agentId: existing.agentId,
+        agentDisplayName: existing.agentDisplayName,
+        items: existing.items,
+        currency: existing.currency,
+        totalMinor: existing.totalMinor,
+        total: formatMinor(existing.totalMinor, existing.currency),
+        status: existing.status,
+        evidencePath: existing.evidencePath,
+        source: 'fixture',
+        nextStep: `Call screen_agent with orderId "${existing.orderId}"`,
+      };
+    }
+
+    if (!input.protocol || !input.agent_id || !input.items?.length) {
+      throw new Error(
+        'Provide either order_ref (to replay a fixture) or protocol + agent_id + items (to construct a new order).',
+      );
+    }
+
+    const agent = store.getAgentOrThrow(input.agent_id);
+    const orderId = `ord_${++orderCounter}`;
+    const nonce = `nc_${Math.random().toString(16).slice(2, 8)}`;
+
+    // A forged signature is a plausible-looking hex string that will not verify.
+    const forged = Array.from({ length: 64 }, () =>
+      '0123456789abcdef'[Math.floor(Math.random() * 16)],
+    ).join('');
+    const signature = input.spoof_signature ? forged : SIGN_VALID;
+
+    let raw: RawOrderPayload;
+    if (input.protocol === 'x402') {
+      const catalogTotal = input.items.reduce((sum, line) => {
+        const p = store.products.get(line.sku);
+        if (!p) throw new Error(`Unknown SKU "${line.sku}"`);
+        return sum + p.priceMinor * line.qty;
+      }, 0);
+
+      const payload: X402Payload = {
+        protocol: 'x402',
+        x402_version: 1,
+        order_ref: orderId,
+        payer: {
+          agent_id: agent.agentId,
+          wallet: agent.wallet ?? '0x0000000000000000000000000000000000000000',
+          signature,
+          nonce,
+        },
+        payment_required: {
+          amount_minor: input.declared_amount_minor ?? catalogTotal,
+          currency: 'INR',
+          network: 'base-sepolia',
+          payee: NOVAGEAR_PAYEE,
+        },
+        line_items: input.items.map((i) => ({ sku: i.sku, qty: i.qty })),
+      };
+      raw = payload;
+    } else {
+      const payload: AcpPayload = {
+        protocol: 'acp',
+        acp_version: '0.3',
+        order_ref: orderId,
+        agent: {
+          id: agent.agentId,
+          display_name: agent.displayName,
+          signature,
+          nonce,
+        },
+        cart: {
+          currency: 'INR',
+          items: input.items.map((i) => ({ sku: i.sku, quantity: i.qty })),
+        },
+        buyer_context: { intent: 'purchase', session_id: `sess_live_${orderCounter}` },
+      };
+      raw = payload;
+    }
+
+    const order = store.ingest(raw);
+    store.orders.set(order.orderId, order);
+
+    ctx.logger.info('Agent order received at NovaGear checkout', {
+      orderId: order.orderId,
+      protocol: order.protocol,
+      agentId: order.agentId,
+      totalMinor: order.totalMinor,
+    });
+
+    return {
+      orderId: order.orderId,
+      protocol: order.protocol,
+      protocolVersion: order.protocolVersion,
+      agentId: order.agentId,
+      agentDisplayName: order.agentDisplayName,
+      items: order.items,
+      currency: order.currency,
+      totalMinor: order.totalMinor,
+      total: formatMinor(order.totalMinor, order.currency),
+      catalogTotal: formatMinor(catalogTotalMinor(order), order.currency),
+      status: order.status,
+      evidencePath: order.evidencePath,
+      source: 'constructed',
+      nextStep: `Call screen_agent with orderId "${order.orderId}"`,
+    };
+  }
+
+  // -------------------------------------------------------------- screening
+
+  @Tool({
+    name: 'screen_agent',
+    description:
+      "Run identity screening on the agent behind an order: registry lookup, cryptographic signature verification against the agent's registry key, blocklist status, dispute history, and (x402 only) declared amount vs catalog price. Returns pass/fail checks, not a score — call compute_trust_score next.",
+    inputSchema: z.object({
+      order_id: z.string().describe('Order to screen, e.g. ord_1002'),
+    }),
+    examples: {
+      request: { order_id: 'ord_1002' },
+      response: {
+        orderId: 'ord_1002',
+        agentDisplayName: 'Nyx Buyer',
+        signatureValid: false,
+        failedChecks: 2,
+        summary: '2 of 5 identity checks failed for Nyx Buyer',
+      },
+    },
+  })
+  async screenAgentTool(input: { order_id: string }, ctx: ExecutionContext) {
+    const order = store.getOrderOrThrow(input.order_id);
+    const result = screenAgent(order);
+
+    ctx.logger.info('Screened buying agent', {
+      orderId: order.orderId,
+      agentId: order.agentId,
+      signatureValid: result.signatureValid,
+      failedChecks: result.failedChecks,
+    });
+
+    return {
+      ...result,
+      protocol: order.protocol,
+      orderTotal: formatMinor(order.totalMinor, order.currency),
+      evidencePath: order.evidencePath,
+      nextStep: `Call compute_trust_score with orderId "${order.orderId}"`,
+    };
+  }
+
+  @Tool({
+    name: 'compute_trust_score',
+    description:
+      'Score an agent order 0-100 across five weighted signals (signature 35, reputation 25, order-size anomaly 20, velocity 12, account age 8), reason over conflicting signals, and decide: approve, hold for seller review, or decline. Applies the decision to the order and logs it. Orders above ₹40,000 are always held for a human.',
+    inputSchema: z.object({
+      order_id: z.string().describe('Order to score, e.g. ord_1002'),
+    }),
+    examples: {
+      request: { order_id: 'ord_1002' },
+      response: {
+        orderId: 'ord_1002',
+        score: 10,
+        band: 'high-risk',
+        verdict: 'decline',
+        conflicts: [],
+      },
+    },
+  })
+  @Widget('order-review')
+  async computeTrustScoreTool(input: { order_id: string }, ctx: ExecutionContext) {
+    const order = store.getOrderOrThrow(input.order_id);
+    const screening = screenAgent(order);
+    const scored = computeTrustScore(order, screening);
+
+    // Act on the decision: this is a gateway, not a report generator.
+    const statusMap = { approve: 'approved', hold: 'held', decline: 'declined' } as const;
+    store.setStatus(order.orderId, statusMap[scored.verdict]);
+    store.recordDecision({
+      orderId: order.orderId,
+      agentId: order.agentId,
+      agentDisplayName: order.agentDisplayName,
+      verdict: scored.verdict,
+      score: scored.score,
+      totalMinor: order.totalMinor,
+      currency: order.currency,
+      reason: scored.reasoning[0] ?? '',
+      decidedAt: new Date().toISOString(),
+    });
+
+    ctx.logger.info('Order decision applied', {
+      orderId: order.orderId,
+      score: scored.score,
+      verdict: scored.verdict,
+      conflicts: scored.conflicts.length,
+    });
+
+    const nextStep =
+      scored.verdict === 'decline'
+        ? `Declined. Consider blocklist_agent for "${order.agentId}".`
+        : scored.verdict === 'hold'
+          ? 'Held for seller review — a human decides before this sale settles.'
+          : `Approved. After settlement, call verify_receipt for "${order.orderId}".`;
+
+    return {
+      ...scored,
+      orderTotal: formatMinor(scored.orderTotalMinor, scored.currency),
+      hitlThreshold: formatMinor(HITL_THRESHOLD_MINOR),
+      status: statusMap[scored.verdict],
+      protocol: order.protocol,
+      items: order.items.map((i) => ({
+        ...i,
+        unitPrice: formatMinor(i.unitPriceMinor, order.currency),
+        lineTotal: formatMinor(i.lineTotalMinor, order.currency),
+      })),
+      screening,
+      evidencePath: order.evidencePath,
+      nextStep,
+    };
+  }
+
+  // ----------------------------------------------------------- verification
+
+  @Tool({
+    name: 'verify_receipt',
+    description:
+      'Diff a settled sales receipt against the on-chain settlement record field by field (amount, currency, payee, per-SKU quantities). Reports every mismatch, the seller-side exposure in rupees, and the recommended action. This is what catches tampered receipts after a sale looks clean.',
+    inputSchema: z.object({
+      order_id: z.string().describe('Settled order to verify, e.g. ord_1003'),
+    }),
+    examples: {
+      request: { order_id: 'ord_1003' },
+      response: {
+        orderId: 'ord_1003',
+        verified: false,
+        mismatchCount: 2,
+        exposure: '₹44,991.00',
+        recommendedAction: 'Flag ord_1003 as disputed and blocklist agt_relay_lyra pending investigation.',
+      },
+    },
+  })
+  @Widget('receipt-diff')
+  async verifyReceiptTool(input: { order_id: string }, ctx: ExecutionContext) {
+    const result = verifyReceipt(input.order_id);
+    const receipt = store.receipts.get(input.order_id)!;
+    const chain = store.onchain.get(input.order_id)!;
+
+    ctx.logger.info('Verified receipt against chain', {
+      orderId: input.order_id,
+      verified: result.verified,
+      mismatches: result.mismatchCount,
+      exposureMinor: result.exposureMinor,
+    });
+
+    return {
+      ...result,
+      exposure: formatMinor(result.exposureMinor, receipt.currency),
+      agentId: receipt.agentId,
+      agentDisplayName: store.agents.get(receipt.agentId)?.displayName ?? receipt.agentId,
+      receipt: {
+        amount: formatMinor(receipt.amountMinor, receipt.currency),
+        payee: receipt.payee,
+        items: receipt.items,
+        issuedAt: receipt.issuedAt,
+      },
+      chain: {
+        amount: formatMinor(chain.amountMinor, chain.currency),
+        payee: chain.payee,
+        items: chain.items,
+        txHash: chain.txHash,
+        network: chain.network,
+        settledAt: chain.settledAt,
+      },
+      nextStep: result.verified
+        ? 'Settlement is consistent — no action needed.'
+        : `Call flag_order for "${input.order_id}", then blocklist_agent for "${receipt.agentId}".`,
+    };
+  }
+
+  // ---------------------------------------------------------------- actions
+
+  @Tool({
+    name: 'flag_order',
+    description:
+      'Mark an order as disputed and attach the evidence behind the dispute. Use after verify_receipt finds a mismatch, or when screening evidence warrants holding the sale.',
+    inputSchema: z.object({
+      order_id: z.string().describe('Order to flag'),
+      reason: z.string().describe('Why the order is disputed'),
+      evidence: z
+        .array(z.string())
+        .optional()
+        .describe('Supporting evidence lines, e.g. specific field mismatches'),
+    }),
+    examples: {
+      request: {
+        order_id: 'ord_1003',
+        reason: 'Receipt amount does not match on-chain settlement',
+        evidence: ['receipt ₹4,999.00 vs chain ₹49,990.00', 'qty 1 vs 10'],
+      },
+      response: { orderId: 'ord_1003', status: 'flagged', exposure: '₹44,991.00' },
+    },
+  })
+  async flagOrder(
+    input: { order_id: string; reason: string; evidence?: string[] },
+    ctx: ExecutionContext,
+  ) {
+    const order = store.getOrderOrThrow(input.order_id);
+
+    // If this order has a settlement pair, price the dispute automatically.
+    let exposureMinor = 0;
+    if (store.receipts.has(order.orderId) && store.onchain.has(order.orderId)) {
+      exposureMinor = verifyReceipt(order.orderId).exposureMinor;
+    }
+
+    const record = {
+      orderId: order.orderId,
+      reason: input.reason,
+      evidence: input.evidence ?? [],
+      exposureMinor,
+      flaggedAt: new Date().toISOString(),
+    };
+    store.flags.set(order.orderId, record);
+    store.setStatus(order.orderId, 'flagged');
+
+    ctx.logger.warn('Order flagged as disputed', {
+      orderId: order.orderId,
+      reason: input.reason,
+      exposureMinor,
+    });
+
+    return {
+      ...record,
+      status: 'flagged',
+      agentId: order.agentId,
+      agentDisplayName: order.agentDisplayName,
+      exposure: formatMinor(exposureMinor, order.currency),
+      nextStep: `Consider blocklist_agent for "${order.agentId}".`,
+    };
+  }
+
+  @Tool({
+    name: 'blocklist_agent',
+    description:
+      'Ban a buying agent from the NovaGear store. Every future order from this agent is declined at screening before it can settle.',
+    inputSchema: z.object({
+      agent_id: z.string().describe('Agent to ban, e.g. agt_ghost_nyx'),
+      reason: z.string().describe('Why the agent is being banned'),
+    }),
+    examples: {
+      request: { agent_id: 'agt_ghost_nyx', reason: 'Spoofed signature on a 40-unit order' },
+      response: { agentId: 'agt_ghost_nyx', blocked: true, blocklistSize: 1 },
+    },
+  })
+  async blocklistAgent(input: { agent_id: string; reason: string }, ctx: ExecutionContext) {
+    const agent = store.getAgentOrThrow(input.agent_id);
+
+    const entry = {
+      agentId: agent.agentId,
+      displayName: agent.displayName,
+      reason: input.reason,
+      blockedAt: new Date().toISOString(),
+    };
+    store.blocklist.set(agent.agentId, entry);
+
+    ctx.logger.warn('Agent blocklisted', { agentId: agent.agentId, reason: input.reason });
+
+    const affected = [...store.orders.values()].filter((o) => o.agentId === agent.agentId);
+
+    return {
+      ...entry,
+      blocked: true,
+      blocklistSize: store.blocklist.size,
+      affectedOrders: affected.map((o) => o.orderId),
+      nextStep: 'Call get_sales_dashboard to see the updated revenue-protected figure.',
+    };
+  }
+
+  // -------------------------------------------------------------- dashboard
+
+  @Tool({
+    name: 'get_sales_dashboard',
+    description:
+      'Seller view of agent-driven sales: order feed by agent, approval/hold/decline counts, flagged orders, the blocklist, and the running "revenue protected" figure — money the gateway stopped from leaving NovaGear.',
+    inputSchema: z.object({
+      agent_id: z.string().optional().describe('Optional: restrict the feed to one agent'),
+    }),
+    examples: {
+      request: {},
+      response: {
+        store: 'NovaGear',
+        revenueProtected: '₹2,44,951.00',
+        counts: { approved: 3, held: 4, declined: 2, flagged: 1 },
+      },
+    },
+  })
+  @Widget('sales-dashboard')
+  async getSalesDashboard(input: { agent_id?: string }, ctx: ExecutionContext) {
+    const orders = [...store.orders.values()].filter(
+      (o) => !input.agent_id || o.agentId === input.agent_id,
+    );
+
+    const counts = {
+      pending: orders.filter((o) => o.status === 'pending').length,
+      approved: orders.filter((o) => o.status === 'approved').length,
+      held: orders.filter((o) => o.status === 'held').length,
+      declined: orders.filter((o) => o.status === 'declined').length,
+      flagged: orders.filter((o) => o.status === 'flagged').length,
+    };
+
+    const approvedRevenueMinor = orders
+      .filter((o) => o.status === 'approved')
+      .reduce((sum, o) => sum + o.totalMinor, 0);
+
+    // Revenue protected = value of orders stopped at screening + exposure
+    // uncovered on settled orders that were flagged.
+    const declinedValueMinor = orders
+      .filter((o) => o.status === 'declined')
+      .reduce((sum, o) => sum + o.totalMinor, 0);
+    const flaggedExposureMinor = [...store.flags.values()].reduce(
+      (sum, f) => sum + f.exposureMinor,
+      0,
+    );
+    const revenueProtectedMinor = declinedValueMinor + flaggedExposureMinor;
+
+    const byAgent = new Map<string, { agentId: string; displayName: string; orders: number; valueMinor: number; declined: number }>();
+    for (const o of orders) {
+      const row = byAgent.get(o.agentId) ?? {
+        agentId: o.agentId,
+        displayName: o.agentDisplayName,
+        orders: 0,
+        valueMinor: 0,
+        declined: 0,
+      };
+      row.orders += 1;
+      row.valueMinor += o.totalMinor;
+      if (o.status === 'declined' || o.status === 'flagged') row.declined += 1;
+      byAgent.set(o.agentId, row);
+    }
+
+    ctx.logger.info('Sales dashboard requested', {
+      orders: orders.length,
+      revenueProtectedMinor,
+    });
+
+    return {
+      store: 'NovaGear',
+      currency: 'INR',
+      counts,
+      totalOrders: orders.length,
+      approvedRevenueMinor,
+      approvedRevenue: formatMinor(approvedRevenueMinor),
+      revenueProtectedMinor,
+      revenueProtected: formatMinor(revenueProtectedMinor),
+      hitlThreshold: formatMinor(HITL_THRESHOLD_MINOR),
+      feed: orders
+        .slice()
+        .sort((a, b) => a.orderId.localeCompare(b.orderId))
+        .map((o) => ({
+          orderId: o.orderId,
+          protocol: o.protocol,
+          agentId: o.agentId,
+          agentDisplayName: o.agentDisplayName,
+          status: o.status,
+          total: formatMinor(o.totalMinor, o.currency),
+          totalMinor: o.totalMinor,
+          items: o.items.map((i) => `${i.qty}× ${i.sku}`).join(', '),
+        })),
+      agents: [...byAgent.values()]
+        .sort((a, b) => b.valueMinor - a.valueMinor)
+        .map((a) => ({ ...a, value: formatMinor(a.valueMinor) })),
+      flagged: [...store.flags.values()].map((f) => ({
+        ...f,
+        exposure: formatMinor(f.exposureMinor),
+      })),
+      blocklist: [...store.blocklist.values()],
+      decisions: store.decisions.slice(0, 10),
+    };
+  }
+
+  // ------------------------------------------------------------------ demo
+
+  @Tool({
+    name: 'reset_demo',
+    description:
+      'Reset all gateway state back to the original fixtures — clears decisions, flags and the blocklist. Use between demo runs.',
+    inputSchema: z.object({}),
+    examples: { request: {}, response: { reset: true, orders: 9 } },
+  })
+  async resetDemo(_input: unknown, ctx: ExecutionContext) {
+    store.reset();
+    ctx.logger.info('Gateway state reset to fixtures');
+    return {
+      reset: true,
+      orders: store.orders.size,
+      agents: store.agents.size,
+      products: store.products.size,
+      message: 'Gateway state restored to the original fixture set.',
+    };
+  }
+}

--- a/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.types.ts
+++ b/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.types.ts
@@ -1,0 +1,169 @@
+/**
+ * Shared domain types for the Agentic Commerce Gateway.
+ *
+ * Money is always handled in **minor units** (paise) as integers so that
+ * receipt-vs-chain comparisons are exact — a float rupee amount would make
+ * a genuine tampering diff indistinguishable from a rounding artefact.
+ */
+
+export type Protocol = 'acp' | 'x402';
+
+export type OrderStatus =
+  | 'pending'
+  | 'approved'
+  | 'held'
+  | 'declined'
+  | 'flagged';
+
+export type Verdict = 'approve' | 'hold' | 'decline';
+
+export interface Product {
+  sku: string;
+  name: string;
+  category: string;
+  priceMinor: number;
+  /** Quantity a normal human buyer orders in one go. */
+  typicalQty: number;
+  /** Above this, the order size is anomalous for this SKU. */
+  maxNormalQty: number;
+}
+
+export interface AgentRecord {
+  agentId: string;
+  displayName: string;
+  operator: string;
+  /** Whether the agent exists in the mock reputation registry at all. */
+  registered: boolean;
+  /** 0-100 reputation from the registry. */
+  reputation: number;
+  accountAgeDays: number;
+  lifetimeOrders: number;
+  disputes: number;
+  /** Observed order rate used for the velocity signal. */
+  ordersLastHour: number;
+  /** Shared secret backing this agent's payload signature (mock registry key). */
+  signingKey: string;
+  wallet?: string;
+}
+
+export interface OrderItem {
+  sku: string;
+  name: string;
+  qty: number;
+  unitPriceMinor: number;
+  lineTotalMinor: number;
+}
+
+/**
+ * Protocol-agnostic order shape. Both ACP- and x402-shaped payloads are
+ * normalized into this before any screening logic runs, so the scoring engine
+ * never branches on wire format.
+ */
+export interface NormalizedOrder {
+  orderId: string;
+  protocol: Protocol;
+  protocolVersion: string;
+  agentId: string;
+  agentDisplayName: string;
+  items: OrderItem[];
+  currency: string;
+  totalMinor: number;
+  signature: string;
+  nonce: string;
+  receivedAt: string;
+  status: OrderStatus;
+  /** x402-only settlement fields; absent for ACP. */
+  payee?: string;
+  network?: string;
+  wallet?: string;
+  /** Evidence path taken during normalization, surfaced to the judge/user. */
+  evidencePath: string[];
+}
+
+export interface ScreeningCheck {
+  id: string;
+  label: string;
+  passed: boolean;
+  detail: string;
+}
+
+export interface ScreeningResult {
+  orderId: string;
+  agentId: string;
+  agentDisplayName: string;
+  registered: boolean;
+  signatureValid: boolean;
+  blocklisted: boolean;
+  checks: ScreeningCheck[];
+  failedChecks: number;
+  summary: string;
+}
+
+export interface ScoreSignal {
+  id: string;
+  label: string;
+  /** Points awarded out of `max`. */
+  points: number;
+  max: number;
+  status: 'pass' | 'warn' | 'fail';
+  detail: string;
+}
+
+export interface TrustScoreResult {
+  orderId: string;
+  agentId: string;
+  agentDisplayName: string;
+  score: number;
+  band: 'low-risk' | 'elevated' | 'high-risk';
+  verdict: Verdict;
+  signals: ScoreSignal[];
+  /** How many of the five weighted signals came back `fail`. */
+  failedSignals: number;
+  /** Signals that point in opposite directions — the reasoning surface. */
+  conflicts: string[];
+  reasoning: string[];
+  hitlRequired: boolean;
+  orderTotalMinor: number;
+  currency: string;
+}
+
+export interface OnChainRecord {
+  orderId: string;
+  txHash: string;
+  network: string;
+  amountMinor: number;
+  currency: string;
+  payee: string;
+  items: Array<{ sku: string; qty: number }>;
+  settledAt: string;
+}
+
+export interface SalesReceipt {
+  orderId: string;
+  agentId: string;
+  amountMinor: number;
+  currency: string;
+  payee: string;
+  items: Array<{ sku: string; qty: number }>;
+  issuedAt: string;
+}
+
+export interface FieldDiff {
+  field: string;
+  receiptValue: string;
+  chainValue: string;
+  match: boolean;
+  severity: 'ok' | 'warning' | 'critical';
+}
+
+export interface ReceiptVerification {
+  orderId: string;
+  verified: boolean;
+  diffs: FieldDiff[];
+  mismatchCount: number;
+  criticalMismatches: number;
+  /** Money the seller would have lost had the receipt been trusted. */
+  exposureMinor: number;
+  summary: string;
+  recommendedAction: string;
+}

--- a/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.verification.ts
+++ b/sample-apps/agentic-commerce-gateway/src/modules/gateway/gateway.verification.ts
@@ -1,0 +1,129 @@
+import { formatMinor, store } from './gateway.store.js';
+import type { FieldDiff, ReceiptVerification } from './gateway.types.js';
+
+/**
+ * Post-sale verification: diff the sales receipt NovaGear issued against the
+ * on-chain settlement record, field by field.
+ *
+ * A receipt that agrees with itself proves nothing — the seller's exposure is
+ * the gap between what the receipt claims and what actually settled.
+ */
+/** Field id -> wording a seller would actually use, for prose summaries. */
+function humanField(field: string): string {
+  if (field.startsWith('line_item.')) return `quantity for ${field.split('.')[1]}`;
+  const map: Record<string, string> = {
+    amount: 'amount',
+    currency: 'currency',
+    payee: 'payee',
+    network: 'network',
+    tx_hash: 'transaction hash',
+  };
+  return map[field] ?? field;
+}
+
+export function verifyReceipt(orderId: string): ReceiptVerification {
+  const receipt = store.receipts.get(orderId);
+  const chain = store.onchain.get(orderId);
+
+  if (!receipt || !chain) {
+    const settled = [...store.receipts.keys()].join(', ');
+    throw new Error(
+      `No settlement pair for "${orderId}". Orders with both a receipt and an on-chain record: ${settled}`,
+    );
+  }
+
+  const diffs: FieldDiff[] = [];
+
+  const amountMatch = receipt.amountMinor === chain.amountMinor;
+  diffs.push({
+    field: 'amount',
+    receiptValue: formatMinor(receipt.amountMinor, receipt.currency),
+    chainValue: formatMinor(chain.amountMinor, chain.currency),
+    match: amountMatch,
+    severity: amountMatch ? 'ok' : 'critical',
+  });
+
+  const currencyMatch = receipt.currency === chain.currency;
+  diffs.push({
+    field: 'currency',
+    receiptValue: receipt.currency,
+    chainValue: chain.currency,
+    match: currencyMatch,
+    severity: currencyMatch ? 'ok' : 'critical',
+  });
+
+  const payeeMatch = receipt.payee.toLowerCase() === chain.payee.toLowerCase();
+  diffs.push({
+    field: 'payee',
+    receiptValue: receipt.payee,
+    chainValue: chain.payee,
+    match: payeeMatch,
+    severity: payeeMatch ? 'ok' : 'critical',
+  });
+
+  // Line items, compared per SKU so a quantity swap is visible.
+  const skus = new Set([
+    ...receipt.items.map((i) => i.sku),
+    ...chain.items.map((i) => i.sku),
+  ]);
+  for (const sku of [...skus].sort()) {
+    const rQty = receipt.items.find((i) => i.sku === sku)?.qty;
+    const cQty = chain.items.find((i) => i.sku === sku)?.qty;
+    const match = rQty === cQty;
+    diffs.push({
+      field: `line_item.${sku}.qty`,
+      receiptValue: rQty === undefined ? '— absent —' : String(rQty),
+      chainValue: cQty === undefined ? '— absent —' : String(cQty),
+      match,
+      severity: match ? 'ok' : 'critical',
+    });
+  }
+
+  diffs.push({
+    field: 'network',
+    receiptValue: '(not asserted by receipt)',
+    chainValue: chain.network,
+    match: true,
+    severity: 'ok',
+  });
+
+  diffs.push({
+    field: 'tx_hash',
+    receiptValue: '(not asserted by receipt)',
+    chainValue: chain.txHash,
+    match: true,
+    severity: 'ok',
+  });
+
+  const mismatches = diffs.filter((d) => !d.match);
+  const criticalMismatches = mismatches.filter((d) => d.severity === 'critical').length;
+
+  // What the seller stands to lose: an understated receipt hides the delta; a
+  // redirected payee loses the entire settled amount.
+  let exposureMinor = 0;
+  if (!amountMatch) {
+    exposureMinor += Math.abs(chain.amountMinor - receipt.amountMinor);
+  }
+  if (!payeeMatch) {
+    exposureMinor += chain.amountMinor;
+  }
+
+  const verified = mismatches.length === 0;
+
+  return {
+    orderId,
+    verified,
+    diffs,
+    mismatchCount: mismatches.length,
+    criticalMismatches,
+    exposureMinor,
+    summary: verified
+      ? `Receipt for ${orderId} matches the on-chain record on every compared field.`
+      : `${mismatches.length} field(s) disagree between the receipt and the chain: ${mismatches
+          .map((m) => humanField(m.field))
+          .join(', ')}. Seller exposure ${formatMinor(exposureMinor, receipt.currency)}.`,
+    recommendedAction: verified
+      ? 'No action required — settlement is consistent.'
+      : `Flag ${orderId} as disputed and blocklist ${receipt.agentId} pending investigation.`,
+  };
+}

--- a/sample-apps/agentic-commerce-gateway/src/widgets/app/_shared/ui.tsx
+++ b/sample-apps/agentic-commerce-gateway/src/widgets/app/_shared/ui.tsx
@@ -1,0 +1,328 @@
+'use client';
+
+import React from 'react';
+
+/**
+ * Shared visual language for the gateway widgets.
+ *
+ * Direction: a customs/inspection slip. These widgets document goods passing a
+ * checkpoint, so they borrow that vernacular — pale stock, hairline rules,
+ * monospace data fields, uppercase micro-labels, and a pressed verdict stamp.
+ * Figures, SKUs, hashes and addresses are all monospace so columns align and a
+ * tampered digit is visible at a glance.
+ */
+
+export const MONO =
+  'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace';
+export const SANS =
+  'ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+export interface Tokens {
+  stock: string;
+  card: string;
+  ink: string;
+  inkSoft: string;
+  rule: string;
+  ruleSoft: string;
+  clear: string;
+  hold: string;
+  danger: string;
+  clearWash: string;
+  holdWash: string;
+  dangerWash: string;
+}
+
+export function tokens(isDark: boolean): Tokens {
+  return isDark
+    ? {
+        stock: '#12151A',
+        card: '#181C23',
+        ink: '#E8EBF0',
+        inkSoft: '#96A0AF',
+        rule: '#2B313B',
+        ruleSoft: '#212730',
+        clear: '#57B586',
+        hold: '#D6A247',
+        danger: '#E4736A',
+        clearWash: 'rgba(87,181,134,0.12)',
+        holdWash: 'rgba(214,162,71,0.12)',
+        dangerWash: 'rgba(228,115,106,0.12)',
+      }
+    : {
+        stock: '#EDF0F4',
+        card: '#FFFFFF',
+        ink: '#1A1F2B',
+        inkSoft: '#5D6779',
+        rule: '#C7CEDA',
+        ruleSoft: '#E1E5EC',
+        clear: '#1F6F4A',
+        hold: '#8F5D0C',
+        danger: '#B3261E',
+        clearWash: 'rgba(31,111,74,0.08)',
+        holdWash: 'rgba(143,93,12,0.08)',
+        dangerWash: 'rgba(179,38,30,0.08)',
+      };
+}
+
+/** Verdict / status -> stamp colour. */
+export function toneFor(t: Tokens, value: string): string {
+  const v = value.toLowerCase();
+  if (['approve', 'approved', 'ok', 'pass', 'low-risk', 'verified', 'clear'].includes(v)) return t.clear;
+  if (['hold', 'held', 'warn', 'elevated', 'pending', 'review'].includes(v)) return t.hold;
+  return t.danger;
+}
+
+/** Tiny uppercase field label, as printed on a declaration form. */
+export function Micro({
+  children,
+  t,
+  style,
+}: {
+  children: React.ReactNode;
+  t: Tokens;
+  style?: React.CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        fontFamily: SANS,
+        fontSize: 9.5,
+        fontWeight: 700,
+        letterSpacing: '0.14em',
+        textTransform: 'uppercase',
+        color: t.inkSoft,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** The signature element: a verdict pressed onto the document. */
+export function Stamp({ label, tone, t }: { label: string; tone: string; t: Tokens }) {
+  return (
+    <div
+      style={{
+        transform: 'rotate(-3deg)',
+        border: `2px solid ${tone}`,
+        boxShadow: `0 0 0 1px ${t.card}, 0 0 0 3px ${tone}`,
+        color: tone,
+        padding: '5px 12px 4px',
+        fontFamily: MONO,
+        fontSize: 13,
+        fontWeight: 700,
+        letterSpacing: '0.18em',
+        textTransform: 'uppercase',
+        whiteSpace: 'nowrap',
+        lineHeight: 1.1,
+        flexShrink: 0,
+      }}
+    >
+      {label}
+    </div>
+  );
+}
+
+/** Perforated reference strip that heads every document. */
+export function RefStrip({
+  t,
+  left,
+  right,
+}: {
+  t: Tokens;
+  left: React.ReactNode;
+  right?: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+        padding: '10px 16px',
+        borderBottom: `1px dashed ${t.rule}`,
+        background: t.stock,
+        flexWrap: 'wrap',
+      }}
+    >
+      <div style={{ fontFamily: MONO, fontSize: 11.5, letterSpacing: '0.08em', color: t.ink }}>
+        {left}
+      </div>
+      {right ? (
+        <div style={{ fontFamily: MONO, fontSize: 10.5, letterSpacing: '0.1em', color: t.inkSoft }}>
+          {right}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** Segmented instrument readout — reads as a gauge, not a progress bar. */
+export function TickMeter({
+  value,
+  max,
+  tone,
+  t,
+  segments = 25,
+}: {
+  value: number;
+  max: number;
+  tone: string;
+  t: Tokens;
+  segments?: number;
+}) {
+  const filled = Math.round((Math.max(0, Math.min(value, max)) / max) * segments);
+  return (
+    <div style={{ display: 'flex', gap: 2, alignItems: 'flex-end', height: 14 }} aria-hidden="true">
+      {Array.from({ length: segments }, (_, i) => (
+        <div
+          key={i}
+          style={{
+            flex: 1,
+            height: i % 5 === 0 ? 14 : 10,
+            background: i < filled ? tone : t.ruleSoft,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Label/value row in the form-field grid. */
+export function Field({
+  label,
+  value,
+  t,
+  mono = true,
+  tone,
+}: {
+  label: string;
+  value: React.ReactNode;
+  t: Tokens;
+  mono?: boolean;
+  tone?: string;
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 3, minWidth: 0 }}>
+      <Micro t={t}>{label}</Micro>
+      <div
+        style={{
+          fontFamily: mono ? MONO : SANS,
+          fontSize: 13,
+          color: tone ?? t.ink,
+          wordBreak: 'break-word',
+          lineHeight: 1.35,
+        }}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export function Section({
+  title,
+  t,
+  children,
+  note,
+}: {
+  title: string;
+  t: Tokens;
+  children: React.ReactNode;
+  note?: React.ReactNode;
+}) {
+  return (
+    <section style={{ borderTop: `1px solid ${t.rule}`, padding: '14px 16px' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          gap: 8,
+          marginBottom: 10,
+        }}
+      >
+        <Micro t={t}>{title}</Micro>
+        {note ? (
+          <div style={{ fontFamily: MONO, fontSize: 10.5, color: t.inkSoft }}>{note}</div>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+/** Document shell shared by all three widgets. */
+export function Slip({
+  t,
+  children,
+  maxWidth = 560,
+}: {
+  t: Tokens;
+  children: React.ReactNode;
+  maxWidth?: number;
+}) {
+  return (
+    <div
+      style={{
+        background: t.stock,
+        padding: 12,
+        fontFamily: SANS,
+        color: t.ink,
+        minHeight: '100%',
+      }}
+    >
+      <style>{`
+        * { box-sizing: border-box; }
+        .gw-grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 20px; }
+        .gw-diff { display: grid; grid-template-columns: 1fr 30px 1fr; align-items: center; gap: 0; }
+        .gw-diff-stack { display: none; }
+        .gw-cell-label { display: none; }
+        button:focus-visible, [tabindex]:focus-visible {
+          outline: 2px solid currentColor; outline-offset: 2px;
+        }
+        @media (max-width: 430px) {
+          .gw-grid-2 { grid-template-columns: 1fr; }
+          .gw-diff { grid-template-columns: 1fr; }
+          .gw-diff-gutter { display: none; }
+          .gw-diff-stack { display: block; }
+          .gw-cell-label { display: block; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          * { transition: none !important; animation: none !important; }
+        }
+      `}</style>
+      <article
+        style={{
+          maxWidth,
+          margin: '0 auto',
+          background: t.card,
+          border: `1px solid ${t.rule}`,
+          boxShadow: '0 1px 2px rgba(16,22,34,0.08), 0 8px 24px -12px rgba(16,22,34,0.25)',
+        }}
+      >
+        {children}
+      </article>
+    </div>
+  );
+}
+
+export function Empty({ t, message }: { t: Tokens; message: string }) {
+  return (
+    <div
+      style={{
+        fontFamily: MONO,
+        fontSize: 12,
+        color: t.inkSoft,
+        padding: 24,
+        textAlign: 'center',
+        background: t.stock,
+        letterSpacing: '0.06em',
+      }}
+    >
+      {message}
+    </div>
+  );
+}

--- a/sample-apps/agentic-commerce-gateway/src/widgets/app/layout.tsx
+++ b/sample-apps/agentic-commerce-gateway/src/widgets/app/layout.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { WidgetLayout } from '@nitrostack/widgets';
+
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, padding: 0, fontFamily: 'system-ui, sans-serif' }}>
+        <WidgetLayout>{children}</WidgetLayout>
+      </body>
+    </html>
+  );
+}

--- a/sample-apps/agentic-commerce-gateway/src/widgets/app/order-review/page.tsx
+++ b/sample-apps/agentic-commerce-gateway/src/widgets/app/order-review/page.tsx
@@ -1,0 +1,341 @@
+'use client';
+
+import React from 'react';
+import { useTheme, useWidgetSDK, useWidgetState } from '@nitrostack/widgets';
+import {
+  Empty,
+  Field,
+  Micro,
+  MONO,
+  RefStrip,
+  SANS,
+  Section,
+  Slip,
+  Stamp,
+  TickMeter,
+  tokens,
+  toneFor,
+} from '../_shared/ui';
+
+interface Signal {
+  id: string;
+  label: string;
+  points: number;
+  max: number;
+  status: 'pass' | 'warn' | 'fail';
+  detail: string;
+}
+
+interface Check {
+  id: string;
+  label: string;
+  passed: boolean;
+  detail: string;
+}
+
+interface OrderReviewData {
+  orderId: string;
+  agentId: string;
+  agentDisplayName: string;
+  score: number;
+  band: string;
+  verdict: string;
+  status: string;
+  protocol: string;
+  signals: Signal[];
+  failedSignals: number;
+  conflicts: string[];
+  reasoning: string[];
+  hitlRequired: boolean;
+  orderTotal: string;
+  hitlThreshold: string;
+  items: Array<{ sku: string; name: string; qty: number; lineTotal: string }>;
+  screening: { checks: Check[]; failedChecks: number; summary: string };
+  evidencePath: string[];
+  nextStep: string;
+}
+
+export default function OrderReview() {
+  const theme = useTheme();
+  const { getToolOutput } = useWidgetSDK();
+  const [state, setState] = useWidgetState<{ showWorking: boolean }>(() => ({
+    showWorking: false,
+  }));
+
+  const t = tokens(theme === 'dark');
+  const data = getToolOutput<OrderReviewData>();
+
+  if (!data) return <Empty t={t} message="AWAITING ORDER REVIEW" />;
+
+  const tone = toneFor(t, data.verdict);
+  const showWorking = state?.showWorking ?? false;
+
+  const statusTone = (s: Signal['status']) =>
+    s === 'pass' ? t.clear : s === 'warn' ? t.hold : t.danger;
+
+  return (
+    <Slip t={t}>
+      <RefStrip
+        t={t}
+        left={
+          <>
+            <strong style={{ fontWeight: 700 }}>{data.orderId}</strong>
+            <span style={{ color: t.inkSoft }}> · {data.protocol.toUpperCase()} · NOVAGEAR</span>
+          </>
+        }
+        right="AGENT ORDER SCREENING"
+      />
+
+      {/* Verdict + score: the two things a seller needs in one glance. */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: 16,
+          padding: '18px 16px 16px',
+        }}
+      >
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <Micro t={t}>Trust score</Micro>
+          <div
+            style={{
+              fontFamily: MONO,
+              fontSize: 46,
+              lineHeight: 1,
+              fontWeight: 700,
+              color: tone,
+              letterSpacing: '-0.02em',
+              margin: '6px 0 8px',
+            }}
+          >
+            {data.score}
+            <span style={{ fontSize: 16, color: t.inkSoft, fontWeight: 400 }}>/100</span>
+          </div>
+          <TickMeter value={data.score} max={100} tone={tone} t={t} />
+          <div
+            style={{
+              fontFamily: MONO,
+              fontSize: 11,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: t.inkSoft,
+              marginTop: 8,
+            }}
+          >
+            {data.band} · {data.failedSignals} of {data.signals.length} signals failed
+          </div>
+        </div>
+        <Stamp label={data.verdict} tone={tone} t={t} />
+      </div>
+
+      <Section title="Buyer" t={t}>
+        <div className="gw-grid-2">
+          <Field label="Agent" value={data.agentDisplayName} t={t} mono={false} />
+          <Field label="Agent ID" value={data.agentId} t={t} />
+          <Field label="Order total" value={data.orderTotal} t={t} tone={tone} />
+          <Field label="Disposition" value={data.status.toUpperCase()} t={t} tone={tone} />
+        </div>
+      </Section>
+
+      <Section title="Cart" t={t} note={`${data.items.length} line item(s)`}>
+        {data.items.map((item) => (
+          <div
+            key={item.sku}
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              gap: 12,
+              padding: '6px 0',
+              borderBottom: `1px solid ${t.ruleSoft}`,
+              fontFamily: MONO,
+              fontSize: 12.5,
+            }}
+          >
+            <span style={{ minWidth: 0 }}>
+              <span style={{ color: t.inkSoft }}>{item.qty}× </span>
+              {item.sku}
+              <span style={{ color: t.inkSoft, fontFamily: SANS, fontSize: 12 }}> {item.name}</span>
+            </span>
+            <span style={{ whiteSpace: 'nowrap' }}>{item.lineTotal}</span>
+          </div>
+        ))}
+      </Section>
+
+      {/* Weighted signals — the seller can see which one sank the order. */}
+      <Section title="Risk signals" t={t} note="points awarded / weight">
+        {data.signals.map((s) => (
+          <div key={s.id} style={{ marginBottom: 12 }}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'baseline',
+                gap: 10,
+              }}
+            >
+              <span style={{ fontFamily: SANS, fontSize: 12.5, fontWeight: 600 }}>{s.label}</span>
+              <span
+                style={{
+                  fontFamily: MONO,
+                  fontSize: 11.5,
+                  color: statusTone(s.status),
+                  whiteSpace: 'nowrap',
+                  letterSpacing: '0.08em',
+                }}
+              >
+                {s.points}/{s.max} {s.status.toUpperCase()}
+              </span>
+            </div>
+            <div style={{ margin: '5px 0 4px' }}>
+              <TickMeter value={s.points} max={s.max} tone={statusTone(s.status)} t={t} segments={16} />
+            </div>
+            <div style={{ fontFamily: SANS, fontSize: 11.5, color: t.inkSoft, lineHeight: 1.4 }}>
+              {s.detail}
+            </div>
+          </div>
+        ))}
+      </Section>
+
+      {data.conflicts.length > 0 && (
+        <Section title="Conflicting evidence" t={t} note={`${data.conflicts.length}`}>
+          {data.conflicts.map((c, i) => (
+            <div
+              key={i}
+              style={{
+                background: t.holdWash,
+                borderLeft: `3px solid ${t.hold}`,
+                padding: '9px 11px',
+                marginBottom: 8,
+                fontFamily: SANS,
+                fontSize: 12,
+                lineHeight: 1.45,
+              }}
+            >
+              {c}
+            </div>
+          ))}
+        </Section>
+      )}
+
+      {/* Only meaningful when the order is actually waiting on a person — a
+          declined order never reaches settlement. */}
+      {data.hitlRequired && data.verdict === 'hold' && (
+        <Section title="Human review" t={t}>
+          <div style={{ fontFamily: SANS, fontSize: 12, lineHeight: 1.45 }}>
+            Order total exceeds the {data.hitlThreshold} threshold. A person signs off before this
+            sale settles, regardless of score.
+          </div>
+        </Section>
+      )}
+
+      <Section title="Identity checks" t={t} note={data.screening.summary}>
+        {data.screening.checks.map((c) => (
+          <div
+            key={c.id}
+            style={{
+              display: 'flex',
+              gap: 9,
+              padding: '5px 0',
+              alignItems: 'flex-start',
+              fontFamily: SANS,
+              fontSize: 12,
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                fontFamily: MONO,
+                color: c.passed ? t.clear : t.danger,
+                fontWeight: 700,
+                lineHeight: 1.4,
+              }}
+            >
+              {c.passed ? '✓' : '✗'}
+            </span>
+            <span style={{ minWidth: 0 }}>
+              <span style={{ fontWeight: 600 }}>{c.label}</span>
+              <span style={{ color: t.inkSoft }}> — {c.detail}</span>
+            </span>
+          </div>
+        ))}
+      </Section>
+
+      {/* The gateway's working, kept out of the way until asked for. */}
+      <Section title="Gateway working" t={t}>
+        <button
+          onClick={() => setState({ showWorking: !showWorking })}
+          aria-expanded={showWorking}
+          style={{
+            fontFamily: MONO,
+            fontSize: 11,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            background: 'transparent',
+            color: t.ink,
+            border: `1px solid ${t.rule}`,
+            padding: '6px 11px',
+            cursor: 'pointer',
+          }}
+        >
+          {showWorking ? '− Hide reasoning' : '+ Show reasoning'}
+        </button>
+
+        {showWorking && (
+          <div style={{ marginTop: 11 }}>
+            <Micro t={t} style={{ marginBottom: 6 }}>
+              Decision trail
+            </Micro>
+            {data.reasoning.map((r, i) => (
+              <div
+                key={i}
+                style={{
+                  fontFamily: SANS,
+                  fontSize: 12,
+                  lineHeight: 1.45,
+                  paddingLeft: 12,
+                  borderLeft: `2px solid ${t.ruleSoft}`,
+                  marginBottom: 7,
+                }}
+              >
+                {r}
+              </div>
+            ))}
+
+            <Micro t={t} style={{ margin: '12px 0 6px' }}>
+              Evidence path ({data.protocol.toUpperCase()})
+            </Micro>
+            {data.evidencePath.map((e, i) => (
+              <div
+                key={i}
+                style={{
+                  fontFamily: MONO,
+                  fontSize: 11,
+                  color: t.inkSoft,
+                  lineHeight: 1.5,
+                  wordBreak: 'break-word',
+                }}
+              >
+                {e}
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      <div
+        style={{
+          borderTop: `1px dashed ${t.rule}`,
+          background: t.stock,
+          padding: '10px 16px',
+          fontFamily: MONO,
+          fontSize: 11,
+          color: t.inkSoft,
+          lineHeight: 1.4,
+        }}
+      >
+        NEXT — {data.nextStep}
+      </div>
+    </Slip>
+  );
+}

--- a/sample-apps/agentic-commerce-gateway/src/widgets/app/receipt-diff/page.tsx
+++ b/sample-apps/agentic-commerce-gateway/src/widgets/app/receipt-diff/page.tsx
@@ -1,0 +1,288 @@
+'use client';
+
+import React from 'react';
+import { useTheme, useWidgetSDK } from '@nitrostack/widgets';
+import {
+  Empty,
+  Micro,
+  MONO,
+  RefStrip,
+  SANS,
+  Section,
+  Slip,
+  Stamp,
+  tokens,
+} from '../_shared/ui';
+
+interface Diff {
+  field: string;
+  receiptValue: string;
+  chainValue: string;
+  match: boolean;
+  severity: 'ok' | 'warning' | 'critical';
+}
+
+interface ReceiptDiffData {
+  orderId: string;
+  verified: boolean;
+  diffs: Diff[];
+  mismatchCount: number;
+  criticalMismatches: number;
+  exposure: string;
+  summary: string;
+  recommendedAction: string;
+  agentId: string;
+  agentDisplayName: string;
+  receipt: { amount: string; payee: string; issuedAt: string };
+  chain: { amount: string; payee: string; txHash: string; network: string; settledAt: string };
+  nextStep: string;
+}
+
+/** Field name -> the wording a seller would use. */
+function fieldLabel(field: string): string {
+  if (field.startsWith('line_item.')) {
+    const sku = field.split('.')[1];
+    return `Quantity · ${sku}`;
+  }
+  const map: Record<string, string> = {
+    amount: 'Amount',
+    currency: 'Currency',
+    payee: 'Paid to',
+    network: 'Network',
+    tx_hash: 'Transaction',
+  };
+  return map[field] ?? field;
+}
+
+export default function ReceiptDiff() {
+  const theme = useTheme();
+  const { getToolOutput } = useWidgetSDK();
+
+  const t = tokens(theme === 'dark');
+  const data = getToolOutput<ReceiptDiffData>();
+
+  if (!data) return <Empty t={t} message="AWAITING SETTLEMENT RECORD" />;
+
+  const tone = data.verified ? t.clear : t.danger;
+
+  return (
+    <Slip t={t} maxWidth={620}>
+      <RefStrip
+        t={t}
+        left={
+          <>
+            <strong style={{ fontWeight: 700 }}>{data.orderId}</strong>
+            <span style={{ color: t.inkSoft }}> · {data.agentId}</span>
+          </>
+        }
+        right="RECEIPT vs ON-CHAIN RECORD"
+      />
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: 16,
+          padding: '16px 16px 14px',
+        }}
+      >
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <Micro t={t}>
+            {data.verified ? 'Settlement consistent' : 'Settlement discrepancy'}
+          </Micro>
+          <div
+            style={{
+              fontFamily: SANS,
+              fontSize: 13.5,
+              lineHeight: 1.45,
+              marginTop: 6,
+              color: t.ink,
+            }}
+          >
+            {data.summary}
+          </div>
+        </div>
+        <Stamp label={data.verified ? 'Verified' : 'Mismatch'} tone={tone} t={t} />
+      </div>
+
+      {/* The diff itself: claim on the left, record on the right. */}
+      <Section
+        title="Field comparison"
+        t={t}
+        note={`${data.mismatchCount} of ${data.diffs.length} disagree`}
+      >
+        <div
+          className="gw-diff"
+          style={{
+            paddingBottom: 6,
+            borderBottom: `1px solid ${t.rule}`,
+            marginBottom: 2,
+          }}
+        >
+          <Micro t={t}>Receipt claims</Micro>
+          <div className="gw-diff-gutter" />
+          <Micro t={t}>Chain records</Micro>
+        </div>
+
+        {data.diffs.map((d) => {
+          const bad = !d.match;
+          return (
+            <div
+              key={d.field}
+              style={{
+                background: bad ? t.dangerWash : 'transparent',
+                borderBottom: `1px solid ${t.ruleSoft}`,
+                padding: '9px 0 9px 0',
+              }}
+            >
+              <div
+                style={{
+                  fontFamily: SANS,
+                  fontSize: 11,
+                  fontWeight: 600,
+                  color: bad ? t.danger : t.inkSoft,
+                  marginBottom: 4,
+                  paddingLeft: bad ? 9 : 0,
+                  borderLeft: bad ? `3px solid ${t.danger}` : 'none',
+                }}
+              >
+                {fieldLabel(d.field)}
+              </div>
+
+              <div className="gw-diff" style={{ paddingLeft: bad ? 12 : 0 }}>
+                <div style={{ minWidth: 0 }}>
+                  <span className="gw-cell-label">
+                    <Micro t={t} style={{ marginBottom: 2 }}>
+                      Receipt
+                    </Micro>
+                  </span>
+                  <div
+                    style={{
+                      fontFamily: MONO,
+                      fontSize: 13,
+                      color: bad ? t.danger : t.ink,
+                      fontWeight: bad ? 700 : 400,
+                      wordBreak: 'break-all',
+                      lineHeight: 1.4,
+                    }}
+                  >
+                    {d.receiptValue}
+                  </div>
+                </div>
+
+                <div
+                  className="gw-diff-gutter"
+                  aria-hidden="true"
+                  style={{
+                    fontFamily: MONO,
+                    fontSize: 15,
+                    fontWeight: 700,
+                    textAlign: 'center',
+                    color: bad ? t.danger : t.rule,
+                  }}
+                >
+                  {bad ? '≠' : '='}
+                </div>
+
+                <div style={{ minWidth: 0 }}>
+                  <span className="gw-cell-label">
+                    <Micro t={t} style={{ marginBottom: 2, marginTop: 6 }}>
+                      Chain {bad ? '(≠)' : ''}
+                    </Micro>
+                  </span>
+                  <div
+                    style={{
+                      fontFamily: MONO,
+                      fontSize: 13,
+                      color: bad ? t.danger : t.ink,
+                      fontWeight: bad ? 700 : 400,
+                      wordBreak: 'break-all',
+                      lineHeight: 1.4,
+                    }}
+                  >
+                    {d.chainValue}
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </Section>
+
+      {/* Accounting convention: the total sits under a double rule. */}
+      <div
+        style={{
+          margin: '0 16px',
+          borderTop: `1px solid ${t.rule}`,
+          borderBottom: `3px double ${data.verified ? t.rule : t.danger}`,
+          padding: '12px 0',
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          gap: 12,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Micro t={t}>Seller exposure</Micro>
+        <div
+          style={{
+            fontFamily: MONO,
+            fontSize: 26,
+            fontWeight: 700,
+            color: data.verified ? t.inkSoft : t.danger,
+            letterSpacing: '-0.01em',
+          }}
+        >
+          {data.exposure}
+        </div>
+      </div>
+
+      <Section title="Settlement record" t={t}>
+        <div style={{ fontFamily: MONO, fontSize: 11.5, lineHeight: 1.6, color: t.inkSoft }}>
+          <div style={{ wordBreak: 'break-all' }}>
+            <span style={{ color: t.ink }}>tx</span> {data.chain.txHash}
+          </div>
+          <div>
+            <span style={{ color: t.ink }}>network</span> {data.chain.network}
+          </div>
+          <div>
+            <span style={{ color: t.ink }}>settled</span> {data.chain.settledAt}
+          </div>
+          <div>
+            <span style={{ color: t.ink }}>receipt issued</span> {data.receipt.issuedAt}
+          </div>
+        </div>
+      </Section>
+
+      <Section title="Recommended action" t={t}>
+        <div
+          style={{
+            fontFamily: SANS,
+            fontSize: 12.5,
+            lineHeight: 1.5,
+            background: data.verified ? t.clearWash : t.dangerWash,
+            borderLeft: `3px solid ${tone}`,
+            padding: '10px 12px',
+          }}
+        >
+          {data.recommendedAction}
+        </div>
+      </Section>
+
+      <div
+        style={{
+          borderTop: `1px dashed ${t.rule}`,
+          background: t.stock,
+          padding: '10px 16px',
+          fontFamily: MONO,
+          fontSize: 11,
+          color: t.inkSoft,
+          lineHeight: 1.4,
+        }}
+      >
+        NEXT — {data.nextStep}
+      </div>
+    </Slip>
+  );
+}

--- a/sample-apps/agentic-commerce-gateway/src/widgets/app/sales-dashboard/page.tsx
+++ b/sample-apps/agentic-commerce-gateway/src/widgets/app/sales-dashboard/page.tsx
@@ -1,0 +1,384 @@
+'use client';
+
+import React from 'react';
+import { useTheme, useWidgetSDK } from '@nitrostack/widgets';
+import { Empty, Micro, MONO, RefStrip, SANS, Section, Slip, tokens } from '../_shared/ui';
+
+interface FeedRow {
+  orderId: string;
+  protocol: string;
+  agentId: string;
+  agentDisplayName: string;
+  status: string;
+  total: string;
+  totalMinor: number;
+  items: string;
+}
+
+interface DashboardData {
+  store: string;
+  counts: {
+    pending: number;
+    approved: number;
+    held: number;
+    declined: number;
+    flagged: number;
+  };
+  totalOrders: number;
+  approvedRevenue: string;
+  revenueProtected: string;
+  hitlThreshold: string;
+  feed: FeedRow[];
+  agents: Array<{ agentId: string; displayName: string; orders: number; value: string; declined: number }>;
+  flagged: Array<{ orderId: string; reason: string; exposure: string; evidence: string[] }>;
+  blocklist: Array<{ agentId: string; displayName: string; reason: string }>;
+}
+
+const GLYPH: Record<string, string> = {
+  approved: '✓',
+  held: '‖',
+  declined: '✗',
+  flagged: '⚑',
+  pending: '·',
+};
+
+/**
+ * The dashboard is the one document the server sends no `nextStep` for — it
+ * reports on the whole store rather than one order — so the footer states what
+ * currently needs a person, in order of urgency.
+ */
+function nextAction(d: DashboardData): string {
+  if (d.counts.flagged > 0) {
+    return `${d.counts.flagged} disputed order(s) open. Settle or write off each before the next payout run.`;
+  }
+  if (d.counts.held > 0) {
+    return `${d.counts.held} order(s) await seller sign-off above the ${d.hitlThreshold} threshold.`;
+  }
+  if (d.counts.pending > 0) {
+    return `${d.counts.pending} order(s) not yet screened. Run compute_trust_score on each.`;
+  }
+  return 'No orders need seller action. Screening is current.';
+}
+
+export default function SalesDashboard() {
+  const theme = useTheme();
+  const { getToolOutput } = useWidgetSDK();
+
+  const t = tokens(theme === 'dark');
+  const data = getToolOutput<DashboardData>();
+
+  if (!data) return <Empty t={t} message="AWAITING SALES LEDGER" />;
+
+  const toneFor = (status: string) =>
+    status === 'approved'
+      ? t.clear
+      : status === 'held' || status === 'pending'
+        ? t.hold
+        : t.danger;
+
+  /** An order counts as stopped if the gateway kept the money from leaving. */
+  const stopped = (s: string) => s === 'declined' || s === 'flagged';
+  /** Only approved orders have actually settled; pending and held are still open. */
+  const settled = (s: string) => s === 'approved';
+
+  return (
+    <Slip t={t} maxWidth={640}>
+      <style>{`
+        .gw-led { display: grid; grid-template-columns: 16px 1fr 88px 88px; gap: 8px; align-items: baseline; }
+        .gw-led-stopped { display: none; }
+        @media (max-width: 470px) {
+          .gw-led { grid-template-columns: 16px 1fr 92px; }
+          .gw-led-settled { display: none; }
+          .gw-led-stopped { display: block; }
+        }
+      `}</style>
+
+      <RefStrip t={t} left={<strong>{data.store}</strong>} right="AGENT SALES LEDGER" />
+
+      {/* Disposition strip — what the gateway did with the day's orders. */}
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 0,
+          borderBottom: `1px solid ${t.rule}`,
+        }}
+      >
+        {(
+          [
+            ['approved', data.counts.approved, t.clear],
+            ['held', data.counts.held, t.hold],
+            ['declined', data.counts.declined, t.danger],
+            ['flagged', data.counts.flagged, t.danger],
+            ['pending', data.counts.pending, t.inkSoft],
+          ] as Array<[string, number, string]>
+        ).map(([label, count, tone]) => (
+          <div
+            key={label}
+            style={{
+              flex: '1 1 88px',
+              padding: '11px 10px',
+              borderRight: `1px solid ${t.ruleSoft}`,
+            }}
+          >
+            <div style={{ fontFamily: MONO, fontSize: 21, fontWeight: 700, color: tone }}>
+              {count}
+            </div>
+            <Micro t={t} style={{ marginTop: 2 }}>
+              {label}
+            </Micro>
+          </div>
+        ))}
+      </div>
+
+      {/* The ledger tape: settled on one side, stopped on the other. */}
+      <Section title="Order ledger" t={t} note={`${data.totalOrders} agent order(s)`}>
+        <div
+          className="gw-led"
+          style={{ paddingBottom: 6, borderBottom: `1px solid ${t.rule}`, marginBottom: 4 }}
+        >
+          <div />
+          <Micro t={t}>Order</Micro>
+          <Micro t={t} style={{ textAlign: 'right' }}>
+            <span className="gw-led-settled">Settled</span>
+            <span className="gw-led-stopped">Amount</span>
+          </Micro>
+          <Micro t={t} style={{ textAlign: 'right' }} >
+            <span className="gw-led-settled">Stopped</span>
+          </Micro>
+        </div>
+
+        {data.feed.map((row) => {
+          const tone = toneFor(row.status);
+          const isStopped = stopped(row.status);
+          const isSettled = settled(row.status);
+          return (
+            <div
+              key={row.orderId}
+              className="gw-led"
+              style={{ padding: '7px 0', borderBottom: `1px solid ${t.ruleSoft}` }}
+            >
+              <div
+                aria-hidden="true"
+                style={{ fontFamily: MONO, fontSize: 12, color: tone, fontWeight: 700 }}
+              >
+                {GLYPH[row.status] ?? '·'}
+              </div>
+
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontFamily: MONO, fontSize: 12.5 }}>
+                  {row.orderId}
+                  <span style={{ color: t.inkSoft, fontSize: 10.5, letterSpacing: '0.06em' }}>
+                    {' '}
+                    {row.protocol.toUpperCase()}
+                  </span>
+                </div>
+                <div
+                  style={{
+                    fontFamily: SANS,
+                    fontSize: 11.5,
+                    color: t.inkSoft,
+                    lineHeight: 1.35,
+                    overflowWrap: 'anywhere',
+                  }}
+                >
+                  {row.agentDisplayName} · {row.items}
+                </div>
+              </div>
+
+              {/* Wide layout: two money columns. Narrow: one, colour-coded. */}
+              <div
+                style={{
+                  fontFamily: MONO,
+                  fontSize: 12.5,
+                  textAlign: 'right',
+                  color: isSettled ? t.ink : t.inkSoft,
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                <span className="gw-led-settled">{isSettled ? row.total : '—'}</span>
+                <span className="gw-led-stopped" style={{ color: tone }}>
+                  {row.total}
+                </span>
+              </div>
+
+              <div
+                className="gw-led-settled"
+                style={{
+                  fontFamily: MONO,
+                  fontSize: 12.5,
+                  textAlign: 'right',
+                  color: isStopped ? t.danger : t.ruleSoft,
+                  whiteSpace: 'nowrap',
+                  fontWeight: isStopped ? 700 : 400,
+                }}
+              >
+                {isStopped ? row.total : '—'}
+              </div>
+            </div>
+          );
+        })}
+
+        {/* Totals sit under a double rule, as on a paper ledger. */}
+        <div
+          style={{
+            marginTop: 10,
+            borderTop: `1px solid ${t.rule}`,
+            borderBottom: `3px double ${t.rule}`,
+            padding: '12px 0',
+            display: 'flex',
+            gap: 16,
+            flexWrap: 'wrap',
+            justifyContent: 'space-between',
+          }}
+        >
+          <div>
+            <Micro t={t}>Revenue settled</Micro>
+            <div style={{ fontFamily: MONO, fontSize: 20, fontWeight: 700, marginTop: 3 }}>
+              {data.approvedRevenue}
+            </div>
+          </div>
+          <div style={{ textAlign: 'right' }}>
+            <Micro t={t}>Revenue protected</Micro>
+            <div
+              style={{
+                fontFamily: MONO,
+                fontSize: 28,
+                fontWeight: 700,
+                color: t.clear,
+                marginTop: 3,
+                letterSpacing: '-0.01em',
+              }}
+            >
+              {data.revenueProtected}
+            </div>
+          </div>
+        </div>
+        <div
+          style={{
+            fontFamily: SANS,
+            fontSize: 11,
+            color: t.inkSoft,
+            marginTop: 7,
+            lineHeight: 1.45,
+          }}
+        >
+          Protected = value of orders declined at screening, plus exposure uncovered on settled
+          orders that were flagged. Orders above {data.hitlThreshold} always go to a human.
+        </div>
+      </Section>
+
+      {data.flagged.length > 0 && (
+        <Section title="Disputed orders" t={t} note={`${data.flagged.length}`}>
+          {data.flagged.map((f) => (
+            <div
+              key={f.orderId}
+              style={{
+                background: t.dangerWash,
+                borderLeft: `3px solid ${t.danger}`,
+                padding: '9px 11px',
+                marginBottom: 8,
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  gap: 10,
+                  flexWrap: 'wrap',
+                }}
+              >
+                <span style={{ fontFamily: MONO, fontSize: 12.5, fontWeight: 700 }}>
+                  {f.orderId}
+                </span>
+                <span style={{ fontFamily: MONO, fontSize: 12.5, color: t.danger }}>
+                  {f.exposure}
+                </span>
+              </div>
+              <div style={{ fontFamily: SANS, fontSize: 12, marginTop: 3, lineHeight: 1.4 }}>
+                {f.reason}
+              </div>
+              {f.evidence.map((e, i) => (
+                <div
+                  key={i}
+                  style={{ fontFamily: MONO, fontSize: 11, color: t.inkSoft, marginTop: 2 }}
+                >
+                  {e}
+                </div>
+              ))}
+            </div>
+          ))}
+        </Section>
+      )}
+
+      <Section title="Buying agents" t={t} note={`${data.agents.length}`}>
+        {data.agents.map((a) => (
+          <div
+            key={a.agentId}
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              gap: 10,
+              padding: '6px 0',
+              borderBottom: `1px solid ${t.ruleSoft}`,
+              flexWrap: 'wrap',
+            }}
+          >
+            <span style={{ minWidth: 0 }}>
+              <span style={{ fontFamily: SANS, fontSize: 12.5, fontWeight: 600 }}>
+                {a.displayName}
+              </span>
+              <span style={{ fontFamily: MONO, fontSize: 11, color: t.inkSoft }}>
+                {' '}
+                {a.agentId}
+              </span>
+            </span>
+            <span style={{ fontFamily: MONO, fontSize: 12, whiteSpace: 'nowrap' }}>
+              {a.orders} order(s) · {a.value}
+              {a.declined > 0 && (
+                <span style={{ color: t.danger }}> · {a.declined} stopped</span>
+              )}
+            </span>
+          </div>
+        ))}
+      </Section>
+
+      <Section title="Blocklist" t={t} note={data.blocklist.length ? `${data.blocklist.length}` : 'empty'}>
+        {data.blocklist.length === 0 ? (
+          <div style={{ fontFamily: SANS, fontSize: 12, color: t.inkSoft }}>
+            No agents banned yet. Blocklist an agent to decline its future orders at screening.
+          </div>
+        ) : (
+          data.blocklist.map((b) => (
+            <div
+              key={b.agentId}
+              style={{ padding: '6px 0', borderBottom: `1px solid ${t.ruleSoft}` }}
+            >
+              <div style={{ fontFamily: MONO, fontSize: 12.5, color: t.danger, fontWeight: 700 }}>
+                {b.agentId}
+                <span style={{ color: t.inkSoft, fontWeight: 400 }}> · {b.displayName}</span>
+              </div>
+              <div style={{ fontFamily: SANS, fontSize: 11.5, color: t.inkSoft, marginTop: 2 }}>
+                {b.reason}
+              </div>
+            </div>
+          ))
+        )}
+      </Section>
+
+      <div
+        style={{
+          borderTop: `1px dashed ${t.rule}`,
+          background: t.stock,
+          padding: '10px 16px',
+          fontFamily: MONO,
+          fontSize: 11,
+          color: t.inkSoft,
+          lineHeight: 1.4,
+        }}
+      >
+        NEXT — {nextAction(data)}
+      </div>
+    </Slip>
+  );
+}

--- a/sample-apps/agentic-commerce-gateway/src/widgets/next-env.d.ts
+++ b/sample-apps/agentic-commerce-gateway/src/widgets/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/sample-apps/agentic-commerce-gateway/src/widgets/next.config.js
+++ b/sample-apps/agentic-commerce-gateway/src/widgets/next.config.js
@@ -1,0 +1,45 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  transpilePackages: ['nitrostack'],
+  
+  // Static export for production builds
+  ...(process.env.NODE_ENV === 'production' && {
+    output: 'export',
+    distDir: 'out',
+    images: {
+      unoptimized: true,
+    },
+  }),
+  
+  // Development optimizations to prevent cache corruption
+  ...(process.env.NODE_ENV === 'development' && {
+    // Use memory cache instead of filesystem cache in dev to avoid stale chunks
+    webpack: (config, { isServer }) => {
+      // Disable persistent caching in development to prevent chunk reference errors
+      if (config.cache && config.cache.type === 'filesystem') {
+        config.cache = {
+          type: 'memory',
+        };
+      }
+      
+      // Improve cache busting for new files
+      if (!isServer) {
+        config.cache = false; // Disable cache completely on client in dev
+      }
+      
+      return config;
+    },
+    
+    // Disable build activity indicator which can cause issues
+    devIndicators: {
+      buildActivity: false,
+      buildActivityPosition: 'bottom-right',
+    },
+    
+    // Faster dev server
+    compress: false,
+  }),
+};
+
+export default nextConfig;

--- a/sample-apps/agentic-commerce-gateway/src/widgets/package-lock.json
+++ b/sample-apps/agentic-commerce-gateway/src/widgets/package-lock.json
@@ -1,0 +1,2515 @@
+{
+  "name": "calculator-widgets",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "calculator-widgets",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0",
+        "@nitrostack/core": "^1.0.14",
+        "@nitrostack/widgets": "^1.0.8",
+        "next": "^14.2.5",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20",
+        "@types/react": "^18",
+        "@types/react-dom": "^18",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.5.tgz",
+      "integrity": "sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg==",
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nitrostack/core": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@nitrostack/core/-/core-1.0.14.tgz",
+      "integrity": "sha512-FfG5rOxZwAztHiwPqRPj3xjgoiiPa1A06y2BBqGRlNAkK8R5izImD/f3zhvo1OrGKtoDC/qEw2iykKK24UR/FA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.4",
+        "bcryptjs": "^2.4.3",
+        "cors": "^2.8.5",
+        "dotenv": "^17.2.3",
+        "express": "^4.21.2",
+        "jose": "^6.1.0",
+        "jsonwebtoken": "^9.0.2",
+        "reflect-metadata": "^0.2.1",
+        "uuid": "^11.0.5",
+        "winston": "^3.17.0",
+        "ws": "^8.18.3",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/@nitrostack/core/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/@nitrostack/core/node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/@nitrostack/core/node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nitrostack/core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@nitrostack/widgets": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@nitrostack/widgets/-/widgets-1.0.8.tgz",
+      "integrity": "sha512-/E8MAgOp/rYOyRNydzamxsJAhsBp7Q9A8LYB7m+kqy+o0ubLBsU7rb1EIaIg8JX8KPdxfchxqwo0HxzUWRsYDg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@modelcontextprotocol/ext-apps": ">=0.1.0",
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.33",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
+      "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.5.tgz",
+      "integrity": "sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.35",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/sample-apps/agentic-commerce-gateway/src/widgets/package.json
+++ b/sample-apps/agentic-commerce-gateway/src/widgets/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "calculator-widgets",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3001 --port 3001",
+    "build": "next build",
+    "start": "next start -p 3001"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/ext-apps": ">=0.1.0",
+    "@nitrostack/core": "^1.0.14",
+    "@nitrostack/widgets": "^1.0.8",
+    "next": "^14.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "typescript": "^5"
+  }
+}

--- a/sample-apps/agentic-commerce-gateway/src/widgets/tsconfig.json
+++ b/sample-apps/agentic-commerce-gateway/src/widgets/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}
+

--- a/sample-apps/agentic-commerce-gateway/src/widgets/widget-manifest.json
+++ b/sample-apps/agentic-commerce-gateway/src/widgets/widget-manifest.json
@@ -1,0 +1,909 @@
+{
+  "version": "1.0.0",
+  "widgets": [
+    {
+      "uri": "/order-review",
+      "name": "Order Review Card",
+      "description": "Agent order summary with trust score, weighted risk signals, conflicting evidence and the gateway verdict",
+      "examples": [
+        {
+          "name": "Declined — spoofed signature",
+          "description": "Day-old agent orders 40 headsets with a forged signature",
+          "data": {
+            "orderId": "ord_1002",
+            "agentId": "agt_ghost_nyx",
+            "agentDisplayName": "Nyx Buyer",
+            "score": 10,
+            "band": "high-risk",
+            "verdict": "decline",
+            "signals": [
+              {
+                "id": "signature",
+                "label": "Signature validity",
+                "points": 0,
+                "max": 35,
+                "status": "fail",
+                "detail": "Payload signature does not verify — identity is not proven"
+              },
+              {
+                "id": "reputation",
+                "label": "Registry reputation",
+                "points": 3,
+                "max": 25,
+                "status": "fail",
+                "detail": "Reputation 12/100 over 3 lifetime orders"
+              },
+              {
+                "id": "order_size",
+                "label": "Order size vs product norms",
+                "points": 0,
+                "max": 20,
+                "status": "fail",
+                "detail": "40× NG-HS-01 is 10.0× the normal ceiling of 4 for that SKU"
+              },
+              {
+                "id": "velocity",
+                "label": "Order velocity",
+                "points": 7,
+                "max": 12,
+                "status": "warn",
+                "detail": "9 order(s) placed in the last hour"
+              },
+              {
+                "id": "account_age",
+                "label": "Account age",
+                "points": 0,
+                "max": 8,
+                "status": "fail",
+                "detail": "Agent account is 1 day(s) old"
+              }
+            ],
+            "failedSignals": 4,
+            "conflicts": [],
+            "reasoning": [
+              "Signature verification failed; identity is unproven, so the sale cannot settle safely."
+            ],
+            "hitlRequired": true,
+            "orderTotalMinor": 19996000,
+            "currency": "INR",
+            "orderTotal": "₹1,99,960.00",
+            "hitlThreshold": "₹40,000.00",
+            "status": "declined",
+            "protocol": "x402",
+            "items": [
+              {
+                "sku": "NG-HS-01",
+                "name": "NovaSound H500 Headset",
+                "qty": 40,
+                "unitPriceMinor": 499900,
+                "lineTotalMinor": 19996000,
+                "unitPrice": "₹4,999.00",
+                "lineTotal": "₹1,99,960.00"
+              }
+            ],
+            "screening": {
+              "orderId": "ord_1002",
+              "agentId": "agt_ghost_nyx",
+              "agentDisplayName": "Nyx Buyer",
+              "registered": true,
+              "signatureValid": false,
+              "blocklisted": false,
+              "checks": [
+                {
+                  "id": "registry_lookup",
+                  "label": "Agent registry lookup",
+                  "passed": true,
+                  "detail": "Nyx Buyer (unverified) found in registry, reputation 12/100"
+                },
+                {
+                  "id": "signature_valid",
+                  "label": "Payload signature",
+                  "passed": false,
+                  "detail": "Signature b3f5c1d9e7a20486… does not verify against agt_ghost_nyx's registry key — spoofed or replayed"
+                },
+                {
+                  "id": "not_blocklisted",
+                  "label": "Blocklist status",
+                  "passed": true,
+                  "detail": "Agent is not blocklisted"
+                },
+                {
+                  "id": "dispute_history",
+                  "label": "Dispute history",
+                  "passed": true,
+                  "detail": "2 prior dispute(s) across 3 lifetime order(s)"
+                },
+                {
+                  "id": "amount_declaration",
+                  "label": "Declared amount vs catalog",
+                  "passed": true,
+                  "detail": "Declared ₹1,99,960.00 matches catalog pricing"
+                }
+              ],
+              "failedChecks": 1,
+              "summary": "1 of 5 identity checks failed for Nyx Buyer"
+            },
+            "evidencePath": [
+              "protocol=x402 → settlement-bearing payload",
+              "catalog repriced 1 line item(s) → 19996000 minor units",
+              "declared amount matches catalog total",
+              "payee 0x9A4fD21bC7e05a83F16D4e92B0c7A15d38E6b204 on base-sepolia"
+            ],
+            "nextStep": "Declined. Consider blocklist_agent for \"agt_ghost_nyx\"."
+          }
+        },
+        {
+          "name": "Approved — clean sale",
+          "description": "Established shopper agent buys one keyboard",
+          "data": {
+            "orderId": "ord_1001",
+            "agentId": "agt_shopper_atlas",
+            "agentDisplayName": "Atlas Shopping Assistant",
+            "score": 98,
+            "band": "low-risk",
+            "verdict": "approve",
+            "signals": [
+              {
+                "id": "signature",
+                "label": "Signature validity",
+                "points": 35,
+                "max": 35,
+                "status": "pass",
+                "detail": "Payload signature verifies against the registry key"
+              },
+              {
+                "id": "reputation",
+                "label": "Registry reputation",
+                "points": 23,
+                "max": 25,
+                "status": "pass",
+                "detail": "Reputation 92/100 over 341 lifetime orders"
+              },
+              {
+                "id": "order_size",
+                "label": "Order size vs product norms",
+                "points": 20,
+                "max": 20,
+                "status": "pass",
+                "detail": "1× NG-KB-01 is within normal purchase size"
+              },
+              {
+                "id": "velocity",
+                "label": "Order velocity",
+                "points": 12,
+                "max": 12,
+                "status": "pass",
+                "detail": "2 order(s) placed in the last hour"
+              },
+              {
+                "id": "account_age",
+                "label": "Account age",
+                "points": 8,
+                "max": 8,
+                "status": "pass",
+                "detail": "Agent account is 420 day(s) old"
+              }
+            ],
+            "failedSignals": 0,
+            "conflicts": [],
+            "reasoning": [
+              "Trust score 98/100 clears the approval bar of 70."
+            ],
+            "hitlRequired": false,
+            "orderTotalMinor": 849900,
+            "currency": "INR",
+            "orderTotal": "₹8,499.00",
+            "hitlThreshold": "₹40,000.00",
+            "status": "approved",
+            "protocol": "acp",
+            "items": [
+              {
+                "sku": "NG-KB-01",
+                "name": "Nova Mechanical Keyboard TKL",
+                "qty": 1,
+                "unitPriceMinor": 849900,
+                "lineTotalMinor": 849900,
+                "unitPrice": "₹8,499.00",
+                "lineTotal": "₹8,499.00"
+              }
+            ],
+            "screening": {
+              "orderId": "ord_1001",
+              "agentId": "agt_shopper_atlas",
+              "agentDisplayName": "Atlas Shopping Assistant",
+              "registered": true,
+              "signatureValid": true,
+              "blocklisted": false,
+              "checks": [
+                {
+                  "id": "registry_lookup",
+                  "label": "Agent registry lookup",
+                  "passed": true,
+                  "detail": "Atlas Shopping Assistant (Atlas AI) found in registry, reputation 92/100"
+                },
+                {
+                  "id": "signature_valid",
+                  "label": "Payload signature",
+                  "passed": true,
+                  "detail": "HMAC over the canonical ACP payload matches the registry key"
+                },
+                {
+                  "id": "not_blocklisted",
+                  "label": "Blocklist status",
+                  "passed": true,
+                  "detail": "Agent is not blocklisted"
+                },
+                {
+                  "id": "dispute_history",
+                  "label": "Dispute history",
+                  "passed": true,
+                  "detail": "0 prior dispute(s) across 341 lifetime order(s)"
+                }
+              ],
+              "failedChecks": 0,
+              "summary": "All 4 identity checks passed for Atlas Shopping Assistant"
+            },
+            "evidencePath": [
+              "protocol=acp → cart-shaped payload, no settlement block",
+              "catalog priced 1 cart line(s) → 849900 minor units",
+              "buyer intent \"purchase\""
+            ],
+            "nextStep": "Approved. After settlement, call verify_receipt for \"ord_1001\"."
+          }
+        },
+        {
+          "name": "Held — conflicting signals",
+          "description": "Reputable agent places a bulk order above the human-review threshold",
+          "data": {
+            "orderId": "ord_1004",
+            "agentId": "agt_bulk_orion",
+            "agentDisplayName": "Orion Procurement Bot",
+            "score": 80,
+            "band": "low-risk",
+            "verdict": "hold",
+            "signals": [
+              {
+                "id": "signature",
+                "label": "Signature validity",
+                "points": 35,
+                "max": 35,
+                "status": "pass",
+                "detail": "Payload signature verifies against the registry key"
+              },
+              {
+                "id": "reputation",
+                "label": "Registry reputation",
+                "points": 19,
+                "max": 25,
+                "status": "pass",
+                "detail": "Reputation 74/100 over 96 lifetime orders"
+              },
+              {
+                "id": "order_size",
+                "label": "Order size vs product norms",
+                "points": 6,
+                "max": 20,
+                "status": "warn",
+                "detail": "12× NG-DK-01 is 3.0× the normal ceiling of 4 for that SKU"
+              },
+              {
+                "id": "velocity",
+                "label": "Order velocity",
+                "points": 12,
+                "max": 12,
+                "status": "pass",
+                "detail": "4 order(s) placed in the last hour"
+              },
+              {
+                "id": "account_age",
+                "label": "Account age",
+                "points": 8,
+                "max": 8,
+                "status": "pass",
+                "detail": "Agent account is 184 day(s) old"
+              }
+            ],
+            "failedSignals": 0,
+            "conflicts": [
+              "Established agent (74/100) placing an unusually large order — plausible business procurement, but outside its own historical pattern."
+            ],
+            "reasoning": [
+              "Trust score 80/100 clears the approval bar of 70.",
+              "Order total ₹65,988.00 exceeds the ₹40,000.00 human-review threshold — held for the seller even though screening passed.",
+              "Conflict: Established agent (74/100) placing an unusually large order — plausible business procurement, but outside its own historical pattern."
+            ],
+            "hitlRequired": true,
+            "orderTotalMinor": 6598800,
+            "currency": "INR",
+            "orderTotal": "₹65,988.00",
+            "hitlThreshold": "₹40,000.00",
+            "status": "held",
+            "protocol": "acp",
+            "items": [
+              {
+                "sku": "NG-DK-01",
+                "name": "NovaDock USB-C Hub",
+                "qty": 12,
+                "unitPriceMinor": 549900,
+                "lineTotalMinor": 6598800,
+                "unitPrice": "₹5,499.00",
+                "lineTotal": "₹65,988.00"
+              }
+            ],
+            "screening": {
+              "orderId": "ord_1004",
+              "agentId": "agt_bulk_orion",
+              "agentDisplayName": "Orion Procurement Bot",
+              "registered": true,
+              "signatureValid": true,
+              "blocklisted": false,
+              "checks": [
+                {
+                  "id": "registry_lookup",
+                  "label": "Agent registry lookup",
+                  "passed": true,
+                  "detail": "Orion Procurement Bot (Orion Supply Co.) found in registry, reputation 74/100"
+                },
+                {
+                  "id": "signature_valid",
+                  "label": "Payload signature",
+                  "passed": true,
+                  "detail": "HMAC over the canonical ACP payload matches the registry key"
+                },
+                {
+                  "id": "not_blocklisted",
+                  "label": "Blocklist status",
+                  "passed": true,
+                  "detail": "Agent is not blocklisted"
+                },
+                {
+                  "id": "dispute_history",
+                  "label": "Dispute history",
+                  "passed": true,
+                  "detail": "2 prior dispute(s) across 96 lifetime order(s)"
+                }
+              ],
+              "failedChecks": 0,
+              "summary": "All 4 identity checks passed for Orion Procurement Bot"
+            },
+            "evidencePath": [
+              "protocol=acp → cart-shaped payload, no settlement block",
+              "catalog priced 1 cart line(s) → 6598800 minor units",
+              "buyer intent \"bulk_purchase\""
+            ],
+            "nextStep": "Held for seller review — a human decides before this sale settles."
+          }
+        }
+      ],
+      "tags": [
+        "fraud",
+        "screening",
+        "trust-score",
+        "agent-commerce"
+      ]
+    },
+    {
+      "uri": "/receipt-diff",
+      "name": "Receipt Diff View",
+      "description": "Field-by-field comparison of a sales receipt against the on-chain settlement record, with seller exposure",
+      "examples": [
+        {
+          "name": "Tampered receipt",
+          "description": "Receipt says one unit at 4,999; the chain says ten at 49,990",
+          "data": {
+            "orderId": "ord_1003",
+            "verified": false,
+            "diffs": [
+              {
+                "field": "amount",
+                "receiptValue": "₹4,999.00",
+                "chainValue": "₹49,990.00",
+                "match": false,
+                "severity": "critical"
+              },
+              {
+                "field": "currency",
+                "receiptValue": "INR",
+                "chainValue": "INR",
+                "match": true,
+                "severity": "ok"
+              },
+              {
+                "field": "payee",
+                "receiptValue": "0x9A4fD21bC7e05a83F16D4e92B0c7A15d38E6b204",
+                "chainValue": "0x9A4fD21bC7e05a83F16D4e92B0c7A15d38E6b204",
+                "match": true,
+                "severity": "ok"
+              },
+              {
+                "field": "line_item.NG-HS-01.qty",
+                "receiptValue": "1",
+                "chainValue": "10",
+                "match": false,
+                "severity": "critical"
+              },
+              {
+                "field": "network",
+                "receiptValue": "(not asserted by receipt)",
+                "chainValue": "base-sepolia",
+                "match": true,
+                "severity": "ok"
+              },
+              {
+                "field": "tx_hash",
+                "receiptValue": "(not asserted by receipt)",
+                "chainValue": "0x8d13f60a2c94e7b5013da8f27c46b9e0518a3d7f92c6b04e15a8d3f70b29c641",
+                "match": true,
+                "severity": "ok"
+              }
+            ],
+            "mismatchCount": 2,
+            "criticalMismatches": 2,
+            "exposureMinor": 4499100,
+            "summary": "2 field(s) disagree between the receipt and the chain: amount, quantity for NG-HS-01. Seller exposure ₹44,991.00.",
+            "recommendedAction": "Flag ord_1003 as disputed and blocklist agt_relay_lyra pending investigation.",
+            "exposure": "₹44,991.00",
+            "agentId": "agt_relay_lyra",
+            "agentDisplayName": "Lyra Checkout Relay",
+            "receipt": {
+              "amount": "₹4,999.00",
+              "payee": "0x9A4fD21bC7e05a83F16D4e92B0c7A15d38E6b204",
+              "items": [
+                {
+                  "sku": "NG-HS-01",
+                  "qty": 1
+                }
+              ],
+              "issuedAt": "2026-07-31T10:02:47.000Z"
+            },
+            "chain": {
+              "amount": "₹49,990.00",
+              "payee": "0x9A4fD21bC7e05a83F16D4e92B0c7A15d38E6b204",
+              "items": [
+                {
+                  "sku": "NG-HS-01",
+                  "qty": 10
+                }
+              ],
+              "txHash": "0x8d13f60a2c94e7b5013da8f27c46b9e0518a3d7f92c6b04e15a8d3f70b29c641",
+              "network": "base-sepolia",
+              "settledAt": "2026-07-31T10:02:58.000Z"
+            },
+            "nextStep": "Call flag_order for \"ord_1003\", then blocklist_agent for \"agt_relay_lyra\"."
+          }
+        },
+        {
+          "name": "Redirected payment",
+          "description": "Correct amount settled to the wrong payee",
+          "data": {
+            "orderId": "ord_1008",
+            "verified": false,
+            "diffs": [
+              {
+                "field": "amount",
+                "receiptValue": "₹15,794.00",
+                "chainValue": "₹15,794.00",
+                "match": true,
+                "severity": "ok"
+              },
+              {
+                "field": "currency",
+                "receiptValue": "INR",
+                "chainValue": "INR",
+                "match": true,
+                "severity": "ok"
+              },
+              {
+                "field": "payee",
+                "receiptValue": "0x9A4fD21bC7e05a83F16D4e92B0c7A15d38E6b204",
+                "chainValue": "0x7cE0b41a92D5f36A08c1e4B7d590F62a3C84e015",
+                "match": false,
+                "severity": "critical"
+              },
+              {
+                "field": "line_item.NG-MS-01.qty",
+                "receiptValue": "6",
+                "chainValue": "6",
+                "match": true,
+                "severity": "ok"
+              },
+              {
+                "field": "network",
+                "receiptValue": "(not asserted by receipt)",
+                "chainValue": "base-sepolia",
+                "match": true,
+                "severity": "ok"
+              },
+              {
+                "field": "tx_hash",
+                "receiptValue": "(not asserted by receipt)",
+                "chainValue": "0x6b28e0c74f931da05c83b6e2170f4a9d35c81e07b24af960d1c53e8a7f240b13",
+                "match": true,
+                "severity": "ok"
+              }
+            ],
+            "mismatchCount": 1,
+            "criticalMismatches": 1,
+            "exposureMinor": 1579400,
+            "summary": "1 field(s) disagree between the receipt and the chain: payee. Seller exposure ₹15,794.00.",
+            "recommendedAction": "Flag ord_1008 as disputed and blocklist agt_probe_zeta pending investigation.",
+            "exposure": "₹15,794.00",
+            "agentId": "agt_probe_zeta",
+            "agentDisplayName": "Zeta Comparison Agent",
+            "receipt": {
+              "amount": "₹15,794.00",
+              "payee": "0x9A4fD21bC7e05a83F16D4e92B0c7A15d38E6b204",
+              "items": [
+                {
+                  "sku": "NG-MS-01",
+                  "qty": 6
+                }
+              ],
+              "issuedAt": "2026-07-31T11:08:33.000Z"
+            },
+            "chain": {
+              "amount": "₹15,794.00",
+              "payee": "0x7cE0b41a92D5f36A08c1e4B7d590F62a3C84e015",
+              "items": [
+                {
+                  "sku": "NG-MS-01",
+                  "qty": 6
+                }
+              ],
+              "txHash": "0x6b28e0c74f931da05c83b6e2170f4a9d35c81e07b24af960d1c53e8a7f240b13",
+              "network": "base-sepolia",
+              "settledAt": "2026-07-31T11:08:41.000Z"
+            },
+            "nextStep": "Call flag_order for \"ord_1008\", then blocklist_agent for \"agt_probe_zeta\"."
+          }
+        },
+        {
+          "name": "Clean settlement",
+          "description": "Receipt and chain agree on every field",
+          "data": {
+            "orderId": "ord_1001",
+            "verified": true,
+            "diffs": [
+              {
+                "field": "amount",
+                "receiptValue": "₹8,499.00",
+                "chainValue": "₹8,499.00",
+                "match": true,
+                "severity": "ok"
+              },
+              {
+                "field": "currency",
+                "receiptValue": "INR",
+                "chainValue": "INR",
+                "match": true,
+                "severity": "ok"
+              },
+              {
+                "field": "payee",
+                "receiptValue": "0x9A4fD21bC7e05a83F16D4e92B0c7A15d38E6b204",
+                "chainValue": "0x9A4fD21bC7e05a83F16D4e92B0c7A15d38E6b204",
+                "match": true,
+                "severity": "ok"
+              },
+              {
+                "field": "line_item.NG-KB-01.qty",
+                "receiptValue": "1",
+                "chainValue": "1",
+                "match": true,
+                "severity": "ok"
+              },
+              {
+                "field": "network",
+                "receiptValue": "(not asserted by receipt)",
+                "chainValue": "base-sepolia",
+                "match": true,
+                "severity": "ok"
+              },
+              {
+                "field": "tx_hash",
+                "receiptValue": "(not asserted by receipt)",
+                "chainValue": "0x4a91c7e35b08d2f6a17e94c0b53d8e26f10a7c495b3d80e6f2a91c47b085d3e2",
+                "match": true,
+                "severity": "ok"
+              }
+            ],
+            "mismatchCount": 0,
+            "criticalMismatches": 0,
+            "exposureMinor": 0,
+            "summary": "Receipt for ord_1001 matches the on-chain record on every compared field.",
+            "recommendedAction": "No action required — settlement is consistent.",
+            "exposure": "₹0.00",
+            "agentId": "agt_shopper_atlas",
+            "agentDisplayName": "Atlas Shopping Assistant",
+            "receipt": {
+              "amount": "₹8,499.00",
+              "payee": "0x9A4fD21bC7e05a83F16D4e92B0c7A15d38E6b204",
+              "items": [
+                {
+                  "sku": "NG-KB-01",
+                  "qty": 1
+                }
+              ],
+              "issuedAt": "2026-07-31T09:14:22.000Z"
+            },
+            "chain": {
+              "amount": "₹8,499.00",
+              "payee": "0x9A4fD21bC7e05a83F16D4e92B0c7A15d38E6b204",
+              "items": [
+                {
+                  "sku": "NG-KB-01",
+                  "qty": 1
+                }
+              ],
+              "txHash": "0x4a91c7e35b08d2f6a17e94c0b53d8e26f10a7c495b3d80e6f2a91c47b085d3e2",
+              "network": "base-sepolia",
+              "settledAt": "2026-07-31T09:14:31.000Z"
+            },
+            "nextStep": "Settlement is consistent — no action needed."
+          }
+        }
+      ],
+      "tags": [
+        "verification",
+        "settlement",
+        "diff",
+        "on-chain"
+      ]
+    },
+    {
+      "uri": "/sales-dashboard",
+      "name": "Sales Dashboard",
+      "description": "Agent order ledger with settled vs stopped revenue, disputed orders, buying agents and the store blocklist",
+      "examples": [
+        {
+          "name": "After a fraud sweep",
+          "description": "Two agents blocklisted, one order disputed, revenue protected counted up",
+          "data": {
+            "store": "NovaGear",
+            "currency": "INR",
+            "counts": {
+              "pending": 5,
+              "approved": 1,
+              "held": 1,
+              "declined": 1,
+              "flagged": 1
+            },
+            "totalOrders": 9,
+            "approvedRevenueMinor": 849900,
+            "approvedRevenue": "₹8,499.00",
+            "revenueProtectedMinor": 24495100,
+            "revenueProtected": "₹2,44,951.00",
+            "hitlThreshold": "₹40,000.00",
+            "feed": [
+              {
+                "orderId": "ord_1001",
+                "protocol": "acp",
+                "agentId": "agt_shopper_atlas",
+                "agentDisplayName": "Atlas Shopping Assistant",
+                "status": "approved",
+                "total": "₹8,499.00",
+                "totalMinor": 849900,
+                "items": "1× NG-KB-01"
+              },
+              {
+                "orderId": "ord_1002",
+                "protocol": "x402",
+                "agentId": "agt_ghost_nyx",
+                "agentDisplayName": "Nyx Buyer",
+                "status": "declined",
+                "total": "₹1,99,960.00",
+                "totalMinor": 19996000,
+                "items": "40× NG-HS-01"
+              },
+              {
+                "orderId": "ord_1003",
+                "protocol": "x402",
+                "agentId": "agt_relay_lyra",
+                "agentDisplayName": "Lyra Checkout Relay",
+                "status": "flagged",
+                "total": "₹4,999.00",
+                "totalMinor": 499900,
+                "items": "1× NG-HS-01"
+              },
+              {
+                "orderId": "ord_1004",
+                "protocol": "acp",
+                "agentId": "agt_bulk_orion",
+                "agentDisplayName": "Orion Procurement Bot",
+                "status": "held",
+                "total": "₹65,988.00",
+                "totalMinor": 6598800,
+                "items": "12× NG-DK-01"
+              },
+              {
+                "orderId": "ord_1005",
+                "protocol": "x402",
+                "agentId": "agt_swarm_kilo",
+                "agentDisplayName": "Kilo Rapid Buyer",
+                "status": "pending",
+                "total": "₹10,497.00",
+                "totalMinor": 1049700,
+                "items": "3× NG-WC-01"
+              },
+              {
+                "orderId": "ord_1006",
+                "protocol": "acp",
+                "agentId": "agt_shadow_umbra",
+                "agentDisplayName": "Umbra Checkout Agent",
+                "status": "pending",
+                "total": "₹12,598.00",
+                "totalMinor": 1259800,
+                "items": "2× NG-KB-02"
+              },
+              {
+                "orderId": "ord_1007",
+                "protocol": "acp",
+                "agentId": "agt_concierge_vega",
+                "agentDisplayName": "Vega Personal Concierge",
+                "status": "pending",
+                "total": "₹15,798.00",
+                "totalMinor": 1579800,
+                "items": "1× NG-HS-02, 1× NG-MS-01"
+              },
+              {
+                "orderId": "ord_1008",
+                "protocol": "x402",
+                "agentId": "agt_probe_zeta",
+                "agentDisplayName": "Zeta Comparison Agent",
+                "status": "pending",
+                "total": "₹15,794.00",
+                "totalMinor": 1579400,
+                "items": "6× NG-MS-01"
+              },
+              {
+                "orderId": "ord_1009",
+                "protocol": "acp",
+                "agentId": "agt_shopper_atlas",
+                "agentDisplayName": "Atlas Shopping Assistant",
+                "status": "pending",
+                "total": "₹64,995.00",
+                "totalMinor": 6499500,
+                "items": "5× NG-HS-02"
+              }
+            ],
+            "agents": [
+              {
+                "agentId": "agt_ghost_nyx",
+                "displayName": "Nyx Buyer",
+                "orders": 1,
+                "valueMinor": 19996000,
+                "declined": 1,
+                "value": "₹1,99,960.00"
+              },
+              {
+                "agentId": "agt_shopper_atlas",
+                "displayName": "Atlas Shopping Assistant",
+                "orders": 2,
+                "valueMinor": 7349400,
+                "declined": 0,
+                "value": "₹73,494.00"
+              },
+              {
+                "agentId": "agt_bulk_orion",
+                "displayName": "Orion Procurement Bot",
+                "orders": 1,
+                "valueMinor": 6598800,
+                "declined": 0,
+                "value": "₹65,988.00"
+              },
+              {
+                "agentId": "agt_concierge_vega",
+                "displayName": "Vega Personal Concierge",
+                "orders": 1,
+                "valueMinor": 1579800,
+                "declined": 0,
+                "value": "₹15,798.00"
+              },
+              {
+                "agentId": "agt_probe_zeta",
+                "displayName": "Zeta Comparison Agent",
+                "orders": 1,
+                "valueMinor": 1579400,
+                "declined": 0,
+                "value": "₹15,794.00"
+              },
+              {
+                "agentId": "agt_shadow_umbra",
+                "displayName": "Umbra Checkout Agent",
+                "orders": 1,
+                "valueMinor": 1259800,
+                "declined": 0,
+                "value": "₹12,598.00"
+              },
+              {
+                "agentId": "agt_swarm_kilo",
+                "displayName": "Kilo Rapid Buyer",
+                "orders": 1,
+                "valueMinor": 1049700,
+                "declined": 0,
+                "value": "₹10,497.00"
+              },
+              {
+                "agentId": "agt_relay_lyra",
+                "displayName": "Lyra Checkout Relay",
+                "orders": 1,
+                "valueMinor": 499900,
+                "declined": 1,
+                "value": "₹4,999.00"
+              }
+            ],
+            "flagged": [
+              {
+                "orderId": "ord_1003",
+                "reason": "Receipt amount and quantity disagree with the on-chain settlement",
+                "evidence": [
+                  "amount: receipt ₹4,999.00 vs chain ₹49,990.00",
+                  "qty NG-HS-01: 1 vs 10"
+                ],
+                "exposureMinor": 4499100,
+                "flaggedAt": "2026-07-31T14:01:58.063Z",
+                "exposure": "₹44,991.00"
+              }
+            ],
+            "blocklist": [
+              {
+                "agentId": "agt_ghost_nyx",
+                "displayName": "Nyx Buyer",
+                "reason": "Spoofed signature on a 40-unit order",
+                "blockedAt": "2026-07-31T14:01:58.063Z"
+              },
+              {
+                "agentId": "agt_relay_lyra",
+                "displayName": "Lyra Checkout Relay",
+                "reason": "Tampered sales receipt",
+                "blockedAt": "2026-07-31T14:01:58.063Z"
+              }
+            ],
+            "decisions": [
+              {
+                "orderId": "ord_1004",
+                "agentId": "agt_bulk_orion",
+                "agentDisplayName": "Orion Procurement Bot",
+                "verdict": "hold",
+                "score": 80,
+                "totalMinor": 6598800,
+                "currency": "INR",
+                "reason": "Trust score 80/100 clears the approval bar of 70.",
+                "decidedAt": "2026-07-31T14:01:58.061Z"
+              },
+              {
+                "orderId": "ord_1001",
+                "agentId": "agt_shopper_atlas",
+                "agentDisplayName": "Atlas Shopping Assistant",
+                "verdict": "approve",
+                "score": 98,
+                "totalMinor": 849900,
+                "currency": "INR",
+                "reason": "Trust score 98/100 clears the approval bar of 70.",
+                "decidedAt": "2026-07-31T14:01:58.061Z"
+              },
+              {
+                "orderId": "ord_1002",
+                "agentId": "agt_ghost_nyx",
+                "agentDisplayName": "Nyx Buyer",
+                "verdict": "decline",
+                "score": 10,
+                "totalMinor": 19996000,
+                "currency": "INR",
+                "reason": "Signature verification failed; identity is unproven, so the sale cannot settle safely.",
+                "decidedAt": "2026-07-31T14:01:58.060Z"
+              }
+            ]
+          }
+        }
+      ],
+      "tags": [
+        "dashboard",
+        "sales",
+        "revenue-protected",
+        "blocklist"
+      ]
+    }
+  ],
+  "generatedAt": "2026-07-31T14:03:04.260Z"
+}

--- a/sample-apps/agentic-commerce-gateway/tsconfig.json
+++ b/sample-apps/agentic-commerce-gateway/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022"],
+    "moduleResolution": "node",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/widgets"]
+}
+

--- a/sample-apps/agentic-commerce-gateway/vercel.json
+++ b/sample-apps/agentic-commerce-gateway/vercel.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "echo 'no install needed - static console'",
+  "buildCommand": "echo 'no build needed - console is a single self-contained file'",
+  "outputDirectory": "console",
+  "cleanUrls": true,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+    }
+  ]
+}


### PR DESCRIPTION
Fraud screening for AI shopping agents, built on the NitroStack TypeScript SDK. Track: **Fintech**.

The gateway sits inside a seller's checkout. It screens the buying agent **before** a sale settles, then verifies every receipt field-by-field against the on-chain settlement record **after**. Demo merchant is NovaGear, a mock electronics store.

### Try it live

| | |
|---|---|
| **Seller dashboard** | https://agentic-commerce-gateway-6a6cafaa-rudra-srmist.app.nitrocloud.ai/console |
| **Plays itself** | https://agentic-commerce-gateway-6a6cafaa-rudra-srmist.app.nitrocloud.ai/console?run=all |
| **MCP endpoint** | https://agentic-commerce-gateway-6a6cafaa-rudra-srmist.app.nitrocloud.ai/mcp |
| **SSE (ChatGPT)** | https://agentic-commerce-gateway-6a6cafaa-rudra-srmist.app.nitrocloud.ai/sse |

The dashboard is a browser MCP client the server hosts itself — same origin as `/mcp`, no build step, no second deployment. Every figure on it comes back from the deployed gateway over the protocol; nothing is canned. Select any of the nine orders to run the real investigation against it, or use `?run=all` to play all six scenarios hands-free.

Append `?theme=light` or `?theme=dark` to pin the theme.

### What it demonstrates

- **Branching evidence paths.** ACP- and x402-shaped payloads normalize into one schema, and the x402 path picks up a declared-amount check that the ACP path has no basis for — different investigation per protocol, not a flag.
- **Real verification.** Signatures are HMAC-SHA256 over the canonical order. Quantities and totals are inside the signed material, so tampering with a quantity genuinely breaks verification.
- **Reasoning over conflicting signals.** Signals that disagree are surfaced as explicit conflicts rather than averaged away — a valid signature on a 40-unit order from a day-old agent, or a correctly signed underpayment.
- **Consequential action.** Verdicts are applied, not reported: order status changes, agents get blocklisted, and a blocklisted agent's *next* order is declined at screening.
- **Post-sale autonomy.** `verify_receipt` diffs receipt against chain, prices the seller's exposure in rupees, and returns a concrete recommended action.

### Surface

9 tools · 3 resources · 2 prompts · 3 MCP widgets, plus a browser seller console the server hosts at `/console` (single self-contained file, speaks MCP over Streamable HTTP directly).

### Tests

`npm test` runs 33 end-to-end checks that speak MCP over the wire rather than calling the functions directly, so a green run means the tools work through the protocol. `npm run test:live` runs the same suite against the deployed server. Verified passing from a clean `npm install` of this directory.

### Honest scope

Payloads are protocol-shaped, not live ACP/x402 integrations, and settlement records are fixtures — no chain is read. The README states this plainly. What the gateway *decides* is computed at request time: signatures, trust scores and receipt diffs are all derived, never stored.