### PR TITLE
fix(core): propagate HTTP Authorization header and params._meta into tool ExecutionContext

### DIFF
--- a/typescript/packages/core/src/core/__tests__/server.oauth-context.test.ts
+++ b/typescript/packages/core/src/core/__tests__/server.oauth-context.test.ts
@@ -158,6 +158,36 @@ describe('ExecutionContext metadata (OAuth bridging)', () => {
         expect(context.metadata.authorization).toBe('Bearer explicit');
     });
 
+    it('forwards the session context through the transport factory registration', async () => {
+        // Regression: the factory closures passed to setMcpServerFactory must
+        // forward sessionContext, otherwise the transport-captured auth header
+        // never reaches the per-session MCP server (caught by e2e testing).
+        const originalTransport = process.env.MCP_TRANSPORT_TYPE;
+        process.env.MCP_TRANSPORT_TYPE = 'http';
+        try {
+            await server.start();
+        } finally {
+            process.env.MCP_TRANSPORT_TYPE = originalTransport;
+        }
+
+        const { StreamableHttpTransport } = await import('../transports/streamable-http.js');
+        const transportInstances = (StreamableHttpTransport as any).mock.results;
+        expect(transportInstances.length).toBeGreaterThan(0);
+        const transportInstance = transportInstances[transportInstances.length - 1].value;
+        const factory = transportInstance.setMcpServerFactory.mock.calls[0]?.[0];
+        expect(factory).toBeDefined();
+
+        const sessionMcp = factory({ authHeader: 'Bearer forwarded-token' });
+        const callTool = getCallToolHandler(sessionMcp);
+        const tool = makeTool('forwarded-tool');
+        server.tool(tool as any);
+
+        await callTool({ params: { name: 'forwarded-tool', arguments: {} } });
+
+        const context = (tool.execute as any).mock.calls[0][1];
+        expect(context.metadata.authorization).toBe('Bearer forwarded-token');
+    });
+
     it('stores the auth header on legacy SSE session context', async () => {
         const res = {} as any;
         await (server as any).startLegacySdkSseSession(res, '/mcp/messages', 'Bearer sse-token');

--- a/typescript/packages/core/src/core/__tests__/server.oauth-context.test.ts
+++ b/typescript/packages/core/src/core/__tests__/server.oauth-context.test.ts
@@ -1,0 +1,178 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import type { NitroStackServer as NitroStackServerType } from '../server';
+
+// Mock dependencies
+jest.unstable_mockModule('@modelcontextprotocol/sdk/server/index.js', () => ({
+    Server: jest.fn().mockImplementation(() => ({
+        connect: jest.fn(),
+        close: jest.fn(),
+        addTool: jest.fn(),
+        addResource: jest.fn(),
+        addPrompt: jest.fn(),
+        setRequestHandler: jest.fn(),
+        onerror: jest.fn()
+    }))
+}));
+jest.unstable_mockModule('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+    SSEServerTransport: jest.fn(),
+    StdioServerTransport: jest.fn()
+}));
+jest.unstable_mockModule('@modelcontextprotocol/sdk/server/sse.js', () => ({
+    SSEServerTransport: jest.fn().mockImplementation(() => ({
+        sessionId: 'sse-session-1',
+        handlePostMessage: jest.fn(),
+        close: jest.fn(),
+    }))
+}));
+jest.unstable_mockModule('../logger', () => ({
+    createLogger: () => ({
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn()
+    })
+}));
+jest.unstable_mockModule('../transports/streamable-http.js', () => ({
+    StreamableHttpTransport: jest.fn().mockImplementation(() => ({
+        start: jest.fn(),
+        close: jest.fn(),
+        setToolsCallback: jest.fn(),
+        setServerConfig: jest.fn(),
+        setMcpServerFactory: jest.fn(),
+    }))
+}));
+jest.unstable_mockModule('../di/container.js', () => ({
+    DIContainer: {
+        getInstance: jest.fn().mockReturnValue({
+            resolve: jest.fn(),
+            register: jest.fn(),
+            registerValue: jest.fn(),
+            getInstances: jest.fn().mockReturnValue([]),
+            instantiateAll: jest.fn()
+        })
+    }
+}));
+jest.unstable_mockModule('../builders.js', () => ({
+    buildController: jest.fn().mockReturnValue({
+        tools: [],
+        resources: [],
+        prompts: []
+    })
+}));
+jest.unstable_mockModule('../module.js', () => ({
+    Module: jest.fn((meta: any) => (target: any) => {
+        Reflect.defineMetadata('nitro:module', meta, target);
+        return target;
+    }),
+    isModule: jest.fn().mockReturnValue(true),
+    getModuleMetadata: jest.fn().mockImplementation((m: any) => Reflect.getMetadata('nitro:module', m))
+}));
+
+const { Server: McpServer } = await import('@modelcontextprotocol/sdk/server/index.js');
+const { NitroStackServer } = await import('../server');
+const { CallToolRequestSchema } = await import('@modelcontextprotocol/sdk/types.js');
+
+function makeTool(name: string) {
+    return {
+        name,
+        execute: jest.fn().mockImplementation(async () => 'ok'),
+        toMcpTool: () => ({ name } as any),
+        hasComponent: () => false,
+        getComponent: () => undefined
+    };
+}
+
+function getCallToolHandler(mcpInstance: any) {
+    const calls = mcpInstance.setRequestHandler.mock.calls;
+    return calls.find((c: any) => c[0] === CallToolRequestSchema)?.[1];
+}
+
+describe('ExecutionContext metadata (OAuth bridging)', () => {
+    let server: NitroStackServerType;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        server = new NitroStackServer({ name: 'test-server', version: '1.0.0' });
+    });
+
+    it('merges request.params._meta (MCP spec) into context metadata', async () => {
+        const mcpInstance = (McpServer as any).mock.results[0].value;
+        const callTool = getCallToolHandler(mcpInstance);
+        const tool = makeTool('meta-tool');
+        server.tool(tool as any);
+
+        await callTool({
+            params: {
+                name: 'meta-tool',
+                arguments: { _meta: { fromArgs: 'a', shared: 'args' }, foo: 'bar' },
+                _meta: { fromParams: 'p', shared: 'params' },
+            },
+        });
+
+        const context = (tool.execute as any).mock.calls[0][1];
+        expect(context.metadata.fromArgs).toBe('a');
+        expect(context.metadata.fromParams).toBe('p');
+        // params._meta takes precedence over arguments._meta
+        expect(context.metadata.shared).toBe('params');
+    });
+
+    it('keeps legacy arguments._meta behavior for Studio clients', async () => {
+        const mcpInstance = (McpServer as any).mock.results[0].value;
+        const callTool = getCallToolHandler(mcpInstance);
+        const tool = makeTool('legacy-tool');
+        server.tool(tool as any);
+
+        await callTool({
+            params: { name: 'legacy-tool', arguments: { _meta: { authorization: 'Bearer studio-token' } } },
+        });
+
+        const context = (tool.execute as any).mock.calls[0][1];
+        expect(context.metadata.authorization).toBe('Bearer studio-token');
+    });
+
+    it('bridges the session authHeader into context metadata', async () => {
+        const sessionContext = { authHeader: 'Bearer session-token' };
+        const sessionMcp = server.createConfiguredMcpServer(sessionContext as any);
+        const callTool = getCallToolHandler(sessionMcp);
+        const tool = makeTool('auth-tool');
+        server.tool(tool as any);
+
+        await callTool({ params: { name: 'auth-tool', arguments: {} } });
+
+        const context = (tool.execute as any).mock.calls[0][1];
+        expect(context.metadata.authorization).toBe('Bearer session-token');
+    });
+
+    it('lets explicit _meta.authorization win over the captured header', async () => {
+        const sessionContext = { authHeader: 'Bearer session-token' };
+        const sessionMcp = server.createConfiguredMcpServer(sessionContext as any);
+        const callTool = getCallToolHandler(sessionMcp);
+        const tool = makeTool('explicit-tool');
+        server.tool(tool as any);
+
+        await callTool({
+            params: { name: 'explicit-tool', arguments: {}, _meta: { authorization: 'Bearer explicit' } },
+        });
+
+        const context = (tool.execute as any).mock.calls[0][1];
+        expect(context.metadata.authorization).toBe('Bearer explicit');
+    });
+
+    it('stores the auth header on legacy SSE session context', async () => {
+        const res = {} as any;
+        await (server as any).startLegacySdkSseSession(res, '/mcp/messages', 'Bearer sse-token');
+
+        const sessions = Array.from((server as any).legacySdkSseSessions.values()) as any[];
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0].sessionContext.authHeader).toBe('Bearer sse-token');
+
+        // The per-session MCP server handler sees the bridged header
+        const callTool = getCallToolHandler(sessions[0].server);
+        const tool = makeTool('sse-tool');
+        server.tool(tool as any);
+        await callTool({ params: { name: 'sse-tool', arguments: {} } });
+
+        const context = (tool.execute as any).mock.calls[0][1];
+        expect(context.metadata.authorization).toBe('Bearer sse-token');
+    });
+});

