### PR TITLE
test(core): add ReadResource response shaping assertions

### DIFF
--- a/typescript/packages/core/src/core/__tests__/server.extended.test.ts
+++ b/typescript/packages/core/src/core/__tests__/server.extended.test.ts
@@ -183,14 +183,40 @@ describe('NitroStackServer Extended Tests', () => {
             mimeType: 'text/html'
         };
         server.resource(resource as any);
-        await readRes({ params: { uri: 'r1' } });
+            // Text resource
 
-        // Types: binary and json
-        (resource.fetch as any).mockImplementation(async () => ({ type: 'binary', data: Buffer.from('bin') }));
-        await readRes({ params: { uri: 'r1' } });
-        (resource.fetch as any).mockImplementation(async () => ({ type: 'json', data: { j: 1 } }));
-        await readRes({ params: { uri: 'r1' } });
+        const textResult = await readRes({ params: { uri: 'r1' } });
+        expect(textResult.contents[0]).toEqual({
+            uri: 'r1',
+            mimeType: 'text/html',
+            text: 'val'
+        });
 
+        // Binary resource
+        (resource.fetch as any).mockImplementation(async () => ({
+            type: 'binary',
+            data: Buffer.from('bin')
+        }));
+
+        const binaryResult = await readRes({ params: { uri: 'r1' } });
+        expect(binaryResult.contents[0]).toEqual({
+            uri: 'r1',
+            mimeType: 'text/html',
+            blob: Buffer.from('bin').toString('base64')
+        });
+
+        // JSON resource
+        (resource.fetch as any).mockImplementation(async () => ({
+            type: 'json',
+            data: { j: 1 }
+        }));
+
+        const jsonResult = await readRes({ params: { uri: 'r1' } });
+        expect(jsonResult.contents[0]).toEqual({
+            uri: 'r1',
+            mimeType: 'text/html',
+            text: JSON.stringify({ j: 1 }, null, 2)
+        });
         await expect(readRes({ params: { uri: 'non-existent' } })).rejects.toThrow();
 
         // Resource error


### PR DESCRIPTION
## Description

Adds explicit tests for `ReadResource` response shaping based on `content.type`.

The tests verify that:

- `text` resources return their data using the `text` field.
- `binary` resources return Base64-encoded data using the `blob` field.
- `json` resources are stringified and returned using the `text` field.
- The resource `mimeType` is preserved in each response.
- Valid JSON payloads are handled by the JSON branch without falling through to the default case.

Closes #18

## Type of Change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Internal code change
- [x] test: Test-only changes
- [ ] chore: Build, CI, or tooling changes

## Testing

Ran the targeted core test suite:

`npx jest src/core/__tests__/server.extended.test.ts`

Result:

- 1 test suite passed
- 5 tests passed
- 0 tests failed

The tests cover `text`, `binary`, and `json` resource response shapes.

## Checklist

- [x] My changes are focused on the issue described.
- [x] I have added/updated tests for the changed behavior.
- [x] The relevant test suite passes locally.
- [x] I have followed the project's coding and contribution guidelines.
- [x] No unrelated files are included in this PR.