### PR TITLE
fix(templates): standardize OAuth conditional loading and fix ScopeGuard bypass

### DIFF
--- a/typescript/packages/cli/templates/typescript-oauth/src/app.module.ts
+++ b/typescript/packages/cli/templates/typescript-oauth/src/app.module.ts
@@ -34,60 +34,31 @@ import { SystemHealthCheck } from './health/system.health.js';
   imports: [
     ConfigModule.forRoot(),
 
-    // Enable OAuth 2.1 authentication
-    OAuthModule.forRoot({
-      // Whether OAuth is enforced. Defaults to false (dev-friendly): the server
-      // runs out-of-the-box and protected endpoints are reachable without a token.
-      // Set OAUTH_REQUIRED=true to enforce auth (fail-closed). When enforced but no
-      // verifier (JWKS_URI / INTROSPECTION_ENDPOINT) is configured, the server still
-      // starts and warns, but rejects protected requests until one is configured.
-      required: process.env.OAUTH_REQUIRED === 'true',
-
-      // Resource URI - YOUR MCP server's public URL
-      // This is used for token audience binding (RFC 8707)
-      // CRITICAL: Tokens must be issued specifically for this URI
-      resourceUri: process.env.RESOURCE_URI || 'https://mcplocal',
-
-      // Authorization Server(s) - The OAuth provider URL(s)
-      // Supports multiple auth servers for federation scenarios
-      authorizationServers: [
-        process.env.AUTH_SERVER_URL || 'https://dev-5dt0utuk31h13tjm.us.auth0.com',
-      ],
-
-      // Supported scopes for this MCP server
-      // Define what permissions your server supports
-      scopesSupported: [
-        'read',        // Read access to resources
-        'write',       // Write/modify resources
-        'admin',       // Administrative operations
-      ],
-
-      // Token Introspection (RFC 7662) - For opaque tokens
-      // If your OAuth provider issues opaque tokens (not JWTs),
-      // you MUST configure introspection to validate them
-      tokenIntrospectionEndpoint: process.env.INTROSPECTION_ENDPOINT,
-      tokenIntrospectionClientId: process.env.INTROSPECTION_CLIENT_ID,
-      tokenIntrospectionClientSecret: process.env.INTROSPECTION_CLIENT_SECRET,
-
-      // Expected audience (defaults to resourceUri if not provided)
-      // MUST match the audience claim in tokens (RFC 8707)
-      audience: process.env.TOKEN_AUDIENCE,
-
-      // Expected issuer (optional but recommended)
-      // If provided, tokens must be from this issuer
-      issuer: process.env.TOKEN_ISSUER,
-
-      // Custom validation (optional)
-      // Add any additional validation logic beyond spec requirements
-      customValidation: async (tokenPayload) => {
-        // Example: Check if user is active in your database
-        // const user = await db.users.findOne({ id: tokenPayload.sub });
-        // return user?.active === true;
-
-        // For now, accept all valid tokens
-        return true;
-      },
-    }),
+    // Conditionally load OAuth 2.1 authentication only when OAUTH_REQUIRED=true
+    ...(process.env.OAUTH_REQUIRED === 'true'
+      ? [
+          OAuthModule.forRoot({
+            required: true,
+            resourceUri: process.env.RESOURCE_URI || 'https://mcplocal',
+            authorizationServers: [
+              process.env.AUTH_SERVER_URL || 'https://dev-5dt0utuk31h13tjm.us.auth0.com',
+            ],
+            scopesSupported: [
+              'read',        // Read access to resources
+              'write',       // Write/modify resources
+              'admin',       // Administrative operations
+            ],
+            tokenIntrospectionEndpoint: process.env.INTROSPECTION_ENDPOINT,
+            tokenIntrospectionClientId: process.env.INTROSPECTION_CLIENT_ID,
+            tokenIntrospectionClientSecret: process.env.INTROSPECTION_CLIENT_SECRET,
+            audience: process.env.TOKEN_AUDIENCE,
+            issuer: process.env.TOKEN_ISSUER,
+            customValidation: async (_tokenPayload) => {
+              return true;
+            },
+          }),
+        ]
+      : []),
 
     FlightsModule
   ],