--- a/typescript/packages/core/src/core/__tests__/transport.streamable.test.ts
+++ b/typescript/packages/core/src/core/__tests__/transport.streamable.test.ts
@@ -148,6 +148,59 @@ describe('StreamableHttpTransport (SDK-delegated host)', () => {
         expect([200, 204]).toContain(delRes.status);
     });
 
+    it('bridges the HTTP Authorization header into the session context', async () => {
+        const sessionContexts: any[] = [];
+        const authTransport = new StreamableHttpTransport({ port: 3069, host: 'localhost', enableCors: true });
+        authTransport.setMcpServerFactory(((sessionContext: any) => {
+            sessionContexts.push(sessionContext);
+            return makeServerFactory()();
+        }) as any);
+        await authTransport.start();
+
+        try {
+            // 1. initialize without an auth header
+            const initRes = await fetch('http://localhost:3069/mcp', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', Accept: MCP_ACCEPT },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'initialize',
+                    params: {
+                        protocolVersion: '2025-06-18',
+                        capabilities: {},
+                        clientInfo: { name: 'test-client', version: '1.0.0' },
+                    },
+                }),
+            });
+            expect(initRes.status).toBe(200);
+            const sessionId = initRes.headers.get('mcp-session-id');
+            expect(sessionId).toBeTruthy();
+            await initRes.text();
+
+            expect(sessionContexts).toHaveLength(1);
+            expect(sessionContexts[0].authHeader).toBeUndefined();
+
+            // 2. subsequent request carries the bearer token
+            const listRes = await fetch('http://localhost:3069/mcp', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: MCP_ACCEPT,
+                    'mcp-session-id': sessionId!,
+                    Authorization: 'Bearer test-token-123',
+                },
+                body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
+            });
+            expect(listRes.status).toBe(200);
+            await listRes.text();
+
+            expect(sessionContexts[0].authHeader).toBe('Bearer test-token-123');
+        } finally {
+            await authTransport.close();
+        }
+    });
+
     it('rejects a non-initialize POST without a session with 400', async () => {
         const res = await fetch(baseUrl, {
             method: 'POST',

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -1149,7 +1149,7 @@ export class NitroStackServer {
 
       // Delegate /mcp protocol handling to the official SDK transport: each
       // session gets its own configured MCP server built via this factory.
-      httpTransport.setMcpServerFactory(() => this.createConfiguredMcpServer());
+      httpTransport.setMcpServerFactory((sessionContext) => this.createConfiguredMcpServer(sessionContext));
 
       // Set up tools callback and server config for documentation page
       httpTransport.setToolsCallback(async () => {
@@ -1244,7 +1244,7 @@ export class NitroStackServer {
             enableCors: transportOptions?.enableCors !== false, // Enable CORS by default for web clients
             ...getStreamableHttpEnvOptions(),
           });
-          transport.setMcpServerFactory(() => this.createConfiguredMcpServer());
+          transport.setMcpServerFactory((sessionContext) => this.createConfiguredMcpServer(sessionContext));
           this.attachLegacySdkSseIfNeeded(transport as HttpTransport);
           await transport.start();
           httpTransport = transport as HttpTransport;
@@ -1276,7 +1276,7 @@ export class NitroStackServer {
           });
 
           // Delegate /mcp protocol handling to the official SDK transport.
-          transport.setMcpServerFactory(() => this.createConfiguredMcpServer());
+          transport.setMcpServerFactory((sessionContext) => this.createConfiguredMcpServer(sessionContext));
 
           // Set up tools callback and server config for documentation page
           transport.setToolsCallback(async () => {

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -2,6 +2,7 @@ import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import type { Express, Response } from 'express';
+import type { SessionContext } from './transports/streamable-http.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import {
   CallToolRequestSchema,
@@ -69,7 +70,7 @@ interface HttpTransport {
   start(): Promise<void>;
   close(): Promise<void>;
   /** Provide the factory used to build a configured MCP server per /mcp session. */
-  setMcpServerFactory?(factory: () => McpServer): void;
+  setMcpServerFactory?(factory: (sessionContext?: SessionContext) => McpServer): void;
   setLegacySseHandler?(handler: (req: unknown, res: Response) => Promise<void>): void;
   setToolsCallback?(callback: () => Promise<unknown[]>): void;
   setServerConfig?(config: { name: string; version: string; description?: string }): void;
@@ -124,7 +125,7 @@ export class NitroStackServer {
   /** Active sessions for @modelcontextprotocol/sdk SSEServerTransport clients */
   private readonly legacySdkSseSessions = new Map<
     string,
-    { server: McpServer; transport: SSEServerTransport }
+    { server: McpServer; transport: SSEServerTransport; sessionContext: SessionContext }
   >();
 
   /** Task manager for MCP Tasks support */
@@ -206,7 +207,7 @@ export class NitroStackServer {
    * server instance (legacy SSE sessions, official Streamable HTTP sessions),
    * since a single SDK server can only be connected to one transport at a time.
    */
-  public createConfiguredMcpServer(): McpServer {
+  public createConfiguredMcpServer(sessionContext?: SessionContext): McpServer {
     const mcp = new McpServer(
       {
         name: this.config.name,
@@ -214,7 +215,7 @@ export class NitroStackServer {
       },
       NitroStackServer.mcpServerOptions,
     );
-    this.setupHandlersOn(mcp);
+    this.setupHandlersOn(mcp, sessionContext);
     return mcp;
   }
 
@@ -222,13 +223,17 @@ export class NitroStackServer {
    * SDK-compatible legacy HTTP+SSE: GET /sse (SSEServerTransport) and POST /mcp/messages?sessionId=.
    * Streamable HTTP stays on GET/POST /mcp.
    */
-  private async startLegacySdkSseSession(res: Response, messagesPath: string): Promise<void> {
+  private async startLegacySdkSseSession(res: Response, messagesPath: string, authHeader?: string): Promise<void> {
     try {
-      const sessionMcp = this.createConfiguredMcpServer();
+      const sessionContext: SessionContext = {};
+      if (authHeader) {
+        sessionContext.authHeader = authHeader;
+      }
+      const sessionMcp = this.createConfiguredMcpServer(sessionContext);
 
       const transport = new SSEServerTransport(messagesPath, res);
       const sessionId = transport.sessionId;
-      this.legacySdkSseSessions.set(sessionId, { server: sessionMcp, transport });
+      this.legacySdkSseSessions.set(sessionId, { server: sessionMcp, transport, sessionContext });
 
       let closing = false;
       transport.onclose = async () => {
@@ -269,8 +274,8 @@ export class NitroStackServer {
     const LEGACY_SSE_PATH = '/sse';
     const LEGACY_MESSAGES_PATH = '/mcp/messages';
 
-    app.get(LEGACY_SSE_PATH, async (_req, res) => {
-      await this.startLegacySdkSseSession(res, LEGACY_MESSAGES_PATH);
+    app.get(LEGACY_SSE_PATH, async (req, res) => {
+      await this.startLegacySdkSseSession(res, LEGACY_MESSAGES_PATH, req.get('authorization'));
     });
 
     app.post(LEGACY_MESSAGES_PATH, async (req, res) => {
@@ -285,6 +290,12 @@ export class NitroStackServer {
         return;
       }
       try {
+        // Refresh the session auth header on every message POST so tool
+        // handlers see the caller's current credential.
+        const authHeader = req.get('authorization');
+        if (authHeader) {
+          session.sessionContext.authHeader = authHeader;
+        }
         await session.transport.handlePostMessage(
           req as unknown as IncomingMessage,
           res as unknown as ServerResponse,
@@ -307,8 +318,9 @@ export class NitroStackServer {
     }
     // Cursor opens GET /mcp without mcp-session-id; fall back to legacy SSE on that path.
     if (typeof transport.setLegacySseHandler === 'function') {
-      transport.setLegacySseHandler(async (_req, res) => {
-        await this.startLegacySdkSseSession(res, '/mcp/messages');
+      transport.setLegacySseHandler(async (req, res) => {
+        const authHeader = (req as { get?: (name: string) => string | undefined }).get?.('authorization');
+        await this.startLegacySdkSseSession(res, '/mcp/messages', authHeader);
       });
     }
   }
@@ -626,7 +638,7 @@ export class NitroStackServer {
   /**
    * Register MCP protocol handlers on the given server instance (main or per legacy SSE session).
    */
-  private setupHandlersOn(mcp: McpServer): void {
+  private setupHandlersOn(mcp: McpServer, sessionContext?: SessionContext): void {
     // List tools
     mcp.setRequestHandler(ListToolsRequestSchema, async () => {
       this.logger.debug('Listing tools');
@@ -667,11 +679,21 @@ export class NitroStackServer {
         throw new TaskAugmentationRequiredError();
       }
 
-      // Extract _meta from args if present and add to context metadata
+      // Extract _meta from request params (MCP spec) and from arguments
+      // (legacy Studio clients); params._meta takes precedence.
       const argsRecord = (args || {}) as Record<string, JsonValue>;
-      const { _meta, ...toolArgs } = argsRecord;
+      const { _meta: metaFromArgs, ...toolArgs } = argsRecord;
+      const combinedMeta: Record<string, JsonValue> = {
+        ...(metaFromArgs as Record<string, JsonValue> | undefined),
+        ...(requestParams._meta as Record<string, JsonValue> | undefined),
+      };
+      // Bridge the transport-captured HTTP Authorization header so OAuth
+      // guards can authenticate remote HTTP/SSE clients. Explicit _meta wins.
+      if (sessionContext?.authHeader && combinedMeta['authorization'] === undefined) {
+        combinedMeta['authorization'] = sessionContext.authHeader;
+      }
       const context = this.createContext({
-        metadata: _meta as Record<string, JsonValue> | undefined,
+        metadata: combinedMeta,
         toolName: name
       });
 

--- a/typescript/packages/core/src/core/transports/streamable-http.ts
+++ b/typescript/packages/core/src/core/transports/streamable-http.ts
@@ -25,11 +25,23 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
 /**
+ * Mutable per-session context shared between the transport and the MCP server
+ * instance handling that session. The transport refreshes it on each HTTP
+ * request; MCP request handlers read it when building the tool
+ * ExecutionContext, which is how the HTTP Authorization header reaches
+ * OAuth-aware guards.
+ */
+export interface SessionContext {
+  /** Raw HTTP Authorization header from the most recent request on this session. */
+  authHeader?: string;
+}
+
+/**
  * Factory that builds a fully-configured MCP server instance.
  * Each Streamable HTTP session gets its own server, since an SDK server can
  * only be connected to a single transport at a time.
  */
-export type McpServerFactory = () => McpServer;
+export type McpServerFactory = (sessionContext?: SessionContext) => McpServer;
 
 /** Handles legacy HTTP+SSE clients that open GET without a Streamable HTTP session id (e.g. Cursor). */
 export type LegacySseHandler = (req: Request, res: Response) => Promise<void>;
@@ -87,6 +99,8 @@ interface McpSession {
   lastActivity: number;
   /** When the session was created (used to reap sessions that never finish initialize). */
   createdAt: number;
+  /** Per-session context shared with the session's MCP server (auth header, etc.). */
+  sessionContext: SessionContext;
 }
 
 /**
@@ -364,6 +378,13 @@ export class StreamableHttpTransport {
         }
       }
 
+      // Bridge the HTTP Authorization header into the session context so tool
+      // handlers can reach it via ExecutionContext.metadata (OAuth over HTTP).
+      const authHeader = req.get('authorization');
+      if (authHeader) {
+        session.sessionContext.authHeader = authHeader;
+      }
+
       // Refresh activity so the idle sweeper only reaps genuinely stale sessions.
       session.lastActivity = Date.now();
 
@@ -398,11 +419,14 @@ export class StreamableHttpTransport {
       throw new Error('StreamableHttpTransport: MCP server factory not set');
     }
 
-    const server = this.mcpServerFactory();
+    // The session context is created before the server so the factory can
+    // close over it; the transport then mutates it on each request.
+    const sessionContext: SessionContext = {};
+    const server = this.mcpServerFactory(sessionContext);
     // Build the session object first so `lastActivity` is a shared, mutable
     // reference visible to both the session map and the idle sweeper.
     const now = Date.now();
-    const session: McpSession = { server, transport: undefined as unknown as StreamableHTTPServerTransport, lastActivity: now, createdAt: now };
+    const session: McpSession = { server, transport: undefined as unknown as StreamableHTTPServerTransport, lastActivity: now, createdAt: now, sessionContext };
     // Register as pending until `initialize` completes; this bounds unfinished
     // sessions against the cap and lets the sweeper reap ones that never finish.
     this.pendingSessions.add(session);


### PR DESCRIPTION
## Description

Remote MCP clients (ChatGPT Apps SDK, Cursor, HTTP/SSE) authenticating with OAuth 2.1 bearer tokens always failed `OAuthGuard` with `OAuth token required`, even after a successful OAuth handshake. Two root causes in `@nitrostack/core`:

1. `StreamableHttpTransport.handleMcpRequest` delegated to the MCP SDK without bridging the HTTP `Authorization` header into the session or execution context.
2. The `tools/call` handler only read `_meta` from `request.params.arguments`, ignoring the spec-compliant `request.params._meta`, so spec-compliant clients had their metadata stripped.

As a result `ExecutionContext.metadata` was always `{}` for HTTP/SSE requests and `OAuthGuard` failed unconditionally when `OAUTH_REQUIRED=true`.

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] refactor: Internal code change
- [ ] test: Test-only changes
- [ ] chore: Build, CI, or tooling changes

## Related Issues

Bug report: `docs/sdk-bug/oauth-http-headers-and-metadata-loss.md` (internal report, validated against v1.0.14)

## Changes Made

- `transports/streamable-http.ts`: added exported `SessionContext` (`{ authHeader?: string }`); `McpServerFactory` now receives it; `McpSession` carries it; `handleMcpRequest` refreshes `authHeader` from the HTTP `Authorization` header on every request (mid-session token refreshes work)
- `server.ts`: `createConfiguredMcpServer` / `setupHandlersOn` accept the per-session `SessionContext`; the `tools/call` handler merges `request.params._meta` (MCP spec) with legacy `arguments._meta` (params wins) and fills `metadata.authorization` from the session header when `_meta` does not provide one explicitly
- `server.ts`: all three `setMcpServerFactory` call sites forward the `sessionContext` into `createConfiguredMcpServer` (second commit — caught by e2e testing; without it the captured header never reached the per-session server)
- Legacy HTTP+SSE path (`GET /sse`, `GET /mcp` fallback, `POST /mcp/messages`) captures and refreshes the header the same way
- Tests: new `server.oauth-context.test.ts` (metadata merging, precedence, header bridging, factory-forwarding regression, legacy SSE) + a real-HTTP header-bridging test in `transport.streamable.test.ts`

## Testing

- [ ] `npm run lint` (no lint script in `@nitrostack/core`)
- [x] `npm test` — 584 tests / 51 suites passing
- [x] Manual testing performed — end-to-end against a live NitroStack MCP server with Auth0 (`OAUTH_REQUIRED=true`, JWKS verification) using a real client-credentials token:

| Scenario | Unfixed 1.0.14 | This PR |
| --- | --- | --- |
| `tools/call` with valid `Authorization: Bearer` header | `OAuth token required` tool error | Tool executes, returns data |
| `tools/call` with `params._meta.authorization` | `OAuth token required` tool error | Tool executes |
| `tools/call` without token | HTTP 401 (auth middleware) | HTTP 401 (unchanged) |

## Screenshots / Recordings

N/A

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [x] I have added/updated tests where appropriate
- [x] I have updated docs where appropriate
- [x] I have kept this PR focused and scoped
- [x] I have used conventional commits