### PR TITLE
docs: fix Streamable HTTP option defaults

### DIFF
--- a/typescript/packages/core/src/core/transports/streamable-http.ts
+++ b/typescript/packages/core/src/core/transports/streamable-http.ts
@@ -51,7 +51,7 @@ export interface StreamableHttpTransportOptions {
   endpoint?: string;
 
   /**
-   * Enable session management (default: true)
+   * Enable session management (default: false)
    */
   enableSessions?: boolean;
 
@@ -74,7 +74,7 @@ export interface StreamableHttpTransportOptions {
   app?: Express;
 
   /**
-   * Enable CORS (default: false for security)
+   * Enable CORS (default: true)
    */
   enableCors?: boolean;
 }


### PR DESCRIPTION
## Summary

Fixes #8.

- Correct `enableSessions` documentation to reflect the actual default of `false`.
- Correct `enableCors` documentation to reflect the actual default of `true`.
- No runtime behavior was changed.

## Validation

- `git diff --check` passed.
- Reviewed the final diff; only the two JSDoc lines were changed.