--- a/typescript/packages/cli/templates/typescript-oauth/src/guards/oauth.guard.ts
+++ b/typescript/packages/cli/templates/typescript-oauth/src/guards/oauth.guard.ts
@@ -125,6 +125,11 @@ export class OAuthGuard implements Guard {
 export function createScopeGuard(requiredScopes: string[]): new () => Guard {
   return class ScopeGuard implements Guard {
     async canActivate(context: ExecutionContext): Promise<boolean> {
+      // Enforcement gate: when OAuth is not required, bypass scope checks
+      if (!OAuthModule.isAuthRequired()) {
+        return true;
+      }
+
       const userScopes = context.auth?.scopes || [];
       
       const missingScopes = requiredScopes.filter(

--- a/typescript/packages/cli/templates/typescript-oauth/src/index.ts
+++ b/typescript/packages/cli/templates/typescript-oauth/src/index.ts
@@ -18,7 +18,7 @@
  */
 
 import 'dotenv/config';
-import { McpApplicationFactory } from '@nitrostack/core';
+import { McpApplicationFactory, DIContainer, OAuthModule } from '@nitrostack/core';
 import { AppModule } from './app.module.js';
 
 /**
@@ -26,7 +26,7 @@ import { AppModule } from './app.module.js';
  */
 async function bootstrap() {
   try {
-    console.error('🔐 Starting Calculator MCP Server with OAuth 2.1...\\n');
+    console.error('🔐 Starting Calculator MCP Server with OAuth 2.1...\n');
 
     // Validate required environment variables for OAuth, set defaults if missing
     if (!process.env.RESOURCE_URI || !process.env.AUTH_SERVER_URL) {
@@ -39,13 +39,25 @@ async function bootstrap() {
     // Create the MCP application
     const server = await McpApplicationFactory.create(AppModule);
 
+    // Suppress unconfigured built-in OAuthModule instantiation warning in dev mode
+    if (!OAuthModule.getConfig()) {
+      DIContainer.getInstance().registerValue(
+        OAuthModule,
+        Object.create(null) as OAuthModule,
+      );
+    }
+
     const authEnforced = process.env.OAUTH_REQUIRED === 'true';
-    console.error('✅ OAuth 2.1 Module configured');
-    console.error(`   Resource URI: ${process.env.RESOURCE_URI}`);
-    console.error(`   Auth Server: ${process.env.AUTH_SERVER_URL}`);
-    console.error(`   Scopes: read, write, admin`);
-    console.error(`   Audience: ${process.env.TOKEN_AUDIENCE || process.env.RESOURCE_URI}`);
-    console.error(`   Enforcement: ${authEnforced ? 'ON (OAUTH_REQUIRED=true)' : 'OFF (dev mode — set OAUTH_REQUIRED=true to enforce)'}\\n`);
+    if (authEnforced) {
+      console.error('✅ OAuth 2.1 Module configured');
+      console.error(`   Resource URI: ${process.env.RESOURCE_URI}`);
+      console.error(`   Auth Server: ${process.env.AUTH_SERVER_URL}`);
+      console.error(`   Scopes: read, write, admin`);
+      console.error(`   Audience: ${process.env.TOKEN_AUDIENCE || process.env.RESOURCE_URI}`);
+      console.error('   Enforcement: ON (OAUTH_REQUIRED=true)\n');
+    } else {
+      console.error('ℹ️  OAuth 2.1 disabled (OAUTH_REQUIRED=false — set OAUTH_REQUIRED=true to enforce)\n');
+    }
 
     // Start the server
     await server.start();


### PR DESCRIPTION
## Description

This PR standardizes OAuth 2.1 handling in the `typescript-oauth` template to align with industry standards and the MCP specification:

1. **Conditional OAuthModule Loading**:
   - In development (`OAUTH_REQUIRED=false`), `OAuthModule` is not loaded, which stops emitting `[NITROSTACK_OAUTH]` discovery signals and prevents clients (NitroStudio, ChatGPT, Cursor) from opening unwanted browser login popups.
   - When `OAUTH_REQUIRED=true`, `OAuthModule` is loaded dynamically and enforces strict token validation.

2. **ScopeGuard Enforcement Gate**:
   - Updated `createScopeGuard` to check `if (!OAuthModule.isAuthRequired()) return true;`, preventing unauthenticated local requests from failing with `Insufficient scope`.

3. **Clean Dev Startup**:
   - Registered a fallback value for `OAuthModule` in DI when `OAUTH_REQUIRED=false` to suppress false-positive container warnings on startup.

## Testing
- Verified clean startup and unauthenticated tool execution when `OAUTH_REQUIRED=false`.
- Verified strict enforcement, discovery metadata, and JWKS token verification when `OAUTH_REQUIRED=true`.
- All unit tests passing.