### PR TITLE
fix(core): reset task TTL on activity

### DIFF
--- a/typescript/packages/core/src/core/__tests__/task.test.ts
+++ b/typescript/packages/core/src/core/__tests__/task.test.ts
@@ -279,6 +279,59 @@ describe('TaskManager', () => {
         });
     });
 
+    // ── TTL cleanup ──────────────────────────────────────────────────────────────
+    describe('TTL cleanup', () => {
+        it('keeps an active task alive when progress resets its TTL', () => {
+            jest.useFakeTimers();
+
+            const ttlManager = new TaskManager({
+                logger: createMockLogger(),
+                defaultTtl: 60000,
+                defaultPollInterval: 1000,
+            });
+
+            try {
+                const task = ttlManager.createTask({ ttl: 60000 });
+                const ctx = new TaskContext(ttlManager, task.taskId);
+
+                // Report progress 50 seconds after creation.
+                jest.advanceTimersByTime(50000);
+                ctx.updateProgress('Still working');
+
+                // Reach the cleanup sweep at 90 seconds.
+                // Task is 90s old, but only 40s idle.
+                jest.advanceTimersByTime(40000);
+
+                expect(ttlManager.hasTask(task.taskId)).toBe(true);
+            } finally {
+                ttlManager.destroy();
+                jest.useRealTimers();
+            }
+        });
+        it('removes a task after its TTL when there is no activity', () => {
+            jest.useFakeTimers();
+
+            const ttlManager = new TaskManager({
+                logger: createMockLogger(),
+                defaultTtl: 60000,
+                defaultPollInterval: 1000,
+            });
+
+            try {
+                const task = ttlManager.createTask({ ttl: 60000 });
+
+                // Cleanup runs every 30 seconds.
+                // At 90 seconds the task has been idle longer than its 60s TTL.
+                jest.advanceTimersByTime(90000);
+
+                expect(ttlManager.hasTask(task.taskId)).toBe(false);
+            } finally {
+                ttlManager.destroy();
+                jest.useRealTimers();
+            }
+        });
+    });
+
     // ── getAbortSignal ──────────────────────────────────────────────────────────
     describe('getAbortSignal', () => {
         it('returns an AbortSignal that is not yet aborted', () => {

--- a/typescript/packages/core/src/core/task.ts
+++ b/typescript/packages/core/src/core/task.ts
@@ -336,8 +336,8 @@ export class TaskManager {
         for (const [taskId, entry] of this.tasks.entries()) {
             if (entry.data.ttl === null) continue; // Unlimited TTL
 
-            const createdTime = new Date(entry.data.createdAt).getTime();
-            if (now - createdTime > entry.data.ttl) {
+            const lastActivityTime = new Date(entry.data.lastUpdatedAt).getTime();
+            if (now - lastActivityTime > entry.data.ttl) {
                 this.tasks.delete(taskId);
                 this.logger.debug(`Expired task cleaned up: ${taskId}`);
             }


### PR DESCRIPTION
 Closes #329

## Summary

Task TTL cleanup was measured from `createdAt`, causing long-running tasks to be removed even when they were actively reporting progress.

This changes TTL cleanup to measure inactivity from `lastUpdatedAt` instead.

Since `updateProgress()` updates task status and refreshes `lastUpdatedAt`, progress now effectively resets the TTL.

## Changes

- Use `lastUpdatedAt` instead of `createdAt` when checking task expiration.
- Add a regression test verifying that progress keeps an active task alive past its original creation-based TTL.
- Add a test verifying that inactive tasks still expire normally.

## Testing

- `npm run build` passes.
- Full core test suite passes: 50 test suites, 579 tests.
- Added TTL cleanup regression coverage.

## Notes

`npm run lint` could not be run because the current `@nitrostack/core` package does not define a `lint` script.