### PR TITLE
docs(cli): link analytics tracking plan

### DIFF
--- a/typescript/packages/cli/README.md
+++ b/typescript/packages/cli/README.md
@@ -47,6 +47,13 @@ servers built with NitroStack.
 - Download: <https://nitrostack.ai/studio>
 - Studio: <https://nitrostack.ai/studio>
 
+## Privacy and Telemetry
+
+The CLI collects anonymous usage data to help improve the developer experience.
+It does not collect personal data or project source code. See the
+[analytics tracking plan](./ANALYTICS.md) for the data collected and how it is
+used.
+
 ## Links
 
 - CLI docs: <https://docs.nitrostack.ai/cli/overview>


### PR DESCRIPTION
## Description

Adds a short Privacy and Telemetry section to the npm-facing CLI README so users can find the existing analytics tracking plan and understand the data boundaries.

## Type of Change

- [x] docs: Documentation update

## Related Issues

Closes #11

## Changes Made

- Document that CLI usage data is anonymous.
- Clarify that personal data and project source code are not collected.
- Link the existing ANALYTICS.md tracking plan.

## Testing

- [x] Verified the relative ANALYTICS.md link target exists.
- [x] Ran git diff --check.
- [x] Manually reviewed the rendered Markdown structure.

## Screenshots / Recordings

Not applicable; documentation-only change.

## Checklist

- [x] I have read and followed CONTRIBUTING.md
- [x] I have added/updated tests where appropriate
- [x] I have updated docs where appropriate
- [x] I have kept this PR focused and scoped
- [x] I have used conventional commits