### PR TITLE
feat(core): implement MCP 2026-07-28 stateless protocol, task management, CIMD/OAuth 2.1 hardening, and MRTR support

### DIFF
--- a/notes/mcp-2026-07-28/01-protocol-changes.md
+++ b/notes/mcp-2026-07-28/01-protocol-changes.md
@@ -1,0 +1,221 @@
+# MCP 2026-07-28: what changed in the protocol
+
+> Blog-source notes. Protocol-only narrative — no NitroStack specifics here (see
+> [`02-nitrostack-changes.md`](./02-nitrostack-changes.md) for the SDK work and
+> [`03-sep-index.md`](./03-sep-index.md) for the per-SEP index).
+>
+> Sources: the [2026-07-28 release candidate post](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/),
+> the [final release post](https://blog.modelcontextprotocol.io/posts/2026-07-28/),
+> and the [specification changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog).
+
+## TL;DR
+
+2026-07-28 is the largest revision of MCP since the protocol launched. It makes
+the protocol **stateless by default**, deletes the `initialize` handshake and
+session IDs, and reorganizes optional capabilities into **independently
+versioned extensions**. Along the way it hardens authorization, adopts full
+**JSON Schema 2020-12** for tool schemas, formalizes **multi-round-trip
+requests** for server→client input, and deprecates Roots, Sampling, and MCP
+logging.
+
+The headline for implementers: a 2026 server can be a plain, horizontally
+scalable HTTP handler. Any replica can answer any request because there is no
+per-connection state to pin.
+
+## 1. The handshake is gone: `initialize` → `server/discover`
+
+**2025-era.** A client opened a session by POSTing `initialize`, the server
+replied with negotiated `protocolVersion` + capabilities, the client sent
+`notifications/initialized`, and every subsequent request rode the same session
+(identified by an `Mcp-Session-Id` header on Streamable HTTP).
+
+**2026-07-28.** There is no `initialize` and no `initialized`. Capability
+discovery is a single, optional, **cacheable** `server/discover` call. Servers
+advertise their identity, capabilities, and negotiated **extensions** there —
+but a client may skip it entirely and go straight to `tools/list` or
+`tools/call`.
+
+Because discovery is just another request, it caches like one and never has to
+be repeated per connection.
+
+## 2. Stateless core: no sessions, no `Mcp-Session-Id`
+
+Every 2026 request is self-describing. Instead of relying on a session
+established at `initialize` time, each request carries a small **per-request
+envelope** in its `_meta`:
+
+| envelope key | meaning |
+| --- | --- |
+| `io.modelcontextprotocol/protocolVersion` | the revision this request speaks (required) |
+| `io.modelcontextprotocol/clientCapabilities` | what the client can do (required) |
+| `io.modelcontextprotocol/clientInfo` | client name/version (optional) |
+
+> Note the camelCase reverse-DNS keys — this trips people up. The reference
+> TypeScript SDK exports them as `PROTOCOL_VERSION_META_KEY`,
+> `CLIENT_CAPABILITIES_META_KEY`, `CLIENT_INFO_META_KEY`.
+
+The transport-level effect: **no server-issued session id**, and any instance
+behind a load balancer can serve any request. Application state that used to be
+implied by a session is now explicit — passed as tool parameters, encoded in
+resource URIs, or stored behind an application-owned handle (the same pattern
+any stateless HTTP API uses).
+
+## 3. Required request headers (SEP-2243)
+
+Streamable HTTP requests now carry standard headers that must agree with the
+body, so proxies and gateways can route/observe MCP traffic without parsing
+JSON-RPC:
+
+- `MCP-Protocol-Version` — cross-checked against the body's envelope claim.
+- `Mcp-Method` — the JSON-RPC method; must equal the body's `method`.
+- `Mcp-Name` — the primary target name (e.g. the tool name on `tools/call`, the
+  URI on `resources/read`).
+- `Mcp-Param-*` — optional, populated from `x-mcp-header` declarations in a
+  tool's input schema.
+
+**If a header disagrees with the body, the request is rejected with `-32020`**
+(a header/body mismatch). In practice this means a `tools/call` without an
+`Mcp-Name` header, or an `Mcp-Method` header that names a different method than
+the body, is a hard 400 — before the tool ever runs.
+
+## 4. Multi Round-Trip Requests (MRTR) replace push elicitation (SEP-2322)
+
+Stateless HTTP has no persistent channel for a server to "call back" to a
+client mid-request. So server→client interactions (elicitation, sampling) are
+reframed as **multi round-trip requests**:
+
+1. A handler that needs more input returns an `input_required` result carrying
+   `inputRequests` and an **opaque `requestState`** (everything it needs to
+   resume — the server keeps nothing).
+2. The client gathers the answers and **re-invokes the same request**, echoing
+   `requestState` and attaching `inputResponses`.
+3. The handler reads the answers and continues (or asks again).
+
+Server→client requests are only legal while a client request is in flight
+(SEP-2260), which falls out naturally from this model.
+
+## 5. Caching hints (SEP-2549)
+
+Results that are safe to cache now say so. `tools/list`, `prompts/list`,
+`resources/list`, `resources/templates/list`, `resources/read`, and
+`server/discover` can carry:
+
+- `ttlMs` — freshness lifetime in milliseconds.
+- `cacheScope` — `public` (shared caches may store it) or `private`.
+
+This is what makes "skip discovery, cache the tool list" safe and standardized
+rather than a client-by-client guess.
+
+## 6. W3C Trace Context (SEP-414)
+
+Distributed-tracing keys travel in `_meta` under their standard names:
+`traceparent`, `tracestate`, `baggage`. A server can correlate a tool call
+across the host, itself, and any downstream service without MCP inventing a
+tracing backend.
+
+## 7. Extensions become first-class (SEP-2133)
+
+Capabilities that used to be baked into the core spec are now **named,
+independently versioned extensions** advertised in `server/discover`:
+
+- `io.modelcontextprotocol/app` — **MCP Apps**: prefetchable, sandboxed UI
+  templates. Tool calls still flow through `tools/call`; the UI is just a
+  template the host renders.
+- `io.modelcontextprotocol/tasks` — the **Tasks** extension (below).
+
+New extensions can ship and version on their own cadence instead of forcing a
+whole-protocol revision.
+
+## 8. Tasks graduate to an extension (SEP-2663)
+
+The experimental 2025 Tasks vocabulary (`tasks/list`, `tasks/result`, a
+client-augmented `task: {}` param) is replaced by a proper extension:
+
+- Task creation can be **server-directed**: if the client advertised the tasks
+  extension and a tool is task-capable, the server may return a task handle from
+  `tools/call` without the client asking.
+- The client drives with `tasks/get`, **`tasks/update`** (new — supersedes the
+  ad-hoc mid-task input request), and `tasks/cancel`.
+- `tasks/list` and `tasks/result` are **removed**; era-mismatched task methods
+  answer `-32601`.
+
+## 9. Full JSON Schema 2020-12 for tools (SEP-2106)
+
+2025-era tool schemas were effectively JSON Schema draft-7 with composition
+stripped and a forced `type: "object"` root. 2026 lifts this to full **JSON
+Schema 2020-12**:
+
+- Input keeps an object root but may now use `oneOf`/`anyOf`/`allOf`,
+  conditionals, and `$ref`/`$defs`.
+- Output schemas are **unrestricted** (not forced to an object).
+- `structuredContent` may be any JSON value.
+
+Implementations should bound schema depth/validation time and must not
+auto-dereference external `$ref` URIs.
+
+## 10. Authorization hardening
+
+Six SEPs plus the final-spec CIMD change tighten the OAuth story:
+
+- **RFC 9207 `iss` validation (SEP-2468).** Clients must verify the `iss`
+  parameter on the authorization response to defend against mix-up attacks.
+- **`application_type` on DCR (SEP-837).** Native/CLI clients declare
+  `application_type: native` so loopback (`localhost`) redirects are accepted.
+- **Issuer-bound credentials (SEP-2352).** Stored tokens are bound to the
+  issuing authorization server; if a resource migrates to a new AS, old
+  credentials are not reused.
+- **OIDC refresh tokens (SEP-2207).** Documented `offline_access` /
+  `prompt=consent` handling for OIDC-style authorization servers.
+- **Scope step-up (SEP-2350).** Incremental scope accumulation and
+  insufficient-scope handling.
+- **`.well-known` suffix insertion (SEP-2351).** Correct metadata URL
+  construction for issuers that carry a path component.
+- **CIMD (final spec).** **Dynamic Client Registration is deprecated** in favor
+  of **Client ID Metadata Documents**: the client's `client_id` is an HTTPS URL
+  that resolves to its metadata document, so authorization servers fetch it
+  instead of running a registration endpoint. DCR remains for backward
+  compatibility.
+
+Discovery-style methods (like `server/discover`) are unauthenticated, just as
+`initialize` was; `tools/call` is not.
+
+## 11. Missing-resource error changes (SEP-2164)
+
+`resources/read` on an unknown URI now returns **`-32602` (Invalid Params)**
+instead of the 2025-era `-32002` (Resource Not Found). It is treated as a bad
+parameter, not a distinct resource-layer error.
+
+## 12. Deprecations (SEP-2577)
+
+**Roots, Sampling, and MCP `logging/setLevel` are deprecated.** Recommended
+replacements:
+
+- Roots → pass paths/URIs as tool parameters or resource URIs.
+- Sampling → the host application's own LLM APIs.
+- MCP logging → standard server logging / OpenTelemetry.
+
+## 2025 vs 2026 at a glance
+
+| Concern | 2025-era (`2025-06-18`) | 2026-07-28 |
+| --- | --- | --- |
+| Handshake | `initialize` + `initialized` | none; optional `server/discover` |
+| Sessions | `Mcp-Session-Id`, sticky | stateless; no session id |
+| Server→client input | push over the session stream | multi-round-trip `input_required` + `requestState` |
+| Request headers | `Mcp-Session-Id` | `MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`, `Mcp-Param-*` |
+| Caching | ad hoc | `ttlMs` + `cacheScope` on list/read/discover |
+| Tracing | none standardized | W3C `traceparent`/`tracestate`/`baggage` in `_meta` |
+| Capabilities | fixed in core | named, versioned **extensions** |
+| Tasks | experimental (`tasks/list`, `tasks/result`) | `io.modelcontextprotocol/tasks` (`get`/`update`/`cancel`) |
+| Tool schema | draft-7, composition stripped, object-only | JSON Schema 2020-12, composition + `$defs`, unrestricted output |
+| Missing resource | `-32002` | `-32602` |
+| Client registration | DCR (RFC 7591) | CIMD (DCR deprecated) |
+| Roots / Sampling / MCP logging | present | deprecated |
+
+## How the protocol will evolve
+
+Making capabilities into versioned extensions is the structural bet: the core
+wire can stay small and stable while extensions (Apps, Tasks, and future ones)
+iterate independently. Combined with a stateless core, that is what lets MCP
+servers be deployed like ordinary web services — behind a load balancer, cached
+at the edge, and observed with the same tracing and gateway tooling as the rest
+of a fleet.

--- a/notes/mcp-2026-07-28/02-nitrostack-changes.md
+++ b/notes/mcp-2026-07-28/02-nitrostack-changes.md
@@ -1,0 +1,204 @@
+# MCP 2026-07-28 in NitroStack: what we changed
+
+> Blog-source notes. This covers the NitroStack package work; see
+> [`01-protocol-changes.md`](./01-protocol-changes.md) for the protocol narrative
+> and [`03-sep-index.md`](./03-sep-index.md) for the per-SEP index.
+
+## The core promise: opt in, don't break
+
+NitroStack is a framework on top of the Model Context Protocol. A protocol
+revision this large could have forced every NitroStack app to migrate. It
+doesn't. The design goal was: **implement all of 2026-07-28 without changing the
+code NitroStack users write.**
+
+We got there with a **dual-adapter** architecture and a single switch.
+
+### The switch
+
+```bash
+# default (unset) — today's 2025-era sessionful behavior, byte-for-byte
+# 2026-07-28 only:
+NITRO_MCP_PROTOCOL_VERSION=2026-07-28
+# both eras from one process (for validation against mixed clients):
+NITRO_MCP_PROTOCOL_VERSION=auto
+```
+
+Accepted values (case-insensitive): `2026-07-28` / `2026` / `modern` /
+`latest` → modern; `auto` / `both` / `dual` → auto; `2025-06-18` /
+`2025-11-25` / `2025` / `legacy` / unset / anything unrecognized → legacy.
+
+The same value is accepted on `@McpApp({ protocolVersion })` /
+`McpServerConfig.protocolVersion`. **Env wins over config** so ops can flip a
+deployed app without a code change. Flipping the eventual default is a one-line
+change in the selector.
+
+## Architecture: one registry, two adapters
+
+NitroStack keeps owning the registry (tools, resources, prompts, tasks, widgets,
+auth). What changes is the wire underneath:
+
+```
+@Tool / @Resource / @Prompt / @Widget / @McpApp   ← user code (unchanged)
+                    │
+          NitroStack registry
+                    │
+        protocol selector (env / config)
+          │                        │
+   legacy adapter            modern adapter
+   (@modelcontextprotocol      (@modelcontextprotocol/server v2
+    /sdk v1, sessionful)         createMcpHandler + serveStdio, stateless)
+```
+
+- **`protocol/version.ts`** — resolves the era (`legacy` | `modern` | `auto`).
+- **`protocol/adapter.ts`** — the `ProtocolRegistry` (read-only view of the
+  registry the adapters consume) and `ProtocolAdapter` contract. The adapters
+  never import NitroStack decorators or DI.
+- **`protocol/modern-v2.adapter.ts`** — binds the registry to the official v2
+  engine (`@modelcontextprotocol/server` + `@modelcontextprotocol/node`).
+- **`protocol/features/`** — the era-specific mappings (cache hints, MRTR, trace
+  context, schema, extensions, errors).
+
+The v2 packages are **loaded lazily** (dynamic `import`) only when the era is
+`modern` or `auto`, so a default install keeps today's import graph and existing
+Jest suites never touch v2.
+
+The legacy path is unchanged: NitroStack still constructs its v1 `McpServer`, and
+the sessionful Streamable HTTP stack (`Mcp-Session-Id`, `MCP_MAX_SESSIONS`,
+session reaping) stays exactly as it was.
+
+## What NitroStack users do NOT change
+
+- `@Tool`, `@Resource`, `@Prompt`, `@Widget`, `@McpApp`, guards, pipes,
+  interceptors, exception filters, DI — all identical.
+- `ExecutionContext` gains **optional** fields; existing handlers ignore them.
+- `@Cache({ ttl })` and resource `metadata.cacheable` already exist; on 2026
+  they additionally populate cache hints.
+
+That's the whole point: a NitroStack app boots on 2026 without a code edit.
+
+## What we added (additive only)
+
+### `ExecutionContext` extensions
+
+New optional fields, populated only on the modern path:
+
+- `protocolVersion` — the request's negotiated revision.
+- `clientInfo`, `clientCapabilities` — from the per-request envelope.
+- `requestState`, `inputResponses` — for MRTR (below).
+- `trace` — W3C Trace Context (`traceparent` / `tracestate` / `baggage`).
+
+### MRTR helpers (`protocol/features/mrtr.ts`)
+
+Handlers are written **once** and work on both eras:
+
+```ts
+import { inputRequired, acceptedContent } from '@nitrostack/core';
+
+async handler(input, ctx) {
+  const confirmed = acceptedContent<boolean>(ctx.inputResponses, 'confirm');
+  if (confirmed === undefined) {
+    return inputRequired({
+      requests: [{ id: 'confirm', message: 'Delete all rows?', schema: { type: 'boolean' } }],
+      requestState: { table: input.table },
+    });
+  }
+  // ...continue with confirmed answer
+}
+```
+
+On 2026 the modern adapter translates this into the SDK's real
+`input_required` result. On 2025, returning `inputRequired(...)` is guarded and
+fails fast with guidance (push-style elicitation is not wired on the legacy
+path), so you don't ship a handler that silently misbehaves.
+
+### Cache hints (`protocol/features/cache-hints.ts`)
+
+`@Cache({ ttl })` (seconds) → tool cache hint `{ ttlMs, cacheScope: 'private' }`.
+Resource `metadata.cacheMaxAge` → resource `resources/read` cache hint. Explicit
+`cacheHint` on a tool/resource wins.
+
+### Extensions map (`protocol/features/extensions.ts`)
+
+Derived from what the app registered and advertised on `server/discover`:
+
+- `io.modelcontextprotocol/app` when any tool ships a `@Widget` / UI component.
+- `io.modelcontextprotocol/tasks` when any tool declares `taskSupport`.
+- App authors can declare extra extensions via `@McpApp({ extensions })`.
+
+`@Widget` / `useWidgetSDK` are untouched; on 2026 the adapter aligns the widget
+metadata with the official MCP Apps extension id.
+
+### Tasks
+
+`@Tool({ taskSupport })`, `context.task.updateProgress()`, and
+`throwIfCancelled()` stay. We added `context.task.update(...)` to mirror the
+2026 `tasks/update`. The experimental 2025 Tasks API remains on the legacy
+adapter; the 2026 path uses the extension lifecycle and does not expose
+`tasks/list` / `tasks/result`.
+
+### Authorization
+
+All additive; required for 2026-conformant auth, available on both eras once
+enabled:
+
+- `OAuth2Client.validateAuthorizationIssuer()` — RFC 9207 `iss` check.
+- `OAuth2Client.registerClient()` infers `application_type` (`native` for
+  loopback redirects); `OAuth2Client.isLoopbackRedirect()` helper.
+- `tokenResponseToStored(..., issuer)` + `getIssuerBoundToken()` — issuer-bound
+  credentials (drops and re-authorizes when the AS migrates).
+- `startAuthorizationFlow({ prompt })` — OIDC refresh (`prompt=consent`).
+- `auth/cimd.ts` — Client ID Metadata Documents: create / validate / resolve /
+  detect. `OAuthModule.enableClientRegistration` (DCR) stays but is marked
+  deprecated for 2026.
+- Auth middleware bypasses `server/discover` (and list methods) the way it used
+  to bypass `initialize`; `tools/call` is never bypassed.
+
+### Transport / notifications
+
+- `StreamableHttpTransport` can route `/mcp` to the modern stateless handler,
+  reports the active protocol label on `/mcp/health`, and its CORS allow-list
+  includes the new `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` /
+  `Mcp-Param-*` headers.
+- 2026 `list_changed` / `resources/updated` are published through the v2
+  `subscriptions/listen` notify bus; 2025 unsolicited notifications are
+  unchanged.
+
+## Three real bugs the 2026 test suite caught
+
+Worth calling out because they'd have been silent breakage on the modern path:
+
+1. **`_meta` envelope keys are camelCase.** The reference SDK uses
+   `io.modelcontextprotocol/protocolVersion` (not `.../protocol-version`).
+   Our first cut read hyphenated keys and never populated `clientInfo` /
+   `clientCapabilities` in `ExecutionContext`.
+2. **Zod v3 is not ingestible by the v2 SDK.** The SDK only accepts Zod ≥ 4.2.0
+   or a `fromJsonSchema(...)`-wrapped JSON Schema. NitroStack ships Zod v3, so
+   the adapter now always converts tool schemas to JSON Schema 2020-12 and wraps
+   them with `fromJsonSchema` before registering — otherwise every `tools/list`
+   failed with `-32603`.
+3. **SEP-2164 error code wasn't wired for resource reads.** A handler throwing
+   NitroStack's `ResourceNotFoundError` was surfacing as `-32603`; the adapter
+   now maps it to `-32602` via the SDK error classes.
+
+## Migration recipe (for when the default flips)
+
+1. Validate under `NITRO_MCP_PROTOCOL_VERSION=auto` against your real clients —
+   one endpoint serves both a 2025 `initialize` and a 2026 `server/discover`.
+2. Move to `NITRO_MCP_PROTOCOL_VERSION=2026-07-28` and confirm tools, resources,
+   prompts, widgets, and auth behave.
+3. Adopt the additive APIs where useful: `inputRequired()` for confirmations,
+   `context.task.update()` for long tasks, cache hints via `@Cache`.
+4. When the ecosystem has moved, flip the selector default to `modern` — a
+   one-line change; no user code edits required.
+
+## Tests
+
+- Every existing Jest suite stays green **without** the env var (default
+  legacy).
+- A parallel `__tests__/protocol-2026/` suite covers the selector, feature
+  mappings (cache/schema/trace/extensions/errors/MRTR), auth hardening, and an
+  end-to-end run driving the real v2 `createMcpHandler` `fetch` handler:
+  stateless `tools/list` (no `Mcp-Session-Id`), `server/discover`, `_meta` →
+  `ExecutionContext`, SEP-2164 `-32602`, SEP-2243 header rejection (`-32020`),
+  and `auto` mode serving both a 2025 `initialize` and a 2026 discover on one
+  handler.

--- a/notes/mcp-2026-07-28/03-sep-index.md
+++ b/notes/mcp-2026-07-28/03-sep-index.md
@@ -1,0 +1,75 @@
+# MCP 2026-07-28 SEP index
+
+> Blog-source notes. One row per change: what the SEP does → where NitroStack
+> implements it → what it means for a NitroStack user. See
+> [`01-protocol-changes.md`](./01-protocol-changes.md) and
+> [`02-nitrostack-changes.md`](./02-nitrostack-changes.md) for prose.
+>
+> **User impact legend:** _none_ = works with no code change; _opt-in_ =
+> available on both eras once you use it; _2026-only_ = active on the modern
+> path.
+
+## Stateless core
+
+| SEP | Spec change | NitroStack file(s) | User impact |
+| --- | --- | --- | --- |
+| [2575](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575) | No `initialize`/`initialized`; per-request `_meta` envelope (`protocolVersion`, `clientCapabilities`, `clientInfo`); new `server/discover`. | `protocol/modern-v2.adapter.ts` (envelope → `ExecutionContext`), `auth/middleware.ts` (discover bypass) | 2026-only; `ExecutionContext.protocolVersion/clientInfo/clientCapabilities` become available |
+| [2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567) | No `Mcp-Session-Id`; any instance serves any request. | `protocol/modern-v2.adapter.ts` (`createMcpHandler`, fresh server per request), `transports/streamable-http.ts` | 2026-only; multi-instance deployments need explicit handles, not sessions |
+| [2260](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2260) | Server→client requests only while a client request is in flight. | enforced by v2 engine; NitroStack elicitation runs inside handlers only | 2026-only; none for users |
+| [2322](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322) | Multi-round-trip `input_required` + opaque `requestState`; client retries with `inputResponses`. | `protocol/features/mrtr.ts`, adapter `runTool`, `ExecutionContext.requestState/inputResponses` | opt-in via `inputRequired()` / `acceptedContent()`; guarded on 2025 |
+| [2243](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243) | Required `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` headers, optional `Mcp-Param-*`; mismatch → `-32020`. | `transports/streamable-http.ts` (CORS allow-list), v2 engine validation | 2026-only; none (transport concern) |
+| [2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549) | `ttlMs` + `cacheScope` on list/read/discover results. | `protocol/features/cache-hints.ts`, `tool.ts`, `resource.ts`, `builders.ts` | opt-in via `@Cache({ ttl })` / resource `cacheMaxAge` |
+| [414](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/414) | W3C Trace Context (`traceparent`/`tracestate`/`baggage`) in `_meta`. | `protocol/features/trace-context.ts`, `ExecutionContext.trace` | 2026-only; read `ctx.trace` if you want correlation |
+| [2164](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2164) | Missing resource → `-32602` (was `-32002`). | `protocol/features/errors.ts`, adapter `readResource` mapping | 2026-only; none (error code) |
+
+## Extensions, Apps, Tasks
+
+| SEP | Spec change | NitroStack file(s) | User impact |
+| --- | --- | --- | --- |
+| [2133](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2133) | Capabilities become named, versioned extensions on `server/discover`. | `protocol/features/extensions.ts`, adapter `advertisedExtensions()` | 2026-only; declare extras via `@McpApp({ extensions })` |
+| MCP Apps | `io.modelcontextprotocol/app`: prefetchable sandboxed UI templates; tool calls still via `tools/call`. | `widget-mcp-meta.ts`, `app-mode.ts`, adapter UI `_meta` alignment | none; `@Widget` / `useWidgetSDK` unchanged |
+| [2663](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2663) | Tasks → extension: server-directed handle, `tasks/get`/`update`/`cancel`, no `tasks/list`/`result`. | `task.ts` (`context.task.update`), adapter tasks handling | opt-in via `@Tool({ taskSupport })`; 2025 experimental Tasks kept on legacy |
+
+## Schema
+
+| SEP | Spec change | NitroStack file(s) | User impact |
+| --- | --- | --- | --- |
+| [2106](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2106) | Full JSON Schema 2020-12: composition + `$ref`/`$defs`, unrestricted output, object input root. | `protocol/features/schema.ts`, adapter `toModernSchema` (Zod v3 → JSON Schema → `fromJsonSchema`) | 2026-only; richer tool schemas survive; none required |
+
+## Authorization hardening
+
+| SEP | Spec change | NitroStack file(s) | User impact |
+| --- | --- | --- | --- |
+| [2468](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2468) | Validate `iss` on the authorization response (RFC 9207). | `auth/client.ts` (`validateAuthorizationIssuer`) | opt-in; hardening for OAuth clients |
+| [837](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/837) | DCR `application_type` (`native` for loopback redirects). | `auth/client.ts` (`registerClient`, `isLoopbackRedirect`), `auth/types.ts` | opt-in; CLI/desktop redirects accepted |
+| [2352](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2352) | Bind stored credentials to the issuing `issuer`; re-auth on AS migration. | `auth/token-store.ts` (`getIssuerBoundToken`, `tokenResponseToStored`), `auth/types.ts` | opt-in |
+| [2207](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2207) | OIDC refresh (`offline_access` / `prompt=consent`). | `auth/client.ts` (`startAuthorizationFlow({ prompt })`) | opt-in |
+| [2350](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2350) | Scope step-up / insufficient-scope handling. | `auth/middleware.ts`, token validation | opt-in |
+| [2351](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2351) | Correct `.well-known` suffix insertion for path-component issuers. | `auth/server-metadata.ts` (audited) | none |
+| Final: CIMD | DCR deprecated in favor of Client ID Metadata Documents. | `auth/cimd.ts`, `auth/index.ts`; `oauth-module.ts` (`enableClientRegistration` marked deprecated) | opt-in; DCR still works |
+
+## Deprecations
+
+| SEP | Spec change | NitroStack file(s) | User impact |
+| --- | --- | --- | --- |
+| [2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577) | Roots, Sampling, MCP `logging/setLevel` deprecated. | not implemented in NitroStack (not added as features); documented replacements | none — use tool params/resource URIs (roots), host LLM APIs (sampling), OpenTelemetry / server logging (logging) |
+
+## Selection / packaging (NitroStack-specific)
+
+| Item | NitroStack file(s) | User impact |
+| --- | --- | --- |
+| Protocol selector (`NITRO_MCP_PROTOCOL_VERSION` / `protocolVersion`) | `protocol/version.ts`, `server.ts`, `types.ts` (`McpServerConfig.protocolVersion`) | opt-in; default unset = legacy |
+| Protocol adapter contract | `protocol/adapter.ts` | none (internal) |
+| v2 engine deps (`@modelcontextprotocol/server`, `@modelcontextprotocol/node`) | `package.json`; lazily imported | none; not loaded on default installs |
+
+## Reference constants (from the reference TypeScript SDK v2)
+
+- `MODERN_WIRE_REVISION` / `FIRST_MODERN_PROTOCOL_VERSION` = `2026-07-28`.
+- `LATEST_PROTOCOL_VERSION` (latest *legacy* handshake) = `2025-11-25`.
+- Envelope `_meta` keys are camelCase reverse-DNS:
+  `io.modelcontextprotocol/protocolVersion`,
+  `io.modelcontextprotocol/clientCapabilities`,
+  `io.modelcontextprotocol/clientInfo`,
+  `io.modelcontextprotocol/serverInfo`.
+- Required envelope keys: `protocolVersion` **and** `clientCapabilities`.
+- Trace keys are bare: `traceparent`, `tracestate`, `baggage`.

--- a/notes/mcp-2026-07-28/03-sep-index.md
+++ b/notes/mcp-2026-07-28/03-sep-index.md
@@ -58,7 +58,7 @@
 
 | Item | NitroStack file(s) | User impact |
 | --- | --- | --- |
-| Protocol selector (`NITRO_MCP_PROTOCOL_VERSION` / `protocolVersion`) | `protocol/version.ts`, `server.ts`, `types.ts` (`McpServerConfig.protocolVersion`) | opt-in; default unset = legacy |
+| Protocol selector (`NITRO_MCP_PROTOCOL_VERSION` / `protocolVersion`) | `protocol/version.ts`, `server.ts`, `types.ts` (`McpServerConfig.protocolVersion`) | default unset = auto (dual modern stateless + legacy fallback) |
 | Protocol adapter contract | `protocol/adapter.ts` | none (internal) |
 | v2 engine deps (`@modelcontextprotocol/server`, `@modelcontextprotocol/node`) | `package.json`; lazily imported | none; not loaded on default installs |
 

--- a/notes/mcp-2026-07-28/04-nitrostudio-client-changes.md
+++ b/notes/mcp-2026-07-28/04-nitrostudio-client-changes.md
@@ -1,0 +1,109 @@
+# NitroStudio: MCP 2026-07-28 client support
+
+> Blog-source notes for the **client** side. NitroStudio is the desktop
+> inspector (Next.js UI + Tauri/Rust transport). This documents how it learned
+> to speak the 2026-07-28 stateless protocol **without breaking any existing
+> 2025-era connection**. Companion to [`02-nitrostack-changes.md`](./02-nitrostack-changes.md)
+> (server side) and [`03-sep-index.md`](./03-sep-index.md).
+
+## TL;DR
+
+- Studio now **auto-negotiates** the protocol era per connection. It probes
+  `server/discover` first; a JSON-RPC result ⇒ modern (2026-07-28 stateless), an
+  error/timeout ⇒ fall back to the legacy `initialize` handshake. No user
+  toggle, no config.
+- Both transports are covered: **STDIO** (negotiated in TypeScript) and **HTTP**
+  (negotiated in the Rust/Tauri transport).
+- On the modern path Studio drops the `initialize`/`initialized` handshake and
+  the `Mcp-Session-Id`, attaches the per-request `_meta` envelope, and (over
+  HTTP) mirrors the SEP-2243 routing headers.
+- Legacy connections are byte-for-byte unchanged — the modern code only runs
+  when a server actually answers `server/discover`.
+
+## Where the real client lives
+
+The production MCP client is **not** the SDK-based `lib/mcp-client.ts` (dead
+code — imports a `http-client-transport.ts` that doesn't exist). The live path
+is:
+
+```
+UI (React) → lib/api.ts (McpManager) → Tauri invoke → src-tauri/src/mcp/*.rs → server
+```
+
+- `lib/api.ts` — `McpManager` builds JSON-RPC, logs traffic, injects `_meta`.
+- `src-tauri/src/mcp/stdio.rs` — spawns the child process, framed JSON-RPC.
+- `src-tauri/src/mcp/http_client.rs` — hand-rolled Streamable-HTTP + legacy
+  HTTP+SSE (exists to bypass browser CORS and to spawn processes).
+
+## New shared modules
+
+| File | Purpose |
+| --- | --- |
+| `nitrostudio/lib/mcp-protocol.ts` | TS source of truth: `ProtocolEra`, version constants, `_meta` key names, SEP-2243 header names, `withModernEnvelope()`, `readNegotiatedServerInfo()`, stateless-version classifier. |
+| `nitrostudio/src-tauri/src/mcp/protocol.rs` | Rust mirror: `ProtocolEra`, envelope builder, `discover_request_body()`, `mcp_name_for()` (routing-header value), `name_required()`. |
+
+Both hard-code the same wire contract taken from `@modelcontextprotocol/{server,client}`
+v2 (the packages the NitroStack server adapter uses) and
+`typescript/packages/core/src/core/protocol/modern-v2.adapter.ts`.
+
+## Change map (SEP → Studio file → behavior)
+
+| SEP / concern | Studio change | Era |
+| --- | --- | --- |
+| 2575 — no `initialize`; `_meta` envelope; `server/discover` | STDIO: `McpManager.negotiateStdioEra()`/`probeStdioDiscover()` in `lib/api.ts`; HTTP: `try_modern_discover()` in `http_client.rs`. Envelope injected in `McpManager.sendRequest()` (`withModernEnvelope`) for modern requests. | 2026-only |
+| 2567 — no `Mcp-Session-Id` | `http_client.rs`: modern branch of `mcp_http_send` skips the session header; `HttpMcpConn.session_id` stays `None`. | 2026-only |
+| 2243 — `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` headers | `http_client.rs`: modern branch sets all three; `Mcp-Name` derived from body params via `protocol::mcp_name_for` (`uri` for `resources/read`, `name` for `tools/call`/`prompts/get`, `taskId` for `tasks/*`). | 2026-only (HTTP) |
+| 2133 — capabilities as `server/discover` result | `readNegotiatedServerInfo()` maps discover/initialize result → `{ era, protocolVersion, serverInfo, capabilities }` on the connection; surfaced via `api.getProtocolInfo()`. | both |
+| 2164 — missing resource `-32602` (was `-32002`) | `executeToolWithRouting` `read_resource` routing already retries on **any** error code, so `-32602` and `-32002` are both handled. | both |
+| MCP Apps `io.modelcontextprotocol/app` | `lib/types.ts`: new `getMcpAppResourceUri()` + priority slot in `resolveWidgetUri()`; still resolves `_meta.ui.resourceUri` for existing servers. | both |
+| 2663 — Tasks extension | `lib/api.ts`: task-augmented `tools/call` param shape is identical across eras; modern requests get the envelope + `Mcp-Name: <taskId>` automatically. `listTasks()` degrades gracefully (`-32601` ⇒ empty) so update-driven 2026 servers without `tasks/list` don't error the panel. | both |
+| 2468 — RFC 9207 `iss` validation | `app/auth/callback/page.tsx`: validates the authorization-response `iss` against the AS `issuer` when present or when the AS advertises `authorization_response_iss_parameter_supported`. | opt-in (gated) |
+| 2351 — path-aware `.well-known` | `lib/oauth-helper.ts`: `buildWellKnownUrl()` inserts the suffix **between host and path** (RFC 8414 §3.1 / RFC 9728 §3.1); PRM discovery tries path-aware then root. Root issuers unchanged. | both |
+| CIMD | `lib/oauth-helper.ts`: `supportsClientIdMetadataDocument()` detection helper. Full CIMD needs Studio to host a client-metadata document, so DCR remains the default (opt-in, non-breaking). | opt-in |
+
+## Auto-negotiation flow
+
+**STDIO** (`connectToProject`, `connectToStdioServer`):
+
+1. Spawn process, wait for startup.
+2. `negotiateStdioEra()` sends `server/discover` (with envelope) — bounded retry
+   for process warm-up. Result ⇒ `modern`; JSON-RPC error ⇒ `legacy`; transport
+   error ⇒ retry.
+3. `modern` ⇒ skip `initialize`; start hot-reload watcher; done.
+   `legacy` ⇒ existing `initialize` + `notifications/initialized` retry loop.
+
+**HTTP** (`mcp_connect_http`):
+
+1. `try_modern_discover()` POSTs `server/discover` with the modern headers,
+   accepts `application/json` or `text/event-stream`.
+2. Success ⇒ store `era = Modern`, return `{ transport: "streamable-2026",
+   era: "modern", protocolVersion }`.
+3. Otherwise fall through to the unchanged Streamable-HTTP `initialize`, then
+   legacy HTTP+SSE.
+
+`McpManager.connect()` records `era`/`protocolVersion`/`negotiated` on the
+`McpConnection`; `sendRequest()` then injects the envelope for modern requests
+only.
+
+## UI surfacing
+
+- **Health** (`app/health/page.tsx`): `ProtocolBadge` shows negotiated era,
+  version, server info, and capability/extension keys.
+- **Settings** (`app/settings/page.tsx`): Runtime Configuration gains an "MCP
+  Protocol" row (era + version).
+- **Logs** (`app/logs/page.tsx`): each traffic entry carries an era chip
+  (`2025`/`2026`); `traffic-log-store.ts` gained an `era` field.
+
+## Non-breaking guarantees
+
+- Modern code paths execute only after a server answers `server/discover`.
+- `era` defaults to `legacy`; the envelope, modern headers, and session-drop are
+  all gated on `era === 'modern'`.
+- OAuth: `iss` is only enforced when returned/advertised; `.well-known` stays
+  identical for root issuers; DCR is still the default.
+
+## Not done / follow-ups
+
+- Full CIMD (requires hosting a client-metadata document from Studio).
+- 2026 server→client MRTR `input_required` prompting in the Studio UI (server
+  supports it; Studio still treats tool calls as single round-trip).

--- a/typescript/packages/cli/src/__tests__/branding.test.ts
+++ b/typescript/packages/cli/src/__tests__/branding.test.ts
@@ -44,10 +44,14 @@ describe('Branding Module', () => {
     const { brand } = await import('../ui/branding.js');
     
     expect(brand).toBeDefined();
-    expect(typeof brand.accent).toBe('function');
-    expect(typeof brand.accentBold).toBe('function');
-    expect(typeof brand.accentLight).toBe('function');
-    expect(typeof brand.accentLighter).toBe('function');
+    expect(typeof brand.signal).toBe('function');
+    expect(typeof brand.signalBold).toBe('function');
+    expect(typeof brand.sky).toBe('function');
+    expect(typeof brand.skyBold).toBe('function');
+    expect(typeof brand.mint).toBe('function');
+    expect(typeof brand.mintBold).toBe('function');
+    expect(typeof brand.error).toBe('function');
+    expect(typeof brand.warning).toBe('function');
   });
 
   it('should create header box', async () => {

--- a/typescript/packages/cli/templates/typescript-oauth/.env.example
+++ b/typescript/packages/cli/templates/typescript-oauth/.env.example
@@ -15,14 +15,15 @@ NITROSTACK_APP_MODE=universal
 # MCP Protocol Version (Optional)
 # =============================================================================
 # NITRO_MCP_PROTOCOL_VERSION selects which MCP wire revision NitroStack speaks.
-# Unset (default) keeps the current 2025-era sessionful behavior, unchanged.
+# Unset (default) defaults to 'auto' (serves 2026-07-28 stateless with legacy fallback).
+#   - auto       : serve both eras from one process (default).
 #   - 2026-07-28 : the new stateless spec (server/discover, per-request _meta,
 #                  Mcp-Method/Mcp-Name headers, cache hints, MRTR, extensions).
-#   - auto       : serve both eras from one process (validate mixed clients).
+#   - 2025-06-18 : the legacy 2025 sessionful spec.
 # On 2026, Dynamic Client Registration (below) is deprecated in favor of CIMD.
 # Your @Tool/@Resource/@Prompt/@Widget code is identical either way.
 # =============================================================================
-# NITRO_MCP_PROTOCOL_VERSION=2026-07-28
+# NITRO_MCP_PROTOCOL_VERSION=auto
 
 # Streamable HTTP Session Limits (Optional)
 # =============================================================================

--- a/typescript/packages/cli/templates/typescript-oauth/.env.example
+++ b/typescript/packages/cli/templates/typescript-oauth/.env.example
@@ -12,6 +12,18 @@ NITROSTACK_APP_MODE=universal
 # HOST=localhost
 # ENABLE_CORS=true
 
+# MCP Protocol Version (Optional)
+# =============================================================================
+# NITRO_MCP_PROTOCOL_VERSION selects which MCP wire revision NitroStack speaks.
+# Unset (default) keeps the current 2025-era sessionful behavior, unchanged.
+#   - 2026-07-28 : the new stateless spec (server/discover, per-request _meta,
+#                  Mcp-Method/Mcp-Name headers, cache hints, MRTR, extensions).
+#   - auto       : serve both eras from one process (validate mixed clients).
+# On 2026, Dynamic Client Registration (below) is deprecated in favor of CIMD.
+# Your @Tool/@Resource/@Prompt/@Widget code is identical either way.
+# =============================================================================
+# NITRO_MCP_PROTOCOL_VERSION=2026-07-28
+
 # Streamable HTTP Session Limits (Optional)
 # =============================================================================
 # Bounds memory against unauthenticated initialize floods. Defaults: 1000 sessions,

--- a/typescript/packages/cli/templates/typescript-oauth/README.md
+++ b/typescript/packages/cli/templates/typescript-oauth/README.md
@@ -41,6 +41,22 @@ Use NitroStudio to test auth flows, inspect tool requests, and validate behavior
 - Download: <https://nitrostack.ai/studio>
 - Studio: <https://nitrostack.ai/studio>
 
+## MCP protocol version (optional)
+
+This server speaks the current 2025-era MCP transport by default. To opt into the
+new **2026-07-28** stateless spec (or serve both eras at once for validation),
+set an environment variable — no code changes are needed:
+
+```bash
+# new stateless spec only
+NITRO_MCP_PROTOCOL_VERSION=2026-07-28
+# both eras from one process (validate mixed clients)
+NITRO_MCP_PROTOCOL_VERSION=auto
+```
+
+Unset keeps today's behavior. On 2026, Dynamic Client Registration is deprecated
+in favor of Client ID Metadata Documents (CIMD). See `.env.example` for details.
+
 ## Links
 
 - Docs: <https://docs.nitrostack.ai>

--- a/typescript/packages/cli/templates/typescript-oauth/README.md
+++ b/typescript/packages/cli/templates/typescript-oauth/README.md
@@ -43,19 +43,23 @@ Use NitroStudio to test auth flows, inspect tool requests, and validate behavior
 
 ## MCP protocol version (optional)
 
-This server speaks the current 2025-era MCP transport by default. To opt into the
-new **2026-07-28** stateless spec (or serve both eras at once for validation),
-set an environment variable — no code changes are needed:
+This server runs in **`auto` mode by default**, dynamically serving both the new
+**2026-07-28** stateless spec and legacy 2025 JSON-RPC clients from a single endpoint.
+You can customize the wire revision via environment variable — no code changes are needed:
 
 ```bash
-# new stateless spec only
-NITRO_MCP_PROTOCOL_VERSION=2026-07-28
-# both eras from one process (validate mixed clients)
+# default (when unset): serve both modern and legacy statelessly
 NITRO_MCP_PROTOCOL_VERSION=auto
+
+# new stateless spec only (strict mode)
+NITRO_MCP_PROTOCOL_VERSION=2026-07-28
+
+# legacy 2025 sessionful wire
+NITRO_MCP_PROTOCOL_VERSION=2025-06-18
 ```
 
-Unset keeps today's behavior. On 2026, Dynamic Client Registration is deprecated
-in favor of Client ID Metadata Documents (CIMD). See `.env.example` for details.
+On 2026, Dynamic Client Registration is deprecated in favor of Client ID Metadata
+Documents (CIMD). See `.env.example` for details.
 
 ## Links
 

--- a/typescript/packages/cli/templates/typescript-pizzaz/.env.example
+++ b/typescript/packages/cli/templates/typescript-pizzaz/.env.example
@@ -15,13 +15,14 @@ NITROSTACK_APP_MODE=universal
 # MCP Protocol Version (Optional)
 # =============================================================================
 # NITRO_MCP_PROTOCOL_VERSION selects which MCP wire revision NitroStack speaks.
-# Unset (default) keeps the current 2025-era sessionful behavior, unchanged.
+# Unset (default) defaults to 'auto' (serves 2026-07-28 stateless with legacy fallback).
+#   - auto       : serve both eras from one process (default).
 #   - 2026-07-28 : the new stateless spec (server/discover, per-request _meta,
 #                  Mcp-Method/Mcp-Name headers, cache hints, MRTR, extensions).
-#   - auto       : serve both eras from one process (validate mixed clients).
+#   - 2025-06-18 : the legacy 2025 sessionful spec.
 # Your @Tool/@Resource/@Prompt/@Widget code is identical either way.
 # =============================================================================
-# NITRO_MCP_PROTOCOL_VERSION=2026-07-28
+# NITRO_MCP_PROTOCOL_VERSION=auto
 
 # Mapbox Configuration (Optional)
 # =============================================================================

--- a/typescript/packages/cli/templates/typescript-pizzaz/.env.example
+++ b/typescript/packages/cli/templates/typescript-pizzaz/.env.example
@@ -12,6 +12,17 @@ NITROSTACK_APP_MODE=universal
 # HOST=localhost
 # ENABLE_CORS=true
 
+# MCP Protocol Version (Optional)
+# =============================================================================
+# NITRO_MCP_PROTOCOL_VERSION selects which MCP wire revision NitroStack speaks.
+# Unset (default) keeps the current 2025-era sessionful behavior, unchanged.
+#   - 2026-07-28 : the new stateless spec (server/discover, per-request _meta,
+#                  Mcp-Method/Mcp-Name headers, cache hints, MRTR, extensions).
+#   - auto       : serve both eras from one process (validate mixed clients).
+# Your @Tool/@Resource/@Prompt/@Widget code is identical either way.
+# =============================================================================
+# NITRO_MCP_PROTOCOL_VERSION=2026-07-28
+
 # Mapbox Configuration (Optional)
 # =============================================================================
 # The map widget uses Mapbox GL for interactive maps. 

--- a/typescript/packages/cli/templates/typescript-pizzaz/README.md
+++ b/typescript/packages/cli/templates/typescript-pizzaz/README.md
@@ -41,18 +41,22 @@ NitroStudio is the fastest way to test and debug interactive widget output.
 
 ## MCP protocol version (optional)
 
-This server speaks the current 2025-era MCP transport by default. To opt into the
-new **2026-07-28** stateless spec (or serve both eras at once for validation),
-set an environment variable — no code changes are needed:
+This server runs in **`auto` mode by default**, dynamically serving both the new
+**2026-07-28** stateless spec and legacy 2025 JSON-RPC clients from a single endpoint.
+You can customize the wire revision via environment variable — no code changes are needed:
 
 ```bash
-# new stateless spec only
-NITRO_MCP_PROTOCOL_VERSION=2026-07-28
-# both eras from one process (validate mixed clients)
+# default (when unset): serve both modern and legacy statelessly
 NITRO_MCP_PROTOCOL_VERSION=auto
+
+# new stateless spec only (strict mode)
+NITRO_MCP_PROTOCOL_VERSION=2026-07-28
+
+# legacy 2025 sessionful wire
+NITRO_MCP_PROTOCOL_VERSION=2025-06-18
 ```
 
-Unset keeps today's behavior. See `.env.example` for details.
+See `.env.example` for details.
 
 ## Links
 

--- a/typescript/packages/cli/templates/typescript-pizzaz/README.md
+++ b/typescript/packages/cli/templates/typescript-pizzaz/README.md
@@ -39,6 +39,21 @@ NitroStudio is the fastest way to test and debug interactive widget output.
 - Download: <https://nitrostack.ai/studio>
 - Studio: <https://nitrostack.ai/studio>
 
+## MCP protocol version (optional)
+
+This server speaks the current 2025-era MCP transport by default. To opt into the
+new **2026-07-28** stateless spec (or serve both eras at once for validation),
+set an environment variable — no code changes are needed:
+
+```bash
+# new stateless spec only
+NITRO_MCP_PROTOCOL_VERSION=2026-07-28
+# both eras from one process (validate mixed clients)
+NITRO_MCP_PROTOCOL_VERSION=auto
+```
+
+Unset keeps today's behavior. See `.env.example` for details.
+
 ## Links
 
 - Docs: <https://docs.nitrostack.ai>

--- a/typescript/packages/cli/templates/typescript-starter/.env.example
+++ b/typescript/packages/cli/templates/typescript-starter/.env.example
@@ -15,10 +15,11 @@ NITROSTACK_APP_MODE=universal
 # MCP Protocol Version (Optional)
 # =============================================================================
 # NITRO_MCP_PROTOCOL_VERSION selects which MCP wire revision NitroStack speaks.
-# Unset (default) keeps the current 2025-era sessionful behavior, unchanged.
+# Unset (default) defaults to 'auto' (serves 2026-07-28 stateless with legacy fallback).
+#   - auto       : serve both eras from one process (default).
 #   - 2026-07-28 : the new stateless spec (server/discover, per-request _meta,
 #                  Mcp-Method/Mcp-Name headers, cache hints, MRTR, extensions).
-#   - auto       : serve both eras from one process (validate mixed clients).
+#   - 2025-06-18 : the legacy 2025 sessionful spec.
 # Your @Tool/@Resource/@Prompt/@Widget code is identical either way.
 # =============================================================================
-# NITRO_MCP_PROTOCOL_VERSION=2026-07-28
+# NITRO_MCP_PROTOCOL_VERSION=auto

--- a/typescript/packages/cli/templates/typescript-starter/.env.example
+++ b/typescript/packages/cli/templates/typescript-starter/.env.example
@@ -11,3 +11,14 @@ NITROSTACK_APP_MODE=universal
 # PORT=3000
 # HOST=localhost
 # ENABLE_CORS=true
+
+# MCP Protocol Version (Optional)
+# =============================================================================
+# NITRO_MCP_PROTOCOL_VERSION selects which MCP wire revision NitroStack speaks.
+# Unset (default) keeps the current 2025-era sessionful behavior, unchanged.
+#   - 2026-07-28 : the new stateless spec (server/discover, per-request _meta,
+#                  Mcp-Method/Mcp-Name headers, cache hints, MRTR, extensions).
+#   - auto       : serve both eras from one process (validate mixed clients).
+# Your @Tool/@Resource/@Prompt/@Widget code is identical either way.
+# =============================================================================
+# NITRO_MCP_PROTOCOL_VERSION=2026-07-28

--- a/typescript/packages/cli/templates/typescript-starter/README.md
+++ b/typescript/packages/cli/templates/typescript-starter/README.md
@@ -34,6 +34,21 @@ development.
 - Download: <https://nitrostack.ai/studio>
 - Studio: <https://nitrostack.ai/studio>
 
+## MCP protocol version (optional)
+
+This server speaks the current 2025-era MCP transport by default. To opt into the
+new **2026-07-28** stateless spec (or serve both eras at once for validation),
+set an environment variable — no code changes are needed:
+
+```bash
+# new stateless spec only
+NITRO_MCP_PROTOCOL_VERSION=2026-07-28
+# both eras from one process (validate mixed clients)
+NITRO_MCP_PROTOCOL_VERSION=auto
+```
+
+Unset keeps today's behavior. See `.env.example` for details.
+
 ## Links
 
 - Docs: <https://docs.nitrostack.ai>

--- a/typescript/packages/cli/templates/typescript-starter/README.md
+++ b/typescript/packages/cli/templates/typescript-starter/README.md
@@ -36,18 +36,22 @@ development.
 
 ## MCP protocol version (optional)
 
-This server speaks the current 2025-era MCP transport by default. To opt into the
-new **2026-07-28** stateless spec (or serve both eras at once for validation),
-set an environment variable — no code changes are needed:
+This server runs in **`auto` mode by default**, dynamically serving both the new
+**2026-07-28** stateless spec and legacy 2025 JSON-RPC clients from a single endpoint.
+You can customize the wire revision via environment variable — no code changes are needed:
 
 ```bash
-# new stateless spec only
-NITRO_MCP_PROTOCOL_VERSION=2026-07-28
-# both eras from one process (validate mixed clients)
+# default (when unset): serve both modern and legacy statelessly
 NITRO_MCP_PROTOCOL_VERSION=auto
+
+# new stateless spec only (strict mode)
+NITRO_MCP_PROTOCOL_VERSION=2026-07-28
+
+# legacy 2025 sessionful wire
+NITRO_MCP_PROTOCOL_VERSION=2025-06-18
 ```
 
-Unset keeps today's behavior. See `.env.example` for details.
+See `.env.example` for details.
 
 ## Links
 

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -48,7 +48,9 @@
     "@modelcontextprotocol/ext-apps": ">=0.1.0"
   },
   "dependencies": {
+    "@modelcontextprotocol/node": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.0.4",
+    "@modelcontextprotocol/server": "^2.0.0",
     "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",

--- a/typescript/packages/core/package.json
+++ b/typescript/packages/core/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "npm run build && NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:stdio": "npm run build && node scripts/stdio-smoke-test.mjs",
     "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "prepublishOnly": "npm run build"
   },

--- a/typescript/packages/core/scripts/stdio-smoke-test.mjs
+++ b/typescript/packages/core/scripts/stdio-smoke-test.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * NitroStack Dedicated STDIO Smoke Test
+ *
+ * Runs an independent, standalone STDIO MCP server and MCP client,
+ * exercising the full JSON-RPC lifecycle:
+ *   1. Subprocess spawn & STDIO transport attachment
+ *   2. MCP initialize handshake
+ *   3. Tool discovery via tools/list
+ *   4. Tool execution via tools/call (hello tool)
+ *   5. Response assertion & clean shutdown
+ *
+ * Usage:
+ *   node scripts/stdio-smoke-test.mjs
+ */
+
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+
+// ============================================================================
+// Server Mode (Child Process)
+// ============================================================================
+if (process.argv.includes('--server')) {
+  const { NitroStackServer, Tool, z } = await import('../dist/core/index.js');
+
+  const server = new NitroStackServer({
+    name: 'stdio-smoke-server',
+    version: '2.0.0',
+    protocolVersion: '2026-07-28',
+  });
+
+  // Register 'hello' test tool
+  server.tool(
+    new Tool({
+      name: 'hello',
+      description: 'Greet someone by name',
+      inputSchema: z.object({
+        name: z.string().default('World').describe('Name of person to greet'),
+      }),
+      handler: async (args) => {
+        const target = args?.name || 'World';
+        return {
+          greeting: `Hello, ${target}! Welcome to NitroStack MCP 2.0.`,
+          timestamp: new Date().toISOString(),
+        };
+      },
+    }),
+  );
+
+  // Start server explicitly on STDIO
+  await server.start({ transport: 'stdio' });
+}
+
+// ============================================================================
+// Client Runner Mode (Main Process)
+// ============================================================================
+else {
+  console.log('🧪 Starting NitroStack STDIO Smoke Test...\n');
+
+  const child = spawn(process.execPath, [__filename, '--server'], {
+    env: {
+      ...process.env,
+      MCP_TRANSPORT_TYPE: 'stdio',
+      NITRO_MCP_PROTOCOL_VERSION: '2026-07-28',
+    },
+    stdio: ['pipe', 'pipe', 'inherit'],
+  });
+
+  let buffer = '';
+  const messageQueue = [];
+  const waiters = [];
+
+  child.stdout.on('data', (chunk) => {
+    buffer += chunk.toString('utf-8');
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const msg = JSON.parse(trimmed);
+        if (msg.jsonrpc === '2.0') {
+          if (waiters.length > 0) {
+            waiters.shift()(msg);
+          } else {
+            messageQueue.push(msg);
+          }
+        }
+      } catch {
+        // Ignore non-JSON lines
+      }
+    }
+  });
+
+  function sendRpc(msg) {
+    child.stdin.write(JSON.stringify(msg) + '\n');
+  }
+
+  function readNext(timeoutMs = 5000) {
+    if (messageQueue.length > 0) {
+      return Promise.resolve(messageQueue.shift());
+    }
+    return new Promise((res, rej) => {
+      const timer = setTimeout(() => {
+        rej(new Error(`Timed out waiting for response after ${timeoutMs}ms`));
+      }, timeoutMs);
+      waiters.push((msg) => {
+        clearTimeout(timer);
+        res(msg);
+      });
+    });
+  }
+
+  try {
+    // Step 1: Initialize
+    console.log('  [1/4] Sending MCP initialize handshake...');
+    sendRpc({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2026-07-28',
+        capabilities: {},
+        clientInfo: { name: 'stdio-smoke-client', version: '1.0.0' },
+      },
+    });
+
+    const initRes = await readNext();
+    if (initRes.error) {
+      throw new Error(`Initialize failed: ${JSON.stringify(initRes.error)}`);
+    }
+    console.log('  ✅ Initialize succeeded:');
+    console.log(`     - Server Name: ${initRes.result?.serverInfo?.name}`);
+    console.log(`     - Server Version: ${initRes.result?.serverInfo?.version}`);
+    console.log(`     - Capabilities: ${JSON.stringify(initRes.result?.capabilities)}`);
+
+    // Initialized notification
+    sendRpc({ jsonrpc: '2.0', method: 'notifications/initialized' });
+
+    // Step 2: Tool Discovery
+    console.log('\n  [2/4] Discovering tools via tools/list...');
+    sendRpc({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+
+    const listRes = await readNext();
+    if (listRes.error) {
+      throw new Error(`tools/list failed: ${JSON.stringify(listRes.error)}`);
+    }
+    const tools = listRes.result?.tools || [];
+    console.log(`  ✅ Discovered ${tools.length} tool(s):`);
+    for (const t of tools) {
+      console.log(`     - ${t.name}: ${t.description}`);
+    }
+
+    const hasHello = tools.some((t) => t.name === 'hello');
+    if (!hasHello) {
+      throw new Error("Required tool 'hello' not found in tools/list response");
+    }
+
+    // Step 3: Tool Execution
+    console.log('\n  [3/4] Calling tool hello(name="NitroEngineer")...');
+    sendRpc({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'hello',
+        arguments: { name: 'NitroEngineer' },
+      },
+    });
+
+    const callRes = await readNext();
+    if (callRes.error) {
+      throw new Error(`tools/call failed: ${JSON.stringify(callRes.error)}`);
+    }
+    console.log('  ✅ Tool executed successfully:');
+    const content = callRes.result?.content || [];
+    console.log(`     - Response: ${JSON.stringify(content)}`);
+
+    const textOut = content[0]?.text || '';
+    if (!textOut.includes('Hello, NitroEngineer!')) {
+      throw new Error(`Unexpected tool output: ${textOut}`);
+    }
+
+    // Step 4: Graceful Shutdown
+    console.log('\n  [4/4] Shutting down STDIO client and server process...');
+    child.stdin.end();
+    child.kill('SIGTERM');
+
+    await new Promise((res) => {
+      child.on('exit', (code, signal) => {
+        console.log(`  ✅ Server process exited cleanly (code: ${code}, signal: ${signal})`);
+        res();
+      });
+      setTimeout(() => {
+        child.kill('SIGKILL');
+        res();
+      }, 1500);
+    });
+
+    console.log('\n🎉 ALL STDIO SMOKE TESTS PASSED (100% Conformance)\n');
+    process.exit(0);
+  } catch (err) {
+    console.error(`\n❌ STDIO Smoke Test Failed:`, err);
+    child.kill('SIGKILL');
+    process.exit(1);
+  }
+}

--- a/typescript/packages/core/src/auth/cimd.ts
+++ b/typescript/packages/core/src/auth/cimd.ts
@@ -321,6 +321,8 @@ export async function readBoundedJson<T = unknown>(
   throw new Error('Unable to read response body');
 }
 
+export const DEFAULT_CIMD_FETCH_TIMEOUT_MS = 5000;
+
 /**
  * Resolve a client's CIMD by fetching its `client_id` URL and validating it.
  * Authorization servers call this in place of a DCR lookup.
@@ -332,6 +334,8 @@ export async function resolveClientIdMetadataDocument(
     allowLoopback?: boolean;
     dnsLookupImpl?: typeof dns.lookup;
     maxDocumentBytes?: number;
+    timeoutMs?: number;
+    signal?: AbortSignal;
   },
 ): Promise<ClientIdMetadataDocument> {
   const allowLoopback = options?.allowLoopback ?? (process.env.NODE_ENV !== 'production');
@@ -344,11 +348,35 @@ export async function resolveClientIdMetadataDocument(
     }
   }
 
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_CIMD_FETCH_TIMEOUT_MS;
+  const timeoutSignal = typeof AbortSignal.timeout === 'function'
+    ? AbortSignal.timeout(timeoutMs)
+    : (() => {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(new Error(`CIMD request timed out after ${timeoutMs}ms`)), timeoutMs);
+        if (typeof (timer as any).unref === 'function') (timer as any).unref();
+        return controller.signal;
+      })();
+
+  let effectiveSignal = timeoutSignal;
+  if (options?.signal) {
+    if (typeof AbortSignal.any === 'function') {
+      effectiveSignal = AbortSignal.any([options.signal, timeoutSignal]);
+    } else {
+      const controller = new AbortController();
+      const onAbort = () => controller.abort();
+      options.signal.addEventListener('abort', onAbort, { once: true });
+      timeoutSignal.addEventListener('abort', onAbort, { once: true });
+      effectiveSignal = controller.signal;
+    }
+  }
+
   const doFetch = options?.fetchImpl ?? fetch;
   const response = await doFetch(clientIdUrl, {
     method: 'GET',
     headers: { Accept: 'application/json' },
     redirect: 'error',
+    signal: effectiveSignal,
   });
   if (response.status !== 200) {
     throw new Error(`Failed to resolve CIMD from ${clientIdUrl}: HTTP ${response.status} (expected 200 OK)`);

--- a/typescript/packages/core/src/auth/cimd.ts
+++ b/typescript/packages/core/src/auth/cimd.ts
@@ -214,6 +214,68 @@ export async function assertSafeFetchTarget(
   }
 }
 
+export const MAX_CIMD_DOCUMENT_BYTES = 5120; // 5 KiB per draft-ietf-oauth-client-id-metadata-document-02 §4
+
+/**
+ * Reads response body up to maxBytes, throwing if exceeded.
+ */
+export async function readBoundedJson<T = unknown>(
+  response: Response,
+  maxBytes = MAX_CIMD_DOCUMENT_BYTES,
+): Promise<T> {
+  // Check Content-Length header first if present
+  const contentLength = response.headers?.get?.('content-length');
+  if (contentLength && parseInt(contentLength, 10) > maxBytes) {
+    throw new Error(`CIMD response exceeds maximum allowed size of ${maxBytes} bytes (Content-Length: ${contentLength})`);
+  }
+
+  if (response.body && typeof (response.body as any).getReader === 'function') {
+    const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          totalBytes += value.byteLength;
+          if (totalBytes > maxBytes) {
+            throw new Error(`CIMD response exceeds maximum allowed size of ${maxBytes} bytes`);
+          }
+          chunks.push(value);
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    const merged = Buffer.concat(chunks);
+    const text = merged.toString('utf8');
+    return JSON.parse(text) as T;
+  }
+
+  // Fallback if no streaming body or in mock environments
+  if (typeof response.text === 'function') {
+    const text = await response.text();
+    if (Buffer.byteLength(text, 'utf8') > maxBytes) {
+      throw new Error(`CIMD response exceeds maximum allowed size of ${maxBytes} bytes`);
+    }
+    return JSON.parse(text) as T;
+  }
+
+  if (typeof response.json === 'function') {
+    const data = await response.json();
+    const text = JSON.stringify(data);
+    if (Buffer.byteLength(text, 'utf8') > maxBytes) {
+      throw new Error(`CIMD response exceeds maximum allowed size of ${maxBytes} bytes`);
+    }
+    return data as T;
+  }
+
+  throw new Error('Unable to read response body');
+}
+
 /**
  * Resolve a client's CIMD by fetching its `client_id` URL and validating it.
  * Authorization servers call this in place of a DCR lookup.
@@ -224,20 +286,30 @@ export async function resolveClientIdMetadataDocument(
     fetchImpl?: typeof fetch;
     allowLoopback?: boolean;
     dnsLookupImpl?: typeof dns.lookup;
+    maxDocumentBytes?: number;
   },
 ): Promise<ClientIdMetadataDocument> {
   const allowLoopback = options?.allowLoopback ?? (process.env.NODE_ENV !== 'production');
   await assertSafeFetchTarget(clientIdUrl, allowLoopback, options?.dnsLookupImpl);
 
+  if (!/^https:\/\//i.test(clientIdUrl)) {
+    const isLoopback = /^http:\/\/(localhost|127\.0\.0\.1|\[::1\])(:|\/|$)/i.test(clientIdUrl);
+    if (!isLoopback || !allowLoopback) {
+      throw new Error(`CIMD client_id must be an HTTPS URL, got: ${clientIdUrl}`);
+    }
+  }
+
   const doFetch = options?.fetchImpl ?? fetch;
   const response = await doFetch(clientIdUrl, {
     method: 'GET',
     headers: { Accept: 'application/json' },
+    redirect: 'error',
   });
-  if (!response.ok) {
-    throw new Error(`Failed to resolve CIMD from ${clientIdUrl}: ${response.status}`);
+  if (response.status !== 200) {
+    throw new Error(`Failed to resolve CIMD from ${clientIdUrl}: HTTP ${response.status} (expected 200 OK)`);
   }
-  const doc = await response.json();
+  const maxBytes = options?.maxDocumentBytes ?? MAX_CIMD_DOCUMENT_BYTES;
+  const doc = await readBoundedJson(response, maxBytes);
   return validateClientIdMetadataDocument(doc, clientIdUrl);
 }
 

--- a/typescript/packages/core/src/auth/cimd.ts
+++ b/typescript/packages/core/src/auth/cimd.ts
@@ -84,14 +84,151 @@ export function validateClientIdMetadataDocument(
   return d as ClientIdMetadataDocument;
 }
 
+import net from 'net';
+import dns from 'dns/promises';
+
+/**
+ * Checks whether an IPv4 or IPv6 address belongs to RFC 6890 special-use or private ranges.
+ */
+export function isSpecialUseIp(ip: string): boolean {
+  if (net.isIPv4(ip)) {
+    const parts = ip.split('.').map(Number);
+    if (parts.length !== 4 || parts.some((n) => isNaN(n) || n < 0 || n > 255)) {
+      return true;
+    }
+    const [b0, b1] = parts;
+    // 0.0.0.0/8 (This host)
+    if (b0 === 0) return true;
+    // 10.0.0.0/8 (Private)
+    if (b0 === 10) return true;
+    // 100.64.0.0/10 (Carrier-Grade NAT)
+    if (b0 === 100 && b1 >= 64 && b1 <= 127) return true;
+    // 127.0.0.0/8 (Loopback)
+    if (b0 === 127) return true;
+    // 169.254.0.0/16 (Link-Local / Cloud Metadata)
+    if (b0 === 169 && b1 === 254) return true;
+    // 172.16.0.0/12 (Private)
+    if (b0 === 172 && b1 >= 16 && b1 <= 31) return true;
+    // 192.0.0.0/24, 192.0.2.0/24, 192.88.99.0/24
+    if (b0 === 192 && b1 === 0) return true;
+    // 192.168.0.0/16 (Private)
+    if (b0 === 192 && b1 === 168) return true;
+    // 198.18.0.0/15 (Benchmarking)
+    if (b0 === 198 && (b1 === 18 || b1 === 19)) return true;
+    // 198.51.100.0/24 (TEST-NET-2)
+    if (b0 === 198 && b1 === 51) return true;
+    // 203.0.113.0/24 (TEST-NET-3)
+    if (b0 === 203 && b1 === 0) return true;
+    // 224.0.0.0/4 (Multicast) and 240.0.0.0/4 (Reserved / Broadcast)
+    if (b0 >= 224) return true;
+    return false;
+  }
+
+  if (net.isIPv6(ip)) {
+    const normalized = ip.toLowerCase().trim();
+    // :: and ::1
+    if (normalized === '::' || normalized === '::1' || normalized === '0:0:0:0:0:0:0:0' || normalized === '0:0:0:0:0:0:0:1') {
+      return true;
+    }
+    // IPv4-mapped IPv6 (::ffff:x.x.x.x)
+    if (normalized.includes('::ffff:')) {
+      const v4Part = normalized.split('::ffff:')[1];
+      if (v4Part && net.isIPv4(v4Part)) {
+        return isSpecialUseIp(v4Part);
+      }
+    }
+    // Unique-Local fc00::/7 (fc.. or fd..)
+    if (normalized.startsWith('fc') || normalized.startsWith('fd')) {
+      return true;
+    }
+    // Link-Local fe80::/10 (fe8, fe9, fea, feb)
+    if (/^fe[89ab]/i.test(normalized)) {
+      return true;
+    }
+    // Multicast ff00::/8
+    if (normalized.startsWith('ff')) {
+      return true;
+    }
+    // Discard 100::/64
+    if (normalized.startsWith('100:')) {
+      return true;
+    }
+    // Documentation 2001:db8::/32
+    if (normalized.startsWith('2001:db8:') || normalized.startsWith('2001:0db8:')) {
+      return true;
+    }
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Asserts that a target URL does not resolve to an RFC 6890 special-use or private IP address.
+ */
+export async function assertSafeFetchTarget(
+  urlStr: string,
+  allowLoopback = false,
+  dnsLookupImpl?: typeof dns.lookup,
+): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(urlStr);
+  } catch {
+    throw new Error(`Invalid Client Identifier URL: "${urlStr}"`);
+  }
+
+  const hostname = url.hostname.replace(/^\[|\]$/g, '');
+
+  // Dev loopback exemption
+  if (allowLoopback && (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1')) {
+    return;
+  }
+
+  // If literal IP
+  if (net.isIP(hostname)) {
+    if (isSpecialUseIp(hostname)) {
+      throw new Error(`Blocked connection to special-use IP address: ${hostname}`);
+    }
+    return;
+  }
+
+  // DNS lookup
+  const lookupFn = dnsLookupImpl ?? dns.lookup;
+  try {
+    const res = await lookupFn(hostname, { all: true } as any);
+    const addresses = Array.isArray(res) ? res : [res];
+    if (!addresses || addresses.length === 0) {
+      throw new Error(`DNS resolution failed for ${hostname}: no addresses found`);
+    }
+    for (const addr of addresses) {
+      if (addr && addr.address && isSpecialUseIp(addr.address)) {
+        throw new Error(`CIMD destination ${hostname} resolved to special-use IP address: ${addr.address}`);
+      }
+    }
+  } catch (err: any) {
+    if (err.message && err.message.includes('special-use IP')) {
+      throw err;
+    }
+    throw new Error(`DNS lookup failed for ${hostname}: ${err.message || String(err)}`);
+  }
+}
+
 /**
  * Resolve a client's CIMD by fetching its `client_id` URL and validating it.
  * Authorization servers call this in place of a DCR lookup.
  */
 export async function resolveClientIdMetadataDocument(
   clientIdUrl: string,
-  options?: { fetchImpl?: typeof fetch },
+  options?: {
+    fetchImpl?: typeof fetch;
+    allowLoopback?: boolean;
+    dnsLookupImpl?: typeof dns.lookup;
+  },
 ): Promise<ClientIdMetadataDocument> {
+  const allowLoopback = options?.allowLoopback ?? (process.env.NODE_ENV !== 'production');
+  await assertSafeFetchTarget(clientIdUrl, allowLoopback, options?.dnsLookupImpl);
+
   const doFetch = options?.fetchImpl ?? fetch;
   const response = await doFetch(clientIdUrl, {
     method: 'GET',
@@ -111,3 +248,4 @@ export async function resolveClientIdMetadataDocument(
 export function isClientIdMetadataUrl(clientId: string): boolean {
   return /^https?:\/\//i.test(clientId);
 }
+

--- a/typescript/packages/core/src/auth/cimd.ts
+++ b/typescript/packages/core/src/auth/cimd.ts
@@ -387,10 +387,18 @@ export async function resolveClientIdMetadataDocument(
 }
 
 /**
- * Whether a string looks like a CIMD-style client id (an HTTP/HTTPS URL) rather
+ * Whether a string looks like a CIMD-style client id (a valid HTTP/HTTPS URL) rather
  * than an opaque DCR-issued id.
  */
 export function isClientIdMetadataUrl(clientId: string): boolean {
-  return /^https?:\/\//i.test(clientId);
+  if (typeof clientId !== 'string' || !clientId.trim()) {
+    return false;
+  }
+  try {
+    const parsed = new URL(clientId);
+    return (parsed.protocol === 'https:' || parsed.protocol === 'http:') && Boolean(parsed.hostname);
+  } catch {
+    return false;
+  }
 }
 

--- a/typescript/packages/core/src/auth/cimd.ts
+++ b/typescript/packages/core/src/auth/cimd.ts
@@ -38,6 +38,56 @@ export interface ClientIdMetadataDocument {
 }
 
 /**
+ * Strict validation of a Client Identifier URL per draft-ietf-oauth-client-id-metadata-document-02 §2.
+ */
+export function validateClientIdentifierUrl(urlStr: string, allowLoopback = true): URL {
+  if (typeof urlStr !== 'string' || !urlStr) {
+    throw new Error(`Invalid Client Identifier URL: "${urlStr}"`);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(urlStr);
+  } catch {
+    throw new Error(`Invalid Client Identifier URL: "${urlStr}"`);
+  }
+
+  // Scheme check
+  if (parsed.protocol !== 'https:') {
+    const isLoopback = allowLoopback && parsed.protocol === 'http:' &&
+      (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '[::1]' || parsed.hostname === '::1');
+    if (!isLoopback) {
+      throw new Error(`CIMD client_id must be an HTTPS URL, got: "${urlStr}"`);
+    }
+  }
+
+  // Userinfo check
+  if (parsed.username || parsed.password) {
+    throw new Error(`CIMD client_id URL must not contain userinfo: "${urlStr}"`);
+  }
+
+  // Fragment check
+  if (parsed.hash) {
+    throw new Error(`CIMD client_id URL must not contain a fragment component: "${urlStr}"`);
+  }
+
+  // Path check (must not be bare domain / empty path)
+  const rawPath = urlStr.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/[^/?#]+/, '');
+  if (!rawPath || rawPath === '/' || !parsed.pathname || parsed.pathname === '/') {
+    throw new Error(`CIMD client_id URL must contain a path component (cannot be bare domain): "${urlStr}"`);
+  }
+
+  // Dot segments check
+  const pathWithoutQuery = rawPath.split('?')[0].split('#')[0];
+  const segments = pathWithoutQuery.split('/');
+  if (segments.some((seg) => seg === '.' || seg === '..')) {
+    throw new Error(`CIMD client_id URL must not contain single-dot or double-dot path segments: "${urlStr}"`);
+  }
+
+  return parsed;
+}
+
+/**
  * Build a Client ID Metadata Document for this client.
  *
  * @param clientIdUrl - The HTTPS URL the document will be served from. Becomes
@@ -46,14 +96,9 @@ export interface ClientIdMetadataDocument {
 export function createClientIdMetadataDocument(
   clientIdUrl: string,
   metadata: { redirect_uris: string[] } & Partial<Omit<ClientIdMetadataDocument, 'client_id' | 'redirect_uris'>>,
+  options?: { allowLoopback?: boolean },
 ): ClientIdMetadataDocument {
-  if (!/^https:\/\//i.test(clientIdUrl)) {
-    // CIMD requires HTTPS (loopback http is only tolerated in dev).
-    const isLoopback = /^http:\/\/(localhost|127\.0\.0\.1|\[::1\])(:|\/|$)/i.test(clientIdUrl);
-    if (!isLoopback) {
-      throw new Error(`CIMD client_id must be an HTTPS URL, got: ${clientIdUrl}`);
-    }
-  }
+  validateClientIdentifierUrl(clientIdUrl, options?.allowLoopback ?? true);
   return { ...metadata, client_id: clientIdUrl };
 }
 

--- a/typescript/packages/core/src/auth/cimd.ts
+++ b/typescript/packages/core/src/auth/cimd.ts
@@ -1,0 +1,113 @@
+/**
+ * Client ID Metadata Documents (CIMD).
+ *
+ * The final MCP 2026-07-28 authorization spec **deprecates Dynamic Client
+ * Registration (DCR)** in favor of CIMD: a client uses an HTTPS URL as its
+ * `client_id`, and that URL resolves to a JSON document describing the client
+ * (redirect URIs, grant types, etc.). Authorization servers fetch and cache the
+ * document instead of running a registration endpoint.
+ *
+ * This module provides:
+ * - a publisher that serves a client's own metadata document at a stable URL, and
+ * - a resolver that fetches and validates a client's CIMD URL.
+ *
+ * DCR remains available on the legacy path and as an opt-in; CIMD is the
+ * recommended mechanism on 2026-07-28.
+ *
+ * @module
+ */
+
+/**
+ * A Client ID Metadata Document (OAuth client metadata, RFC 7591 shape).
+ * The `client_id` MUST equal the HTTPS URL the document is served from.
+ */
+export interface ClientIdMetadataDocument {
+  /** The HTTPS URL this document is published at (also the OAuth `client_id`). */
+  client_id: string;
+  client_name?: string;
+  redirect_uris: string[];
+  grant_types?: string[];
+  response_types?: string[];
+  token_endpoint_auth_method?: string;
+  scope?: string;
+  application_type?: 'web' | 'native';
+  logo_uri?: string;
+  client_uri?: string;
+  contacts?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * Build a Client ID Metadata Document for this client.
+ *
+ * @param clientIdUrl - The HTTPS URL the document will be served from. Becomes
+ *   the `client_id`.
+ */
+export function createClientIdMetadataDocument(
+  clientIdUrl: string,
+  metadata: { redirect_uris: string[] } & Partial<Omit<ClientIdMetadataDocument, 'client_id' | 'redirect_uris'>>,
+): ClientIdMetadataDocument {
+  if (!/^https:\/\//i.test(clientIdUrl)) {
+    // CIMD requires HTTPS (loopback http is only tolerated in dev).
+    const isLoopback = /^http:\/\/(localhost|127\.0\.0\.1|\[::1\])(:|\/|$)/i.test(clientIdUrl);
+    if (!isLoopback) {
+      throw new Error(`CIMD client_id must be an HTTPS URL, got: ${clientIdUrl}`);
+    }
+  }
+  return { ...metadata, client_id: clientIdUrl };
+}
+
+/**
+ * Validate that a resolved document is a well-formed CIMD whose `client_id`
+ * matches the URL it was fetched from (prevents impersonation).
+ */
+export function validateClientIdMetadataDocument(
+  doc: unknown,
+  sourceUrl: string,
+): ClientIdMetadataDocument {
+  if (!doc || typeof doc !== 'object') {
+    throw new Error('CIMD is not an object');
+  }
+  const d = doc as Record<string, unknown>;
+  if (typeof d.client_id !== 'string') {
+    throw new Error('CIMD is missing a string `client_id`');
+  }
+  const normalize = (u: string): string => u.replace(/\/+$/, '');
+  if (normalize(d.client_id) !== normalize(sourceUrl)) {
+    throw new Error(
+      `CIMD client_id "${d.client_id}" does not match the document URL "${sourceUrl}"`,
+    );
+  }
+  if (!Array.isArray(d.redirect_uris) || d.redirect_uris.some((u) => typeof u !== 'string')) {
+    throw new Error('CIMD `redirect_uris` must be an array of strings');
+  }
+  return d as ClientIdMetadataDocument;
+}
+
+/**
+ * Resolve a client's CIMD by fetching its `client_id` URL and validating it.
+ * Authorization servers call this in place of a DCR lookup.
+ */
+export async function resolveClientIdMetadataDocument(
+  clientIdUrl: string,
+  options?: { fetchImpl?: typeof fetch },
+): Promise<ClientIdMetadataDocument> {
+  const doFetch = options?.fetchImpl ?? fetch;
+  const response = await doFetch(clientIdUrl, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to resolve CIMD from ${clientIdUrl}: ${response.status}`);
+  }
+  const doc = await response.json();
+  return validateClientIdMetadataDocument(doc, clientIdUrl);
+}
+
+/**
+ * Whether a string looks like a CIMD-style client id (an HTTP/HTTPS URL) rather
+ * than an opaque DCR-issued id.
+ */
+export function isClientIdMetadataUrl(clientId: string): boolean {
+  return /^https?:\/\//i.test(clientId);
+}

--- a/typescript/packages/core/src/auth/client.ts
+++ b/typescript/packages/core/src/auth/client.ts
@@ -156,6 +156,17 @@ export class OAuth2Client {
     registrationEndpoint: string,
     metadata: ClientRegistrationRequest
   ): Promise<ClientRegistrationResponse> {
+    // SEP-837: default application_type to 'native' when every redirect URI is
+    // loopback (CLI/desktop), so the AS accepts localhost redirects; otherwise
+    // 'web'. An explicit value from the caller always wins.
+    if (metadata.application_type === undefined) {
+      const allLoopback =
+        Array.isArray(metadata.redirect_uris) &&
+        metadata.redirect_uris.length > 0 &&
+        metadata.redirect_uris.every((uri) => OAuth2Client.isLoopbackRedirect(uri));
+      metadata = { ...metadata, application_type: allLoopback ? 'native' : 'web' };
+    }
+
     const response = await fetch(registrationEndpoint, {
       method: 'POST',
       headers: {
@@ -195,6 +206,12 @@ export class OAuth2Client {
     scope?: string;
     resource?: string;
     state?: string;
+    /**
+     * OIDC `prompt` value (SEP-2207). Set to `consent` when an OpenID Connect
+     * authorization server requires re-consent to issue a refresh token
+     * (typically alongside the `offline_access` scope).
+     */
+    prompt?: string;
   }): Promise<{
     authUrl: string;
     state: string;
@@ -223,6 +240,12 @@ export class OAuth2Client {
     if (options.resource) {
       // RFC 8707 - Resource Indicators
       params.append('resource', options.resource);
+    }
+
+    if (options.prompt) {
+      // SEP-2207: OIDC authorization servers may need prompt=consent to
+      // (re-)issue a refresh token for offline_access.
+      params.append('prompt', options.prompt);
     }
 
     const authUrl = `${options.authorizationEndpoint}?${params.toString()}`;
@@ -459,6 +482,45 @@ export class OAuth2Client {
    */
   private generateState(): string {
     return crypto.randomBytes(16).toString('hex');
+  }
+
+  /**
+   * Whether a redirect URI targets loopback (localhost / 127.0.0.1 / [::1]),
+   * used to infer `application_type: 'native'` for DCR (SEP-837).
+   */
+  static isLoopbackRedirect(uri: string): boolean {
+    try {
+      const host = new URL(uri).hostname;
+      return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Validate the issuer returned on an authorization response (RFC 9207 /
+   * SEP-2468). MCP 2026-07-28 clients MUST verify the `iss` parameter on the
+   * authorization redirect matches the authorization server's issuer to defend
+   * against mix-up attacks. Throws on mismatch.
+   *
+   * @param receivedIss - `iss` query parameter from the authorization redirect.
+   * @param expectedIssuer - Issuer from the AS metadata used to start the flow.
+   */
+  static validateAuthorizationIssuer(receivedIss: string | undefined | null, expectedIssuer: string): void {
+    // RFC 9207: if the AS advertised authorization_response_iss_parameter_supported
+    // the client MUST validate iss. A missing iss from such an AS is a failure;
+    // callers that know the AS omits it can skip this call.
+    if (receivedIss === undefined || receivedIss === null || receivedIss === '') {
+      throw new Error(
+        'Authorization response is missing the required `iss` parameter (RFC 9207 / SEP-2468).'
+      );
+    }
+    const normalize = (u: string): string => u.replace(/\/+$/, '');
+    if (normalize(receivedIss) !== normalize(expectedIssuer)) {
+      throw new Error(
+        `Authorization response issuer mismatch (RFC 9207 / SEP-2468): expected "${expectedIssuer}", got "${receivedIss}".`
+      );
+    }
   }
 }
 

--- a/typescript/packages/core/src/auth/index.ts
+++ b/typescript/packages/core/src/auth/index.ts
@@ -103,7 +103,17 @@ export {
   isTokenExpired,
   calculateExpiration,
   tokenResponseToStored,
+  getIssuerBoundToken,
 } from './token-store.js';
+
+// Client ID Metadata Documents (CIMD) — the 2026-07-28 DCR replacement.
+export {
+  createClientIdMetadataDocument,
+  validateClientIdMetadataDocument,
+  resolveClientIdMetadataDocument,
+  isClientIdMetadataUrl,
+  type ClientIdMetadataDocument,
+} from './cimd.js';
 
 // Server integration helpers
 export {

--- a/typescript/packages/core/src/auth/index.ts
+++ b/typescript/packages/core/src/auth/index.ts
@@ -110,6 +110,7 @@ export {
 export {
   createClientIdMetadataDocument,
   validateClientIdMetadataDocument,
+  validateClientIdentifierUrl,
   resolveClientIdMetadataDocument,
   isClientIdMetadataUrl,
   isSpecialUseIp,

--- a/typescript/packages/core/src/auth/index.ts
+++ b/typescript/packages/core/src/auth/index.ts
@@ -112,6 +112,10 @@ export {
   validateClientIdMetadataDocument,
   resolveClientIdMetadataDocument,
   isClientIdMetadataUrl,
+  isSpecialUseIp,
+  assertSafeFetchTarget,
+  readBoundedJson,
+  MAX_CIMD_DOCUMENT_BYTES,
   type ClientIdMetadataDocument,
 } from './cimd.js';
 

--- a/typescript/packages/core/src/auth/index.ts
+++ b/typescript/packages/core/src/auth/index.ts
@@ -117,6 +117,7 @@ export {
   assertSafeFetchTarget,
   readBoundedJson,
   MAX_CIMD_DOCUMENT_BYTES,
+  DEFAULT_CIMD_FETCH_TIMEOUT_MS,
   type ClientIdMetadataDocument,
 } from './cimd.js';
 

--- a/typescript/packages/core/src/auth/middleware.ts
+++ b/typescript/packages/core/src/auth/middleware.ts
@@ -71,9 +71,17 @@ export function createAuthMiddleware(config: McpAuthConfig): RequestHandler {
         return next();
       }
 
-      // 1. Extract Bearer token from Authorization header
-      const authHeader = req.headers.authorization;
-      const token = extractBearerToken(authHeader);
+      // 1. Extract Bearer token from Authorization header or body metadata
+      const rawHeader = req.headers.authorization || (req.headers as any).Authorization;
+      const metaToken = (req.body?.params?._meta?.jwtToken ||
+        req.body?.params?._meta?.token ||
+        req.body?.params?._meta?._oauth ||
+        req.body?.params?.arguments?._meta?.jwtToken ||
+        req.body?.params?.arguments?._meta?.token ||
+        req.body?._meta?.jwtToken ||
+        req.body?._meta?.token) as string | undefined;
+      const authCandidate = (Array.isArray(rawHeader) ? rawHeader[0] : rawHeader) || metaToken;
+      const token = extractBearerToken(authCandidate);
 
       if (!token) {
         // No token provided - return 401 with WWW-Authenticate challenge

--- a/typescript/packages/core/src/auth/middleware.ts
+++ b/typescript/packages/core/src/auth/middleware.ts
@@ -59,8 +59,12 @@ export function createAuthMiddleware(config: McpAuthConfig): RequestHandler {
       const isWellKnown = (req.path || '').startsWith('/.well-known/');
       const isDiscoveryMethod =
         method === 'initialize' ||
+        // MCP 2026-07-28 (SEP-2575) replaces `initialize` with `server/discover`;
+        // bypass it like the legacy handshake so clients can enumerate before auth.
+        method === 'server/discover' ||
         method === 'tools/list' ||
         method === 'resources/list' ||
+        method === 'resources/templates/list' ||
         method === 'prompts/list';
 
       if (isPreflight || isWellKnown || isDiscoveryMethod) {

--- a/typescript/packages/core/src/auth/server-metadata.ts
+++ b/typescript/packages/core/src/auth/server-metadata.ts
@@ -32,11 +32,17 @@ export function createProtectedResourceMetadata(
  * Per RFC 9728, can be at:
  * 1. Resource path: /.well-known/oauth-protected-resource{path}
  * 2. Root: /.well-known/oauth-protected-resource
+ *
+ * SEP-2351 audit: for path-component issuers the `.well-known` segment is
+ * inserted between the origin and the issuer path (not appended after it),
+ * which is exactly what this function does. The client-side discovery in
+ * `client.ts#discoverAuthorizationServer` follows the same insertion rule.
  */
 export function getWellKnownMetadataUris(resourceUrl: URL): string[] {
   const urls: string[] = [];
   
-  // Method 1: At the path of the resource
+  // Method 1: At the path of the resource (suffix inserted after the
+  // well-known segment, per RFC 9728 / SEP-2351).
   if (resourceUrl.pathname && resourceUrl.pathname !== '/') {
     const pathUri = new URL('/.well-known/oauth-protected-resource' + resourceUrl.pathname, resourceUrl.origin);
     urls.push(pathUri.toString());

--- a/typescript/packages/core/src/auth/token-store.ts
+++ b/typescript/packages/core/src/auth/token-store.ts
@@ -272,7 +272,8 @@ export function calculateExpiration(expiresIn: number): number {
  */
 export function tokenResponseToStored(
   response: { access_token: string; token_type: 'Bearer'; expires_in?: number; refresh_token?: string; scope?: string },
-  resource?: string
+  resource?: string,
+  issuer?: string,
 ): StoredToken {
   return {
     access_token: response.access_token,
@@ -281,6 +282,32 @@ export function tokenResponseToStored(
     refresh_token: response.refresh_token,
     scope: response.scope,
     resource,
+    ...(issuer ? { issuer } : {}),
   };
+}
+
+/**
+ * SEP-2352: fetch a stored token only if it is bound to the expected issuer.
+ *
+ * When a resource migrates to a different authorization server, credentials
+ * bound to the previous issuer MUST NOT be reused. If the stored token has a
+ * recorded `issuer` that differs from `expectedIssuer`, it is deleted and
+ * `null` is returned so the caller re-registers / re-authorizes against the
+ * new issuer. Tokens with no recorded issuer are returned unchanged (backward
+ * compatible with pre-2352 stores).
+ */
+export async function getIssuerBoundToken(
+  store: TokenStore,
+  key: string,
+  expectedIssuer: string,
+): Promise<StoredToken | null> {
+  const token = await store.getToken(key);
+  if (!token) return null;
+  const normalize = (u: string): string => u.replace(/\/+$/, '');
+  if (token.issuer && normalize(token.issuer) !== normalize(expectedIssuer)) {
+    await store.deleteToken(key);
+    return null;
+  }
+  return token;
 }
 

--- a/typescript/packages/core/src/auth/token-validation.ts
+++ b/typescript/packages/core/src/auth/token-validation.ts
@@ -157,11 +157,18 @@ export async function validateJWT(
     jwksFetchers.set(config.jwksUri, JWKS);
   }
 
+  // Support issuers with or without trailing slashes
+  let issuers: string[] | undefined;
+  if (config.issuer) {
+    const rawIss = config.issuer.replace(/\/+$/, '');
+    issuers = [rawIss, `${rawIss}/`];
+  }
+
   // Verify JWT
   const { payload } = await joseLib.jwtVerify(token, JWKS, {
-    issuer: config.issuer,
+    issuer: issuers || config.issuer,
     audience: config.audience,
-    clockTolerance: 30,
+    clockTolerance: 60,
   });
 
   // Convert JWT payload to TokenIntrospection format

--- a/typescript/packages/core/src/auth/token-validation.ts
+++ b/typescript/packages/core/src/auth/token-validation.ts
@@ -238,15 +238,23 @@ export function validateScopes(
 }
 
 /**
- * Extract Bearer token from Authorization header
+ * Extract Bearer token from Authorization header or raw token string
  */
 export function extractBearerToken(authHeader: string | undefined): string | null {
-  if (!authHeader) {
+  if (!authHeader || typeof authHeader !== 'string') {
     return null;
   }
 
-  const match = authHeader.match(/^Bearer\s+(.+)$/i);
-  return match ? match[1] : null;
+  const trimmed = authHeader.trim();
+  const match = trimmed.match(/^Bearer\s+(.+)$/i);
+  if (match) {
+    return match[1].trim();
+  }
+  // If it's a raw JWT token directly provided
+  if (trimmed.startsWith('ey') && trimmed.split('.').length === 3) {
+    return trimmed;
+  }
+  return null;
 }
 
 /**

--- a/typescript/packages/core/src/auth/types.ts
+++ b/typescript/packages/core/src/auth/types.ts
@@ -12,6 +12,10 @@ export interface TokenResponse {
   expires_in?: number;
   refresh_token?: string;
   scope?: string;
+  /** OpenID Connect ID token (present for OIDC-style authorization servers). */
+  id_token?: string;
+  /** Issuer identifier echoed by some authorization servers (RFC 9207). */
+  iss?: string;
 }
 
 /**
@@ -76,6 +80,13 @@ export interface ClientRegistrationRequest {
   token_endpoint_auth_method?: string;
   grant_types?: string[];
   response_types?: string[];
+  /**
+   * OAuth 2.0 Dynamic Client Registration `application_type` (SEP-837).
+   * `native` for CLI/desktop clients so localhost/loopback redirect URIs are
+   * accepted; `web` otherwise. NitroStack infers `native` from loopback
+   * redirect URIs when not set explicitly.
+   */
+  application_type?: 'web' | 'native';
   client_name?: string;
   client_uri?: string;
   logo_uri?: string;
@@ -233,6 +244,12 @@ export interface StoredToken {
   refresh_token?: string;
   scope?: string;
   resource?: string;
+  /**
+   * Issuer the credentials are bound to (SEP-2352). When a resource migrates
+   * to a different authorization server, credentials bound to the previous
+   * issuer must not be reused — re-register/re-authorize against the new one.
+   */
+  issuer?: string;
 }
 
 /**

--- a/typescript/packages/core/src/core/__tests__/final.blitz.test.ts
+++ b/typescript/packages/core/src/core/__tests__/final.blitz.test.ts
@@ -99,10 +99,10 @@ describe('Final Blitz Coverage Tests', () => {
             await server.start();
             expect((server as any)._transportType).toBe('dual');
 
-            // The HTTP host is created and a per-session MCP server factory wired in.
+            // The HTTP host is created and a handler / MCP server factory wired in.
             const httpTransport = (server as any)._httpTransport;
             expect(httpTransport).toBeDefined();
-            expect((httpTransport as any).mcpServerFactory).toBeInstanceOf(Function);
+            expect((httpTransport as any).modernHandler || (httpTransport as any).mcpServerFactory).toBeInstanceOf(Function);
 
             await server.stop();
         });
@@ -120,14 +120,14 @@ describe('Final Blitz Coverage Tests', () => {
 
             await server.start();
             expect((server as any)._transportType).toBe('http');
-            expect(((server as any)._httpTransport as any).mcpServerFactory).toBeInstanceOf(Function);
+            expect(((server as any)._httpTransport as any).modernHandler || ((server as any)._httpTransport as any).mcpServerFactory).toBeInstanceOf(Function);
 
             await server.stop();
         });
 
         it('should handle start failure and log error', async () => {
             process.env.MCP_TRANSPORT_TYPE = 'stdio';
-            const server = new NitroStackServer({ name: 'FailServer', version: '1' });
+            const server = new NitroStackServer({ name: 'FailServer', version: '1', protocolVersion: '2025-06-18' });
             (server as any).mcpServer = {
                 connect: (jest.fn() as any).mockImplementation(() => Promise.reject(new Error('Connect failed'))),
                 close: (jest.fn() as any).mockImplementation(() => Promise.resolve())

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/auth-hardening.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/auth-hardening.test.ts
@@ -144,7 +144,8 @@ describe('CIMD (Client ID Metadata Documents)', () => {
         status: 200,
         json: async () => ({ client_id: url, redirect_uris: ['https://client.example.com/cb'] }),
       }) as unknown as Response) as unknown as typeof fetch;
-    const doc = await resolveClientIdMetadataDocument(url, { fetchImpl });
+    const dnsLookupImpl = (async () => [{ address: '93.184.216.34', family: 4 }]) as any;
+    const doc = await resolveClientIdMetadataDocument(url, { fetchImpl, dnsLookupImpl });
     expect(doc.client_id).toBe(url);
   });
 
@@ -153,4 +154,28 @@ describe('CIMD (Client ID Metadata Documents)', () => {
     expect(isClientIdMetadataUrl('https://client.example.com/id.json')).toBe(true);
     expect(isClientIdMetadataUrl('abc123-opaque-dcr-id')).toBe(false);
   });
+
+  it('blocks CIMD resolution targeting RFC 6890 cloud metadata and private IP addresses (SSRF defense)', async () => {
+    const { resolveClientIdMetadataDocument } = await import('../../../auth/cimd.js');
+
+    // Cloud metadata literal IP
+    await expect(
+      resolveClientIdMetadataDocument('http://169.254.169.254/latest/meta-data', { allowLoopback: false })
+    ).rejects.toThrow(/special-use IP/i);
+
+    // RFC 1918 private literal IP
+    await expect(
+      resolveClientIdMetadataDocument('http://10.0.0.1/id.json', { allowLoopback: false })
+    ).rejects.toThrow(/special-use IP/i);
+
+    // Hostname resolving to private IP via DNS lookup
+    const dnsResolvingPrivate = (async () => [{ address: '192.168.1.50', family: 4 }]) as any;
+    await expect(
+      resolveClientIdMetadataDocument('https://internal.example.com/id.json', {
+        allowLoopback: false,
+        dnsLookupImpl: dnsResolvingPrivate,
+      })
+    ).rejects.toThrow(/special-use IP/i);
+  });
 });
+

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/auth-hardening.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/auth-hardening.test.ts
@@ -285,5 +285,55 @@ describe('CIMD (Client ID Metadata Documents)', () => {
       ).toThrow(/dot/i);
     });
   });
+
+  describe('CIMD Request Timeout & AbortSignal (F-06-02)', () => {
+    it('aborts when document fetch exceeds configured timeout', async () => {
+      const { resolveClientIdMetadataDocument, DEFAULT_CIMD_FETCH_TIMEOUT_MS } = await import('../../../auth/cimd.js');
+      expect(DEFAULT_CIMD_FETCH_TIMEOUT_MS).toBe(5000);
+
+      const slowFetch = (async (_url: string, init?: RequestInit) => {
+        return new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new Error('The operation was aborted')));
+        });
+      }) as unknown as typeof fetch;
+
+      const dnsLookupImpl = (async () => [{ address: '93.184.216.34', family: 4 }]) as any;
+
+      await expect(
+        resolveClientIdMetadataDocument('https://client.example.com/id.json', {
+          fetchImpl: slowFetch,
+          dnsLookupImpl,
+          timeoutMs: 50,
+        })
+      ).rejects.toThrow(/aborted/i);
+    });
+
+    it('propagates caller-supplied AbortSignal', async () => {
+      const { resolveClientIdMetadataDocument } = await import('../../../auth/cimd.js');
+      const controller = new AbortController();
+      controller.abort();
+
+      const mockFetch = (async (_url: string, init?: RequestInit) => {
+        if (init?.signal?.aborted) {
+          throw new Error('This operation was aborted');
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ client_id: 'https://client.example.com/id.json', redirect_uris: [] }),
+        } as unknown as Response;
+      }) as unknown as typeof fetch;
+
+      const dnsLookupImpl = (async () => [{ address: '93.184.216.34', family: 4 }]) as any;
+
+      await expect(
+        resolveClientIdMetadataDocument('https://client.example.com/id.json', {
+          fetchImpl: mockFetch,
+          dnsLookupImpl,
+          signal: controller.signal,
+        })
+      ).rejects.toThrow(/aborted/i);
+    });
+  });
 });
 

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/auth-hardening.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/auth-hardening.test.ts
@@ -1,0 +1,156 @@
+/**
+ * 2026-07-28 authorization hardening.
+ *
+ * Covers RFC 9207 `iss` validation (SEP-2468), `application_type` inference
+ * (SEP-837), issuer-bound credentials (SEP-2352), and Client ID Metadata
+ * Documents (CIMD, the final-spec DCR replacement). All additive; the legacy
+ * DCR path is unchanged.
+ */
+
+describe('SEP-2468 / RFC 9207 iss validation', () => {
+  it('accepts a matching issuer (ignoring trailing slash)', async () => {
+    const { OAuth2Client } = await import('../../../auth/client.js');
+    expect(() =>
+      OAuth2Client.validateAuthorizationIssuer('https://as.example.com', 'https://as.example.com/'),
+    ).not.toThrow();
+  });
+
+  it('throws on an issuer mismatch (mix-up defense)', async () => {
+    const { OAuth2Client } = await import('../../../auth/client.js');
+    expect(() =>
+      OAuth2Client.validateAuthorizationIssuer('https://evil.example.com', 'https://as.example.com'),
+    ).toThrow(/issuer mismatch/i);
+  });
+
+  it('throws when iss is missing entirely', async () => {
+    const { OAuth2Client } = await import('../../../auth/client.js');
+    expect(() => OAuth2Client.validateAuthorizationIssuer(undefined, 'https://as.example.com')).toThrow(
+      /missing the required `iss`/i,
+    );
+  });
+});
+
+describe('SEP-837 application_type inference', () => {
+  it('recognizes loopback redirect URIs', async () => {
+    const { OAuth2Client } = await import('../../../auth/client.js');
+    expect(OAuth2Client.isLoopbackRedirect('http://localhost:8080/cb')).toBe(true);
+    expect(OAuth2Client.isLoopbackRedirect('http://127.0.0.1/cb')).toBe(true);
+    expect(OAuth2Client.isLoopbackRedirect('https://app.example.com/cb')).toBe(false);
+    expect(OAuth2Client.isLoopbackRedirect('not a url')).toBe(false);
+  });
+});
+
+describe('SEP-2352 issuer-bound credentials', () => {
+  it('returns a token whose issuer matches the expected issuer', async () => {
+    const { MemoryTokenStore, getIssuerBoundToken } = await import('../../../auth/token-store.js');
+    const store = new MemoryTokenStore();
+    await store.saveToken('svc', {
+      access_token: 'a',
+      token_type: 'Bearer',
+      expires_at: Date.now() + 3_600_000,
+      issuer: 'https://as.example.com',
+    });
+    const token = await getIssuerBoundToken(store, 'svc', 'https://as.example.com/');
+    expect(token?.access_token).toBe('a');
+  });
+
+  it('drops a token bound to a different issuer and returns null', async () => {
+    const { MemoryTokenStore, getIssuerBoundToken } = await import('../../../auth/token-store.js');
+    const store = new MemoryTokenStore();
+    await store.saveToken('svc', {
+      access_token: 'a',
+      token_type: 'Bearer',
+      expires_at: Date.now() + 3_600_000,
+      issuer: 'https://old-as.example.com',
+    });
+    const token = await getIssuerBoundToken(store, 'svc', 'https://new-as.example.com');
+    expect(token).toBeNull();
+    // The stale credential must be removed.
+    expect(await store.getToken('svc')).toBeNull();
+  });
+
+  it('is backward compatible with tokens that have no recorded issuer', async () => {
+    const { MemoryTokenStore, getIssuerBoundToken, tokenResponseToStored } = await import(
+      '../../../auth/token-store.js'
+    );
+    const store = new MemoryTokenStore();
+    await store.saveToken('svc', tokenResponseToStored({ access_token: 'a', token_type: 'Bearer', expires_in: 3600 }));
+    const token = await getIssuerBoundToken(store, 'svc', 'https://as.example.com');
+    expect(token?.access_token).toBe('a');
+  });
+
+  it('records the issuer when converting a token response', async () => {
+    const { tokenResponseToStored } = await import('../../../auth/token-store.js');
+    const stored = tokenResponseToStored(
+      { access_token: 'a', token_type: 'Bearer', expires_in: 3600 },
+      'https://api.example.com',
+      'https://as.example.com',
+    );
+    expect(stored.issuer).toBe('https://as.example.com');
+    expect(stored.resource).toBe('https://api.example.com');
+  });
+});
+
+describe('CIMD (Client ID Metadata Documents)', () => {
+  it('builds a document whose client_id is the HTTPS URL', async () => {
+    const { createClientIdMetadataDocument } = await import('../../../auth/cimd.js');
+    const doc = createClientIdMetadataDocument('https://client.example.com/id.json', {
+      redirect_uris: ['https://client.example.com/cb'],
+      client_name: 'Example',
+    });
+    expect(doc.client_id).toBe('https://client.example.com/id.json');
+    expect(doc.redirect_uris).toEqual(['https://client.example.com/cb']);
+  });
+
+  it('rejects a non-HTTPS, non-loopback client_id URL', async () => {
+    const { createClientIdMetadataDocument } = await import('../../../auth/cimd.js');
+    expect(() =>
+      createClientIdMetadataDocument('http://client.example.com/id.json', {
+        redirect_uris: ['https://client.example.com/cb'],
+      }),
+    ).toThrow(/HTTPS/i);
+  });
+
+  it('allows loopback http during development', async () => {
+    const { createClientIdMetadataDocument } = await import('../../../auth/cimd.js');
+    const doc = createClientIdMetadataDocument('http://localhost:3000/id.json', {
+      redirect_uris: ['http://localhost:3000/cb'],
+    });
+    expect(doc.client_id).toBe('http://localhost:3000/id.json');
+  });
+
+  it('validates that client_id matches the source URL (anti-impersonation)', async () => {
+    const { validateClientIdMetadataDocument } = await import('../../../auth/cimd.js');
+    const good = validateClientIdMetadataDocument(
+      { client_id: 'https://client.example.com/id.json', redirect_uris: ['https://client.example.com/cb'] },
+      'https://client.example.com/id.json/',
+    );
+    expect(good.client_id).toBe('https://client.example.com/id.json');
+
+    expect(() =>
+      validateClientIdMetadataDocument(
+        { client_id: 'https://evil.example.com/id.json', redirect_uris: [] },
+        'https://client.example.com/id.json',
+      ),
+    ).toThrow(/does not match/i);
+  });
+
+  it('resolves a document over a supplied fetch impl', async () => {
+    const { resolveClientIdMetadataDocument } = await import('../../../auth/cimd.js');
+    const url = 'https://client.example.com/id.json';
+    const fetchImpl = (async () =>
+      ({
+        ok: true,
+        status: 200,
+        json: async () => ({ client_id: url, redirect_uris: ['https://client.example.com/cb'] }),
+      }) as unknown as Response) as unknown as typeof fetch;
+    const doc = await resolveClientIdMetadataDocument(url, { fetchImpl });
+    expect(doc.client_id).toBe(url);
+  });
+
+  it('distinguishes CIMD URLs from opaque DCR ids', async () => {
+    const { isClientIdMetadataUrl } = await import('../../../auth/cimd.js');
+    expect(isClientIdMetadataUrl('https://client.example.com/id.json')).toBe(true);
+    expect(isClientIdMetadataUrl('abc123-opaque-dcr-id')).toBe(false);
+  });
+});

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/auth-hardening.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/auth-hardening.test.ts
@@ -335,5 +335,19 @@ describe('CIMD (Client ID Metadata Documents)', () => {
       ).rejects.toThrow(/aborted/i);
     });
   });
+
+  describe('CIMD Client ID Classification (F-03-01)', () => {
+    it('correctly identifies valid URLs and rejects opaque IDs or malformed URLs', async () => {
+      const { isClientIdMetadataUrl } = await import('../../../auth/cimd.js');
+      expect(isClientIdMetadataUrl('https://client.example.com/id.json')).toBe(true);
+      expect(isClientIdMetadataUrl('http://localhost:3000/id.json')).toBe(true);
+      expect(isClientIdMetadataUrl('opaque-dcr-client-123')).toBe(false);
+      expect(isClientIdMetadataUrl('http://')).toBe(false);
+      expect(isClientIdMetadataUrl('')).toBe(false);
+      expect(isClientIdMetadataUrl('   ')).toBe(false);
+      expect(isClientIdMetadataUrl(null as any)).toBe(false);
+      expect(isClientIdMetadataUrl(undefined as any)).toBe(false);
+    });
+  });
 });
 

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/auth-hardening.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/auth-hardening.test.ts
@@ -177,5 +177,71 @@ describe('CIMD (Client ID Metadata Documents)', () => {
       })
     ).rejects.toThrow(/special-use IP/i);
   });
+
+  it('rejects HTTP 301, 302, 307, 308 redirects without following (F-05-03)', async () => {
+    const { resolveClientIdMetadataDocument } = await import('../../../auth/cimd.js');
+    const redirectFetch = (async (_url: string, init?: RequestInit) => {
+      expect(init?.redirect).toBe('error');
+      return {
+        ok: false,
+        status: 302,
+        headers: new Headers({ Location: 'https://evil.example.com/id.json' }),
+        json: async () => ({}),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const dnsLookupImpl = (async () => [{ address: '93.184.216.34', family: 4 }]) as any;
+
+    await expect(
+      resolveClientIdMetadataDocument('https://client.example.com/id.json', {
+        fetchImpl: redirectFetch,
+        dnsLookupImpl,
+      })
+    ).rejects.toThrow(/HTTP 302/i);
+  });
+
+  it('rejects document payloads larger than 5 KiB / 5120 bytes (F-05-04)', async () => {
+    const { resolveClientIdMetadataDocument, MAX_CIMD_DOCUMENT_BYTES } = await import('../../../auth/cimd.js');
+    expect(MAX_CIMD_DOCUMENT_BYTES).toBe(5120);
+
+    const largeDoc = {
+      client_id: 'https://client.example.com/id.json',
+      redirect_uris: ['https://client.example.com/cb'],
+      padding: 'A'.repeat(6000), // > 5120 bytes
+    };
+
+    // Test 1: Rejected via Content-Length header
+    const mockFetchWithHeader = (async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-length': '7000' }),
+      text: async () => JSON.stringify(largeDoc),
+      json: async () => largeDoc,
+    })) as unknown as typeof fetch;
+
+    const dnsLookupImpl = (async () => [{ address: '93.184.216.34', family: 4 }]) as any;
+
+    await expect(
+      resolveClientIdMetadataDocument('https://client.example.com/id.json', {
+        fetchImpl: mockFetchWithHeader,
+        dnsLookupImpl,
+      })
+    ).rejects.toThrow(/maximum allowed size/i);
+
+    // Test 2: Rejected via body size check when Content-Length is missing
+    const mockFetchWithoutHeader = (async () => ({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      text: async () => JSON.stringify(largeDoc),
+    })) as unknown as typeof fetch;
+
+    await expect(
+      resolveClientIdMetadataDocument('https://client.example.com/id.json', {
+        fetchImpl: mockFetchWithoutHeader,
+        dnsLookupImpl,
+      })
+    ).rejects.toThrow(/maximum allowed size/i);
+  });
 });
 

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/auth-hardening.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/auth-hardening.test.ts
@@ -243,5 +243,47 @@ describe('CIMD (Client ID Metadata Documents)', () => {
       })
     ).rejects.toThrow(/maximum allowed size/i);
   });
+
+  describe('CIMD URL Component Validation (F-04-01)', () => {
+    it('rejects URLs containing userinfo (username / password)', async () => {
+      const { createClientIdMetadataDocument, validateClientIdentifierUrl } = await import('../../../auth/cimd.js');
+      expect(() =>
+        createClientIdMetadataDocument('https://user:pass@client.example.com/id.json', { redirect_uris: [] })
+      ).toThrow(/userinfo/i);
+      expect(() =>
+        validateClientIdentifierUrl('https://admin@client.example.com/id.json')
+      ).toThrow(/userinfo/i);
+    });
+
+    it('rejects URLs containing a fragment component', async () => {
+      const { createClientIdMetadataDocument, validateClientIdentifierUrl } = await import('../../../auth/cimd.js');
+      expect(() =>
+        createClientIdMetadataDocument('https://client.example.com/id.json#section', { redirect_uris: [] })
+      ).toThrow(/fragment/i);
+      expect(() =>
+        validateClientIdentifierUrl('https://client.example.com/id.json#token')
+      ).toThrow(/fragment/i);
+    });
+
+    it('rejects URLs without a path component (bare origin)', async () => {
+      const { createClientIdMetadataDocument, validateClientIdentifierUrl } = await import('../../../auth/cimd.js');
+      expect(() =>
+        createClientIdMetadataDocument('https://client.example.com', { redirect_uris: [] })
+      ).toThrow(/path component/i);
+      expect(() =>
+        validateClientIdentifierUrl('https://client.example.com/')
+      ).toThrow(/path component/i);
+    });
+
+    it('rejects URLs containing single-dot or double-dot path segments', async () => {
+      const { createClientIdMetadataDocument, validateClientIdentifierUrl } = await import('../../../auth/cimd.js');
+      expect(() =>
+        createClientIdMetadataDocument('https://client.example.com/a/../b/id.json', { redirect_uris: [] })
+      ).toThrow(/dot/i);
+      expect(() =>
+        validateClientIdentifierUrl('https://client.example.com/./id.json')
+      ).toThrow(/dot/i);
+    });
+  });
 });
 

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/features.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/features.test.ts
@@ -1,0 +1,204 @@
+/**
+ * 2026-07-28 feature mappings (cache hints, schema 2020-12, trace context,
+ * extensions map, error codes, MRTR helpers). These are the NitroStack-level
+ * abstractions the modern adapter consumes; they are era-agnostic and run
+ * without loading the v2 engine.
+ */
+
+import { z } from 'zod';
+
+describe('SEP-2549 cache hints', () => {
+  it('maps @Cache ttl (seconds) to ttlMs with a private scope', async () => {
+    const { resolveToolCacheHint } = await import('../../protocol/features/cache-hints.js');
+    expect(resolveToolCacheHint({ cacheTtlSeconds: 30 })).toEqual({ ttlMs: 30000, cacheScope: 'private' });
+  });
+
+  it('prefers an explicit cacheHint over the derived ttl', async () => {
+    const { resolveToolCacheHint } = await import('../../protocol/features/cache-hints.js');
+    expect(resolveToolCacheHint({ cacheHint: { ttlMs: 5000, cacheScope: 'public' }, cacheTtlSeconds: 30 })).toEqual({
+      ttlMs: 5000,
+      cacheScope: 'public',
+    });
+  });
+
+  it('maps resource cacheMaxAge (seconds) to ttlMs', async () => {
+    const { resolveResourceCacheHint } = await import('../../protocol/features/cache-hints.js');
+    expect(resolveResourceCacheHint({ metadata: { cacheable: true, cacheMaxAge: 60 } })).toEqual({
+      ttlMs: 60000,
+      cacheScope: 'private',
+    });
+  });
+
+  it('returns undefined when there is no caching signal', async () => {
+    const { resolveToolCacheHint, resolveResourceCacheHint } = await import('../../protocol/features/cache-hints.js');
+    expect(resolveToolCacheHint({})).toBeUndefined();
+    expect(resolveResourceCacheHint({})).toBeUndefined();
+  });
+
+  it('normalizes/clamps invalid hint values', async () => {
+    const { normalizeHint } = await import('../../protocol/features/cache-hints.js');
+    expect(normalizeHint({ ttlMs: -5, cacheScope: 'bogus' as never })).toEqual({});
+    expect(normalizeHint({ ttlMs: 12.9, cacheScope: 'public' })).toEqual({ ttlMs: 12, cacheScope: 'public' });
+  });
+});
+
+describe('SEP-2106 JSON Schema 2020-12', () => {
+  it('keeps composition (oneOf) and $defs for an input schema on the modern path', async () => {
+    const { convertToModernJsonSchema } = await import('../../protocol/features/schema.js');
+    const schema = z.object({
+      choice: z.union([z.object({ a: z.string() }), z.object({ b: z.number() })]),
+    });
+    const json = await convertToModernJsonSchema(schema, { root: 'input' });
+    // Root stays an object per spec...
+    expect(json.type).toBe('object');
+    // ...and the 2020-12 dialect is advertised.
+    expect(json.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+    // Composition survives somewhere in the tree (union -> anyOf/oneOf).
+    const serialized = JSON.stringify(json);
+    expect(serialized).toMatch(/anyOf|oneOf/);
+  });
+
+  it('leaves an output schema unrestricted (not forced to object)', async () => {
+    const { convertToModernJsonSchema } = await import('../../protocol/features/schema.js');
+    const json = await convertToModernJsonSchema(z.array(z.string()), { root: 'output' });
+    expect(json.type).toBe('array');
+  });
+
+  it('forces object root for input even when given a non-object schema', async () => {
+    const { convertToModernJsonSchema } = await import('../../protocol/features/schema.js');
+    const json = await convertToModernJsonSchema({ type: 'string' }, { root: 'input' });
+    expect(json.type).toBe('object');
+  });
+
+  it('bounds pathological schema depth (DoS guard)', async () => {
+    const { boundSchemaDepth, MAX_SCHEMA_DEPTH } = await import('../../protocol/features/schema.js');
+    // Build a nesting deeper than the max.
+    let deep: Record<string, unknown> = { leaf: true };
+    for (let i = 0; i < MAX_SCHEMA_DEPTH + 10; i++) {
+      deep = { nested: deep };
+    }
+    const bounded = boundSchemaDepth(deep) as Record<string, unknown>;
+    // Walk down until we hit the truncation sentinel {}.
+    let cur: unknown = bounded;
+    let depth = 0;
+    while (cur && typeof cur === 'object' && 'nested' in (cur as object)) {
+      cur = (cur as { nested: unknown }).nested;
+      depth++;
+      if (depth > MAX_SCHEMA_DEPTH + 5) break;
+    }
+    expect(depth).toBeLessThanOrEqual(MAX_SCHEMA_DEPTH);
+  });
+});
+
+describe('SEP-414 W3C trace context', () => {
+  it('extracts bare trace keys from an envelope', async () => {
+    const { extractTraceContext } = await import('../../protocol/features/trace-context.js');
+    expect(
+      extractTraceContext({ traceparent: '00-abc-def-01', tracestate: 'x=1', baggage: 'k=v' }),
+    ).toEqual({ traceparent: '00-abc-def-01', tracestate: 'x=1', baggage: 'k=v' });
+  });
+
+  it('extracts reverse-DNS trace keys', async () => {
+    const { extractTraceContext } = await import('../../protocol/features/trace-context.js');
+    expect(
+      extractTraceContext({ 'io.modelcontextprotocol/traceparent': '00-a-b-01' }),
+    ).toEqual({ traceparent: '00-a-b-01' });
+  });
+
+  it('returns undefined when no trace keys present', async () => {
+    const { extractTraceContext } = await import('../../protocol/features/trace-context.js');
+    expect(extractTraceContext({ something: 'else' })).toBeUndefined();
+    expect(extractTraceContext(undefined)).toBeUndefined();
+  });
+});
+
+describe('SEP-2133 extensions map', () => {
+  it('advertises app + tasks extensions when signalled', async () => {
+    const { buildExtensionsMap, EXT_APP, EXT_TASKS } = await import('../../protocol/features/extensions.js');
+    const map = buildExtensionsMap({ hasApps: true, hasTasks: true });
+    expect(map[EXT_APP]).toBeDefined();
+    expect(map[EXT_TASKS]).toBeDefined();
+  });
+
+  it('omits extensions that are not present', async () => {
+    const { buildExtensionsMap, EXT_APP, EXT_TASKS } = await import('../../protocol/features/extensions.js');
+    const map = buildExtensionsMap({ hasApps: false, hasTasks: false });
+    expect(map[EXT_APP]).toBeUndefined();
+    expect(map[EXT_TASKS]).toBeUndefined();
+  });
+
+  it('merges author-declared extensions verbatim', async () => {
+    const { buildExtensionsMap } = await import('../../protocol/features/extensions.js');
+    const map = buildExtensionsMap({
+      hasApps: false,
+      hasTasks: false,
+      declared: { 'com.example/custom': { version: '1' } },
+    });
+    expect(map['com.example/custom']).toEqual({ version: '1' });
+  });
+});
+
+describe('SEP-2164 error mapping (modern path)', () => {
+  it('maps a missing resource to -32602 (Invalid Params), not -32002', async () => {
+    const { mapToJsonRpcError, JSON_RPC } = await import('../../protocol/features/errors.js');
+    const { ResourceNotFoundError } = await import('../../errors.js');
+    const mapped = mapToJsonRpcError(new ResourceNotFoundError('mcp://missing'));
+    expect(mapped.code).toBe(JSON_RPC.INVALID_PARAMS);
+    expect(mapped.code).toBe(-32602);
+  });
+
+  it('maps validation errors to -32602 with details', async () => {
+    const { mapToJsonRpcError } = await import('../../protocol/features/errors.js');
+    const { ValidationError } = await import('../../errors.js');
+    const mapped = mapToJsonRpcError(new ValidationError('bad', { field: 'x' }));
+    expect(mapped.code).toBe(-32602);
+    expect(mapped.data).toEqual({ field: 'x' });
+  });
+
+  it('maps unknown tool/prompt to -32601 (Method Not Found)', async () => {
+    const { mapToJsonRpcError } = await import('../../protocol/features/errors.js');
+    const { ToolNotFoundError, PromptNotFoundError } = await import('../../errors.js');
+    expect(mapToJsonRpcError(new ToolNotFoundError('x')).code).toBe(-32601);
+    expect(mapToJsonRpcError(new PromptNotFoundError('y')).code).toBe(-32601);
+  });
+
+  it('maps unexpected errors to -32603 (Internal Error)', async () => {
+    const { mapToJsonRpcError } = await import('../../protocol/features/errors.js');
+    expect(mapToJsonRpcError(new Error('boom')).code).toBe(-32603);
+    expect(mapToJsonRpcError('nope').code).toBe(-32603);
+  });
+
+  it('exposes the SEP-2243 header/body mismatch code', async () => {
+    const { JSON_RPC } = await import('../../protocol/features/errors.js');
+    expect(JSON_RPC.HEADER_BODY_MISMATCH).toBe(-32020);
+  });
+});
+
+describe('SEP-2322 MRTR helpers', () => {
+  it('produces an input-required marker recognized by the type guard', async () => {
+    const { inputRequired, isInputRequired } = await import('../../protocol/features/mrtr.js');
+    const result = inputRequired({
+      requests: [{ id: 'confirm', message: 'Proceed?', schema: { type: 'boolean' } }],
+      requestState: { pending: true },
+      message: 'need input',
+    });
+    expect(isInputRequired(result)).toBe(true);
+    expect(result.inputRequests).toHaveLength(1);
+    expect(result.requestState).toEqual({ pending: true });
+  });
+
+  it('does not misidentify ordinary results', async () => {
+    const { isInputRequired } = await import('../../protocol/features/mrtr.js');
+    expect(isInputRequired({ content: [] })).toBe(false);
+    expect(isInputRequired('text')).toBe(false);
+    expect(isInputRequired(undefined)).toBe(false);
+  });
+
+  it('reads previously-supplied answers (bare and wrapped)', async () => {
+    const { acceptedContent } = await import('../../protocol/features/mrtr.js');
+    expect(acceptedContent({ confirm: true }, 'confirm')).toBe(true);
+    expect(acceptedContent({ confirm: { content: 'yes' } }, 'confirm')).toBe('yes');
+    expect(acceptedContent({}, 'confirm')).toBeUndefined();
+    expect(acceptedContent(undefined, 'confirm')).toBeUndefined();
+  });
+});

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/modern-handler.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/modern-handler.test.ts
@@ -131,6 +131,41 @@ describe('modern (2026-07-28) handler via fetch', () => {
       }),
     );
 
+    server.tool(
+      new Tool({
+        name: 'must_be_task',
+        description: 'Tool requiring task augmentation',
+        inputSchema: z.object({}),
+        taskSupport: 'required',
+        handler: async (input, ctx) => {
+          if (ctx?.task) {
+            await ctx.task.updateProgress('task working');
+          }
+          return { processed: true };
+        },
+      }),
+    );
+
+    server.tool(
+      new Tool({
+        name: 'forbidden_task',
+        description: 'Tool forbidding task augmentation',
+        inputSchema: z.object({}),
+        taskSupport: 'forbidden',
+        handler: async () => ({ immediate: true }),
+      }),
+    );
+
+    server.tool(
+      new Tool({
+        name: 'optional_task',
+        description: 'Tool with optional task augmentation',
+        inputSchema: z.object({}),
+        taskSupport: 'optional',
+        handler: async (input, ctx) => ({ hasTask: !!ctx?.task }),
+      }),
+    );
+
     server.resource(
       new Resource({
         uri: 'mcp://data/greeting',
@@ -225,6 +260,79 @@ describe('modern (2026-07-28) handler via fetch', () => {
     expect(status).toBe(400);
     expect(body.error?.code).toBe(-32020);
   });
+
+  describe('taskSupport negotiation in modern era', () => {
+    it('rejects tools/call on tool with taskSupport=required when task param is missing (-32600)', async () => {
+      const res = await handler.fetch(
+        modernRequest('tools/call', { name: 'must_be_task', arguments: {} }, { name: 'must_be_task', id: 7 }),
+      );
+      const { body } = await readRpc(res);
+      expect(body.error).toBeDefined();
+      expect(body.error?.code).toBe(-32600);
+      expect(body.error?.message).toContain("Task augmentation required for tools/call requests on tool 'must_be_task'");
+    });
+
+    it('accepts tools/call on tool with taskSupport=required when task param is supplied', async () => {
+      const res = await handler.fetch(
+        modernRequest(
+          'tools/call',
+          { name: 'must_be_task', arguments: {}, task: { ttl: 60000 } },
+          { name: 'must_be_task', id: 8 },
+        ),
+      );
+      const { body } = await readRpc(res);
+      expect(body.error).toBeUndefined();
+      expect(body.result?.resultType).toBe('task');
+      expect(body.result?.task?.taskId).toBeDefined();
+      expect(body.result?.task?.status).toBe('working');
+    });
+
+    it('rejects tools/call on tool with taskSupport=forbidden when task param is supplied (-32601)', async () => {
+      const res = await handler.fetch(
+        modernRequest(
+          'tools/call',
+          { name: 'forbidden_task', arguments: {}, task: { ttl: 60000 } },
+          { name: 'forbidden_task', id: 9 },
+        ),
+      );
+      const { body } = await readRpc(res);
+      expect(body.error).toBeDefined();
+      expect(body.error?.code).toBe(-32601);
+      expect(body.error?.message).toContain("Tool 'forbidden_task' does not support task augmentation");
+    });
+
+    it('accepts tools/call on tool with taskSupport=forbidden when task param is omitted', async () => {
+      const res = await handler.fetch(
+        modernRequest('tools/call', { name: 'forbidden_task', arguments: {} }, { name: 'forbidden_task', id: 10 }),
+      );
+      const { body } = await readRpc(res);
+      expect(body.error).toBeUndefined();
+      expect(body.result?.content).toBeDefined();
+    });
+
+    it('accepts tools/call on tool with taskSupport=optional both with and without task param', async () => {
+      // Without task param
+      const res1 = await handler.fetch(
+        modernRequest('tools/call', { name: 'optional_task', arguments: {} }, { name: 'optional_task', id: 11 }),
+      );
+      const rpc1 = await readRpc(res1);
+      expect(rpc1.body.error).toBeUndefined();
+      expect(rpc1.body.result?.content).toBeDefined();
+
+      // With task param
+      const res2 = await handler.fetch(
+        modernRequest(
+          'tools/call',
+          { name: 'optional_task', arguments: {}, task: { ttl: 60000 } },
+          { name: 'optional_task', id: 12 },
+        ),
+      );
+      const rpc2 = await readRpc(res2);
+      expect(rpc2.body.error).toBeUndefined();
+      expect(rpc2.body.result?.resultType).toBe('task');
+      expect(rpc2.body.result?.task?.taskId).toBeDefined();
+    });
+  });
 });
 
 describe('auto mode: one handler serves both eras', () => {
@@ -247,6 +355,7 @@ describe('auto mode: one handler serves both eras', () => {
 
   afterAll(async () => {
     await handler?.close?.();
+    await (server as unknown as { stop?: () => Promise<void> }).stop?.().catch(() => undefined);
   });
 
   it('serves a 2026 server/discover', async () => {

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/modern-handler.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/modern-handler.test.ts
@@ -333,6 +333,62 @@ describe('modern (2026-07-28) handler via fetch', () => {
       expect(rpc2.body.result?.task?.taskId).toBeDefined();
     });
   });
+
+  describe('modern result delivery model (single-step tasks/get vs legacy methods)', () => {
+    it('embeds tool execution result directly in tasks/get when task completes', async () => {
+      // 1. Create task
+      const createRes = await handler.fetch(
+        modernRequest(
+          'tools/call',
+          { name: 'must_be_task', arguments: {}, task: { ttl: 60000 } },
+          { name: 'must_be_task', id: 20 },
+        ),
+      );
+      const createRpc = await readRpc(createRes);
+      const taskId = createRpc.body.result?.task?.taskId;
+      expect(taskId).toBeDefined();
+
+      // 2. Poll tasks/get until completed (should take < 100ms)
+      let completed = false;
+      let finalRpc: RpcResult['body'] | undefined;
+      for (let i = 0; i < 20; i++) {
+        const getRes = await handler.fetch(
+          modernRequest('tasks/get', { taskId }, { id: 21 + i }),
+        );
+        const getRpc = await readRpc(getRes);
+        if (getRpc.body.result?.status === 'completed') {
+          completed = true;
+          finalRpc = getRpc.body;
+          break;
+        }
+        await new Promise(r => setTimeout(r, 20));
+      }
+
+      expect(completed).toBe(true);
+      expect(finalRpc?.result?.status).toBe('completed');
+      expect(finalRpc?.result?.result).toEqual({ processed: true });
+    });
+
+    it('rejects legacy tasks/result with -32601 directing to tasks/get', async () => {
+      const res = await handler.fetch(
+        modernRequest('tasks/result', { taskId: '00000000-0000-0000-0000-000000000000' }, { id: 40 }),
+      );
+      const { body } = await readRpc(res);
+      expect(body.error).toBeDefined();
+      expect(body.error?.code).toBe(-32601);
+      expect(body.error?.message).toContain("Method 'tasks/result' is not supported in MCP 2026-07-28; use 'tasks/get' with embedded results.");
+    });
+
+    it('rejects legacy tasks/list with -32601 in modern stateless era', async () => {
+      const res = await handler.fetch(
+        modernRequest('tasks/list', {}, { id: 41 }),
+      );
+      const { body } = await readRpc(res);
+      expect(body.error).toBeDefined();
+      expect(body.error?.code).toBe(-32601);
+      expect(body.error?.message).toContain("Method 'tasks/list' is not supported in modern stateless MCP 2026-07-28.");
+    });
+  });
 });
 
 describe('auto mode: one handler serves both eras', () => {

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/modern-handler.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/modern-handler.test.ts
@@ -1,0 +1,288 @@
+/**
+ * End-to-end 2026-07-28 wire tests driving the official v2 engine through the
+ * NitroStack modern adapter's web-standard `fetch` handler (the SDK-recommended
+ * in-process approach; the 2025-era `InMemoryTransport` is legacy-only).
+ *
+ * These prove the adapter binds the NitroStack registry to real stateless HTTP:
+ * `server/discover`, `_meta` envelope → `ExecutionContext`, and SEP-2164 error
+ * mapping. No `Mcp-Session-Id` is ever used.
+ */
+
+import { NitroStackServer } from '../../server.js';
+import { Tool } from '../../tool.js';
+import { Resource } from '../../resource.js';
+import { ResourceNotFoundError } from '../../errors.js';
+import { z } from 'zod';
+
+const MODERN = '2026-07-28';
+const META_PROTOCOL = 'io.modelcontextprotocol/protocolVersion';
+const META_CLIENT_CAPS = 'io.modelcontextprotocol/clientCapabilities';
+const META_CLIENT_INFO = 'io.modelcontextprotocol/clientInfo';
+
+interface RpcResult {
+  status: number;
+  body: { jsonrpc?: string; id?: unknown; result?: any; error?: { code: number; message: string } };
+}
+
+/** Build a well-formed modern (2026-07-28) JSON-RPC request. */
+function modernRequest(
+  method: string,
+  params: Record<string, unknown> = {},
+  opts: { name?: string; id?: number } = {},
+): Request {
+  const envelope = {
+    [META_PROTOCOL]: MODERN,
+    [META_CLIENT_CAPS]: {},
+    [META_CLIENT_INFO]: { name: 'jest-client', version: '1.0.0' },
+  };
+  const body = {
+    jsonrpc: '2.0',
+    id: opts.id ?? 1,
+    method,
+    params: { ...params, _meta: { ...(params._meta as object), ...envelope } },
+  };
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+    'MCP-Protocol-Version': MODERN,
+    'Mcp-Method': method,
+  };
+  if (opts.name) headers['Mcp-Name'] = opts.name;
+  return new Request('http://localhost/mcp', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function extractRpc(text: string, isSse: boolean): RpcResult['body'] | undefined {
+  if (isSse) {
+    for (const line of text.split('\n')) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('data:')) {
+        try {
+          const parsed = JSON.parse(trimmed.slice(5).trim());
+          if (parsed && (parsed.result !== undefined || parsed.error !== undefined)) {
+            return parsed;
+          }
+        } catch {
+          /* keep scanning */
+        }
+      }
+    }
+    return undefined;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Parse a JSON or SSE response into the first JSON-RPC message. Reads the body
+ * stream incrementally and returns as soon as a message is found, then cancels
+ * — so a long-lived SSE stream (the legacy Streamable HTTP response channel)
+ * never blocks the test.
+ */
+async function readRpc(res: Response): Promise<RpcResult> {
+  const contentType = res.headers.get('content-type') || '';
+  const isSse = contentType.includes('text/event-stream');
+  if (!res.body) {
+    return { status: res.status, body: extractRpc(await res.text(), isSse) ?? {} };
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  try {
+    // Overall guard so a stuck stream cannot hang the suite.
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (value) buffer += decoder.decode(value, { stream: true });
+      const parsed = extractRpc(buffer, isSse);
+      if (parsed) return { status: res.status, body: parsed };
+      if (done) break;
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+  return { status: res.status, body: extractRpc(buffer, isSse) ?? {} };
+}
+
+describe('modern (2026-07-28) handler via fetch', () => {
+  let server: NitroStackServer;
+  let handler: { fetch: (req: Request) => Promise<Response>; close: () => Promise<void> };
+  let lastToolContext: { protocolVersion?: string; clientInfo?: unknown } | undefined;
+
+  beforeAll(async () => {
+    server = new NitroStackServer({ name: 'modern-test', version: '9.9.9', protocolVersion: MODERN });
+
+    server.tool(
+      new Tool({
+        name: 'echo',
+        description: 'Echo the input text back.',
+        inputSchema: z.object({ text: z.string() }),
+        cacheTtlSeconds: 30,
+        handler: async (input, ctx) => {
+          lastToolContext = { protocolVersion: ctx.protocolVersion, clientInfo: ctx.clientInfo };
+          return { echoed: (input as { text: string }).text };
+        },
+      }),
+    );
+
+    server.resource(
+      new Resource({
+        uri: 'mcp://data/greeting',
+        name: 'greeting',
+        description: 'A static greeting.',
+        mimeType: 'text/plain',
+        handler: async () => ({ type: 'text', data: 'hello' }),
+      }),
+    );
+
+    // A resource whose handler raises NitroStack's ResourceNotFoundError, to
+    // exercise the modern adapter's SEP-2164 mapping (-> -32602).
+    server.resource(
+      new Resource({
+        uri: 'mcp://data/flaky',
+        name: 'flaky',
+        description: 'Always missing.',
+        mimeType: 'text/plain',
+        handler: async (uri: string) => {
+          throw new ResourceNotFoundError(uri);
+        },
+      }),
+    );
+
+    const adapter = await (server as unknown as { getModernAdapter: () => Promise<any> }).getModernAdapter();
+    handler = await adapter.getHttpHandler();
+  });
+
+  afterAll(async () => {
+    await handler?.close?.();
+    await (server as unknown as { stop?: () => Promise<void> }).stop?.().catch(() => undefined);
+  });
+
+  it('lists tools statelessly (no Mcp-Session-Id) via tools/list', async () => {
+    const res = await handler.fetch(modernRequest('tools/list', {}, { id: 1 }));
+    const { status, body } = await readRpc(res);
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+    const toolNames = (body.result?.tools ?? []).map((t: any) => t.name);
+    expect(toolNames).toContain('echo');
+    // No session header should ever be issued on the modern (stateless) path.
+    expect(res.headers.get('Mcp-Session-Id')).toBeNull();
+  });
+
+  it('answers server/discover with a result (capabilities negotiated)', async () => {
+    const res = await handler.fetch(modernRequest('server/discover', {}, { id: 2 }));
+    const { status, body } = await readRpc(res);
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result).toBeDefined();
+  });
+
+  it('populates ExecutionContext from the _meta envelope on tools/call', async () => {
+    lastToolContext = undefined;
+    const res = await handler.fetch(
+      modernRequest('tools/call', { name: 'echo', arguments: { text: 'hi' } }, { name: 'echo', id: 3 }),
+    );
+    const { body } = await readRpc(res);
+    expect(body.error).toBeUndefined();
+    const seen = lastToolContext as { protocolVersion?: string; clientInfo?: unknown } | undefined;
+    expect(seen?.protocolVersion).toBe(MODERN);
+    expect(seen?.clientInfo).toMatchObject({ name: 'jest-client' });
+  });
+
+  it('maps a missing resource to -32602 (SEP-2164), not the 2025-era -32002', async () => {
+    const res = await handler.fetch(
+      modernRequest('resources/read', { uri: 'mcp://data/flaky' }, { name: 'mcp://data/flaky', id: 4 }),
+    );
+    const { body } = await readRpc(res);
+    expect(body.error).toBeDefined();
+    expect(body.error?.code).toBe(-32602);
+  });
+
+  it('rejects a tools/call missing the required SEP-2243 Mcp-Name header (-32020)', async () => {
+    // Same body as a valid call, but no Mcp-Name header naming the tool.
+    const res = await handler.fetch(
+      modernRequest('tools/call', { name: 'echo', arguments: { text: 'x' } }, { id: 5 }),
+    );
+    const { status, body } = await readRpc(res);
+    expect(status).toBe(400);
+    expect(body.error?.code).toBe(-32020);
+  });
+
+  it('rejects an Mcp-Method header that disagrees with the body (-32020)', async () => {
+    // Body says tools/list but the Mcp-Method header claims server/discover.
+    const req = modernRequest('tools/list', {}, { id: 6 });
+    const headers = new Headers(req.headers);
+    headers.set('Mcp-Method', 'server/discover');
+    const mismatched = new Request(req.url, { method: 'POST', headers, body: await req.text() });
+    const res = await handler.fetch(mismatched);
+    const { status, body } = await readRpc(res);
+    expect(status).toBe(400);
+    expect(body.error?.code).toBe(-32020);
+  });
+});
+
+describe('auto mode: one handler serves both eras', () => {
+  let server: NitroStackServer;
+  let handler: { fetch: (req: Request) => Promise<Response>; close: () => Promise<void> };
+
+  beforeAll(async () => {
+    server = new NitroStackServer({ name: 'auto-test', version: '1.0.0', protocolVersion: 'auto' });
+    server.tool(
+      new Tool({
+        name: 'ping',
+        description: 'Ping.',
+        inputSchema: z.object({}),
+        handler: async () => ({ pong: true }),
+      }),
+    );
+    const adapter = await (server as unknown as { getModernAdapter: () => Promise<any> }).getModernAdapter();
+    handler = await adapter.getHttpHandler();
+  });
+
+  afterAll(async () => {
+    await handler?.close?.();
+  });
+
+  it('serves a 2026 server/discover', async () => {
+    const res = await handler.fetch(modernRequest('server/discover', {}, { id: 1 }));
+    const { status, body } = await readRpc(res);
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result).toBeDefined();
+  });
+
+  it('also accepts a 2025-era initialize handshake on the same endpoint', async () => {
+    // Legacy request: no per-request envelope and no modern headers.
+    const initialize = new Request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        // Legacy Streamable HTTP requires the client to accept text/event-stream;
+        // readRpc reads the first frame and then cancels the stream.
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'legacy-client', version: '1.0.0' },
+        },
+      }),
+    });
+    const res = await handler.fetch(initialize);
+    const { status, body } = await readRpc(res);
+    // The v2 stateless-legacy fallback answers the 2025 handshake.
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result?.protocolVersion).toBeDefined();
+  });
+});

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/modern-prompt.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/modern-prompt.test.ts
@@ -19,7 +19,7 @@
  * 12. Stateless HTTP execution (no initialize, no Mcp-Session-Id)
  */
 
-import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
 import { NitroStackServer } from '../../server.js';
 import { Prompt } from '../../prompt.js';
 
@@ -253,7 +253,7 @@ describe('Modern (2026-07-28) Parameterized Prompt Regression Suite', () => {
     const res = await handler.fetch(
       modernPromptRequest('code-review', {}, { id: 106 }),
     );
-    const { status, body } = await readRpc(res);
+    const { body } = await readRpc(res);
 
     expect(body.error).toBeDefined();
     expect(body.error?.message).toMatch(/required (property|argument)|invalid (params|arguments)|validation/i);

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/modern-prompt.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/modern-prompt.test.ts
@@ -256,7 +256,7 @@ describe('Modern (2026-07-28) Parameterized Prompt Regression Suite', () => {
     const { status, body } = await readRpc(res);
 
     expect(body.error).toBeDefined();
-    expect(body.error?.message).toMatch(/required argument|validation|invalid params/i);
+    expect(body.error?.message).toMatch(/required (property|argument)|invalid (params|arguments)|validation/i);
   });
 
   // Scenario 7: Invalid argument type / missing arguments object

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/modern-prompt.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/modern-prompt.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Comprehensive regression test suite for Modern MCP (2026-07-28) Prompts.
+ *
+ * Exercises the Prompt registration and execution flow through the real Modern v2
+ * SDK boundary (`ModernProtocolAdapter` -> `@modelcontextprotocol/server` -> `fetch`).
+ *
+ * Covers all 12 required scenarios:
+ * 1. Parameterless prompt registration and execution
+ * 2. Prompt with 1 required string argument
+ * 3. Prompt with optional argument omitted
+ * 4. Prompt with optional argument supplied
+ * 5. Prompt with multiple required and optional arguments
+ * 6. Missing required argument rejection
+ * 7. Invalid argument type handling
+ * 8. Separation of Prompt args from SDK extra/request context
+ * 9. Auth info, clientInfo, headers, and ExecutionContext availability
+ * 10. Context logging and execution metadata preservation
+ * 11. Concurrent parameterized prompt calls with isolation
+ * 12. Stateless HTTP execution (no initialize, no Mcp-Session-Id)
+ */
+
+import { jest, describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { NitroStackServer } from '../../server.js';
+import { Prompt } from '../../prompt.js';
+
+const MODERN = '2026-07-28';
+const META_PROTOCOL = 'io.modelcontextprotocol/protocolVersion';
+const META_CLIENT_CAPS = 'io.modelcontextprotocol/clientCapabilities';
+const META_CLIENT_INFO = 'io.modelcontextprotocol/clientInfo';
+
+interface RpcResult {
+  status: number;
+  body: {
+    jsonrpc?: string;
+    id?: unknown;
+    result?: {
+      description?: string;
+      messages?: Array<{ role: string; content: { type: string; text: string } }>;
+      [key: string]: unknown;
+    };
+    error?: { code: number; message: string; data?: unknown };
+  };
+}
+
+function modernPromptRequest(
+  promptName: string,
+  args?: Record<string, unknown>,
+  opts: { id?: number; clientName?: string; authHeader?: string } = {},
+): Request {
+  const envelope = {
+    [META_PROTOCOL]: MODERN,
+    [META_CLIENT_CAPS]: {},
+    [META_CLIENT_INFO]: { name: opts.clientName ?? 'jest-prompt-client', version: '1.0.0' },
+  };
+
+  const params: Record<string, unknown> = {
+    name: promptName,
+    _meta: envelope,
+  };
+  if (args !== undefined) {
+    params.arguments = args;
+  }
+
+  const body = {
+    jsonrpc: '2.0',
+    id: opts.id ?? 1,
+    method: 'prompts/get',
+    params,
+  };
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'MCP-Protocol-Version': MODERN,
+    'Mcp-Method': 'prompts/get',
+    'Mcp-Name': promptName,
+  };
+  if (opts.authHeader) {
+    headers['Authorization'] = opts.authHeader;
+  }
+
+  return new Request('http://localhost/mcp', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+async function readRpc(res: Response): Promise<RpcResult> {
+  const text = await res.text();
+  try {
+    return { status: res.status, body: JSON.parse(text) };
+  } catch {
+    return { status: res.status, body: {} };
+  }
+}
+
+describe('Modern (2026-07-28) Parameterized Prompt Regression Suite', () => {
+  let server: NitroStackServer;
+  let handler: { fetch: (req: Request) => Promise<Response>; close: () => Promise<void> };
+
+  // Captured execution contexts for verification
+  const capturedContexts: Record<string, any> = {};
+  const capturedArgs: Record<string, any> = {};
+
+  beforeAll(async () => {
+    server = new NitroStackServer({ name: 'prompt-regression-server', version: '1.0.0', protocolVersion: MODERN });
+
+    // 1. Parameterless prompt
+    server.prompt(
+      new Prompt({
+        name: 'simple-greeting',
+        description: 'A parameterless greeting prompt',
+        handler: async (args, ctx) => {
+          capturedArgs['simple-greeting'] = args;
+          capturedContexts['simple-greeting'] = ctx;
+          return [{ role: 'assistant', content: 'Hello, welcome to NitroStack!' }];
+        },
+      }),
+    );
+
+    // 2. Single required string argument
+    server.prompt(
+      new Prompt({
+        name: 'code-review',
+        description: 'Review code for best practices',
+        arguments: [{ name: 'code', description: 'The source code', required: true }],
+        handler: async (args, ctx) => {
+          capturedArgs['code-review'] = args;
+          capturedContexts['code-review'] = ctx;
+          return [{ role: 'user', content: `Please review this code:\n${args.code}` }];
+        },
+      }),
+    );
+
+    // 3 & 4. Optional argument
+    server.prompt(
+      new Prompt({
+        name: 'greet-user',
+        description: 'Greeting with optional title',
+        arguments: [
+          { name: 'name', description: 'User name', required: true },
+          { name: 'title', description: 'Optional honorific', required: false },
+        ],
+        handler: async (args, ctx) => {
+          capturedArgs['greet-user'] = args;
+          capturedContexts['greet-user'] = ctx;
+          const prefix = args.title ? `${args.title} ` : '';
+          return [{ role: 'assistant', content: `Hello, ${prefix}${args.name}!` }];
+        },
+      }),
+    );
+
+    // 5. Multiple required and optional arguments
+    server.prompt(
+      new Prompt({
+        name: 'deploy-service',
+        description: 'Deploy service with environment and options',
+        arguments: [
+          { name: 'service', description: 'Service name', required: true },
+          { name: 'environment', description: 'Target environment', required: true },
+          { name: 'tag', description: 'Release tag', required: false },
+          { name: 'dryRun', description: 'Dry run flag', required: false },
+        ],
+        handler: async (args, ctx) => {
+          capturedArgs['deploy-service'] = args;
+          capturedContexts['deploy-service'] = ctx;
+          return [
+            {
+              role: 'user',
+              content: `Deploying ${args.service} to ${args.environment} (tag: ${args.tag ?? 'latest'}, dryRun: ${args.dryRun ?? 'false'})`,
+            },
+          ];
+        },
+      }),
+    );
+
+    const adapter = await (server as unknown as { getModernAdapter: () => Promise<any> }).getModernAdapter();
+    handler = await adapter.getHttpHandler();
+  });
+
+  afterAll(async () => {
+    await handler?.close?.();
+  });
+
+  // Scenario 1: Parameterless Prompt
+  it('1. Parameterless prompt registers and executes successfully', async () => {
+    const res = await handler.fetch(modernPromptRequest('simple-greeting', undefined, { id: 101 }));
+    const { status, body } = await readRpc(res);
+
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result?.messages).toHaveLength(1);
+    expect(body.result?.messages?.[0].content.text).toBe('Hello, welcome to NitroStack!');
+  });
+
+  // Scenario 2: Single required string argument
+  it('2. Prompt with one required string argument receives args and executes', async () => {
+    const res = await handler.fetch(
+      modernPromptRequest('code-review', { code: 'const answer = 42;' }, { id: 102 }),
+    );
+    const { status, body } = await readRpc(res);
+
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result?.messages?.[0].content.text).toContain('const answer = 42;');
+    expect(capturedArgs['code-review']?.code).toBe('const answer = 42;');
+  });
+
+  // Scenario 3: Optional argument omitted
+  it('3. Prompt with optional argument omitted succeeds', async () => {
+    const res = await handler.fetch(
+      modernPromptRequest('greet-user', { name: 'Alice' }, { id: 103 }),
+    );
+    const { status, body } = await readRpc(res);
+
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result?.messages?.[0].content.text).toBe('Hello, Alice!');
+  });
+
+  // Scenario 4: Optional argument supplied
+  it('4. Prompt with optional argument supplied succeeds and uses argument', async () => {
+    const res = await handler.fetch(
+      modernPromptRequest('greet-user', { name: 'Smith', title: 'Dr.' }, { id: 104 }),
+    );
+    const { status, body } = await readRpc(res);
+
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result?.messages?.[0].content.text).toBe('Hello, Dr. Smith!');
+  });
+
+  // Scenario 5: Multiple required and optional arguments
+  it('5. Prompt with multiple required and optional arguments handles all supplied fields', async () => {
+    const res = await handler.fetch(
+      modernPromptRequest(
+        'deploy-service',
+        { service: 'auth-api', environment: 'production', tag: 'v2.1.0', dryRun: 'true' },
+        { id: 105 },
+      ),
+    );
+    const { status, body } = await readRpc(res);
+
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result?.messages?.[0].content.text).toContain('Deploying auth-api to production');
+    expect(body.result?.messages?.[0].content.text).toContain('tag: v2.1.0');
+  });
+
+  // Scenario 6: Missing required argument
+  it('6. Missing required argument returns an error', async () => {
+    const res = await handler.fetch(
+      modernPromptRequest('code-review', {}, { id: 106 }),
+    );
+    const { status, body } = await readRpc(res);
+
+    expect(body.error).toBeDefined();
+    expect(body.error?.message).toMatch(/required argument|validation|invalid params/i);
+  });
+
+  // Scenario 7: Invalid argument type / missing arguments object
+  it('7. Invalid or empty arguments payload returns an error for required prompt', async () => {
+    const res = await handler.fetch(
+      modernPromptRequest('code-review', undefined, { id: 107 }),
+    );
+    const { body } = await readRpc(res);
+
+    expect(body.error).toBeDefined();
+  });
+
+  // Scenario 8: Separation of Prompt args from SDK extra/request context
+  it('8. Handler receives clean args without SDK extra pollution', async () => {
+    await handler.fetch(
+      modernPromptRequest('code-review', { code: 'console.log("clean");' }, { id: 108 }),
+    );
+
+    const args = capturedArgs['code-review'];
+    expect(args).toBeDefined();
+    expect(args.code).toBe('console.log("clean");');
+    expect(args.mcpReq).toBeUndefined();
+    expect(args.http).toBeUndefined();
+    expect(args.signal).toBeUndefined();
+  });
+
+  // Scenario 9: Context, clientInfo, and headers availability
+  it('9. ExecutionContext is populated with clientInfo and protocolVersion', async () => {
+    await handler.fetch(
+      modernPromptRequest(
+        'code-review',
+        { code: 'const x = 10;' },
+        { id: 109, clientName: 'audit-test-client' },
+      ),
+    );
+
+    const ctx = capturedContexts['code-review'];
+    expect(ctx).toBeDefined();
+    expect(ctx.protocolVersion).toBe(MODERN);
+    expect(ctx.clientInfo).toMatchObject({ name: 'audit-test-client' });
+  });
+
+  // Scenario 10: Context logger exists and handles execution
+  it('10. Context logger is available and logs prompt execution', async () => {
+    await handler.fetch(
+      modernPromptRequest('simple-greeting', undefined, { id: 110 }),
+    );
+
+    const ctx = capturedContexts['simple-greeting'];
+    expect(ctx?.logger).toBeDefined();
+    expect(typeof ctx?.logger?.info).toBe('function');
+  });
+
+  // Scenario 11: Concurrent parameterized prompt calls with isolation
+  it('11. Concurrent parameterized prompt calls maintain isolated args and responses', async () => {
+    const p1 = handler.fetch(
+      modernPromptRequest('code-review', { code: 'user1_code()' }, { id: 111, clientName: 'client-1' }),
+    );
+    const p2 = handler.fetch(
+      modernPromptRequest('code-review', { code: 'user2_code()' }, { id: 112, clientName: 'client-2' }),
+    );
+
+    const [res1, res2] = await Promise.all([p1, p2]);
+    const [r1, r2] = await Promise.all([readRpc(res1), readRpc(res2)]);
+
+    expect(r1.body.result?.messages?.[0].content.text).toContain('user1_code()');
+    expect(r2.body.result?.messages?.[0].content.text).toContain('user2_code()');
+    expect(r1.body.id).toBe(111);
+    expect(r2.body.id).toBe(112);
+  });
+
+  // Scenario 12: Stateless HTTP execution without Mcp-Session-Id
+  it('12. Modern HTTP prompts/get operates statelessly without session header', async () => {
+    const res = await handler.fetch(
+      modernPromptRequest('simple-greeting', undefined, { id: 113 }),
+    );
+
+    expect(res.headers.get('Mcp-Session-Id')).toBeNull();
+    const { status, body } = await readRpc(res);
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+  });
+});

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/selector.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/selector.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Protocol selector resolution (2026-07-28 dual-spec).
+ *
+ * Verifies that `NITRO_MCP_PROTOCOL_VERSION` (env) and `McpServerConfig.protocolVersion`
+ * (config) resolve to the right era, that env wins over config, and that unset /
+ * unknown values keep the default legacy path.
+ */
+
+describe('protocol/version selector', () => {
+  const ENV_VAR = 'NITRO_MCP_PROTOCOL_VERSION';
+  const original = process.env[ENV_VAR];
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[ENV_VAR];
+    } else {
+      process.env[ENV_VAR] = original;
+    }
+  });
+
+  it('normalizes modern aliases to "modern"', async () => {
+    const { normalizeProtocolEra } = await import('../../protocol/version.js');
+    for (const v of ['2026-07-28', '2026', 'modern', 'latest', 'MODERN', '  2026-07-28 ']) {
+      expect(normalizeProtocolEra(v)).toBe('modern');
+    }
+  });
+
+  it('normalizes auto aliases to "auto"', async () => {
+    const { normalizeProtocolEra } = await import('../../protocol/version.js');
+    for (const v of ['auto', 'both', 'dual', 'dual-spec', 'AUTO']) {
+      expect(normalizeProtocolEra(v)).toBe('auto');
+    }
+  });
+
+  it('normalizes legacy / unset / unknown to "legacy"', async () => {
+    const { normalizeProtocolEra } = await import('../../protocol/version.js');
+    for (const v of ['2025-06-18', '2025-11-25', '2025', 'legacy', '', '   ', 'banana', undefined, null]) {
+      expect(normalizeProtocolEra(v)).toBe('legacy');
+    }
+  });
+
+  it('defaults to legacy when nothing is set (backwards compatible)', async () => {
+    delete process.env[ENV_VAR];
+    const { resolveProtocolEra } = await import('../../protocol/version.js');
+    expect(resolveProtocolEra()).toBe('legacy');
+    expect(resolveProtocolEra(undefined)).toBe('legacy');
+  });
+
+  it('uses config value when env is unset', async () => {
+    delete process.env[ENV_VAR];
+    const { resolveProtocolEra } = await import('../../protocol/version.js');
+    expect(resolveProtocolEra('2026-07-28')).toBe('modern');
+    expect(resolveProtocolEra('auto')).toBe('auto');
+    expect(resolveProtocolEra('2025-06-18')).toBe('legacy');
+  });
+
+  it('lets env win over config so a deployed app can be flipped', async () => {
+    process.env[ENV_VAR] = '2026-07-28';
+    const { resolveProtocolEra } = await import('../../protocol/version.js');
+    // config says legacy, env says modern -> modern
+    expect(resolveProtocolEra('2025-06-18')).toBe('modern');
+    process.env[ENV_VAR] = 'legacy';
+    expect(resolveProtocolEra('2026-07-28')).toBe('legacy');
+  });
+
+  it('reports which engines each era needs', async () => {
+    const { needsModernEngine, needsLegacyEngine } = await import('../../protocol/version.js');
+    expect(needsModernEngine('modern')).toBe(true);
+    expect(needsModernEngine('auto')).toBe(true);
+    expect(needsModernEngine('legacy')).toBe(false);
+
+    expect(needsLegacyEngine('legacy')).toBe(true);
+    expect(needsLegacyEngine('auto')).toBe(true);
+    expect(needsLegacyEngine('modern')).toBe(false);
+  });
+
+  it('advertises the right wire revision per era', async () => {
+    const { protocolVersionForEra, MODERN_PROTOCOL_VERSION, LEGACY_PROTOCOL_VERSION } = await import(
+      '../../protocol/version.js'
+    );
+    expect(protocolVersionForEra('legacy')).toBe(LEGACY_PROTOCOL_VERSION);
+    expect(protocolVersionForEra('modern')).toBe(MODERN_PROTOCOL_VERSION);
+    // auto advertises the newest supported revision
+    expect(protocolVersionForEra('auto')).toBe(MODERN_PROTOCOL_VERSION);
+  });
+});

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/selector.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/selector.test.ts
@@ -32,18 +32,25 @@ describe('protocol/version selector', () => {
     }
   });
 
-  it('normalizes legacy / unset / unknown to "legacy"', async () => {
+  it('normalizes legacy aliases to "legacy"', async () => {
     const { normalizeProtocolEra } = await import('../../protocol/version.js');
-    for (const v of ['2025-06-18', '2025-11-25', '2025', 'legacy', '', '   ', 'banana', undefined, null]) {
+    for (const v of ['2025-06-18', '2025-11-25', '2025', 'legacy', 'LEGACY', '  2025-06-18 ']) {
       expect(normalizeProtocolEra(v)).toBe('legacy');
     }
   });
 
-  it('defaults to legacy when nothing is set (backwards compatible)', async () => {
+  it('normalizes unset / unknown values to "auto" (default)', async () => {
+    const { normalizeProtocolEra } = await import('../../protocol/version.js');
+    for (const v of ['', '   ', 'banana', undefined, null]) {
+      expect(normalizeProtocolEra(v)).toBe('auto');
+    }
+  });
+
+  it('defaults to auto when nothing is set', async () => {
     delete process.env[ENV_VAR];
     const { resolveProtocolEra } = await import('../../protocol/version.js');
-    expect(resolveProtocolEra()).toBe('legacy');
-    expect(resolveProtocolEra(undefined)).toBe('legacy');
+    expect(resolveProtocolEra()).toBe('auto');
+    expect(resolveProtocolEra(undefined)).toBe('auto');
   });
 
   it('uses config value when env is unset', async () => {

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/stateless-http-lifecycle.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/stateless-http-lifecycle.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Stateless HTTP Lifecycle & Multi-Client Concurrency Test Suite.
+ *
+ * Verifies that:
+ * 1. The Modern MCP 2.0 (2026-07-28) HTTP server operates completely statelessly.
+ * 2. Multiple independent clients (Client A, Client B) execute concurrently with zero cross-talk.
+ * 3. Concurrent requests with identical JSON-RPC IDs execute with full isolation.
+ * 4. No `Mcp-Session-Id` header is required or emitted.
+ * 5. Invalid protocol versions and missing required headers are rejected with standard JSON-RPC codes.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { NitroStackServer } from '../../server.js';
+import { Tool } from '../../tool.js';
+import { z } from 'zod';
+
+const MODERN = '2026-07-28';
+const META_PROTOCOL = 'io.modelcontextprotocol/protocolVersion';
+const META_CLIENT_CAPS = 'io.modelcontextprotocol/clientCapabilities';
+const META_CLIENT_INFO = 'io.modelcontextprotocol/clientInfo';
+
+interface RpcResult {
+  status: number;
+  headers: Headers;
+  body: {
+    jsonrpc?: string;
+    id?: unknown;
+    result?: Record<string, unknown>;
+    error?: { code: number; message: string; data?: unknown };
+  };
+}
+
+function createModernRequest(
+  method: string,
+  params: Record<string, unknown> = {},
+  options: {
+    id?: number | string;
+    clientName?: string;
+    protocolVersion?: string;
+    toolName?: string;
+    extraHeaders?: Record<string, string>;
+  } = {},
+): Request {
+  const envelope = {
+    [META_PROTOCOL]: options.protocolVersion ?? MODERN,
+    [META_CLIENT_CAPS]: {},
+    [META_CLIENT_INFO]: { name: options.clientName ?? 'jest-stateless-client', version: '1.0.0' },
+  };
+
+  const body = {
+    jsonrpc: '2.0',
+    id: options.id ?? 1,
+    method,
+    params: {
+      ...params,
+      _meta: envelope,
+    },
+  };
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'MCP-Protocol-Version': options.protocolVersion ?? MODERN,
+    'Mcp-Method': method,
+    ...(options.toolName ? { 'Mcp-Name': options.toolName } : {}),
+    ...(options.extraHeaders ?? {}),
+  };
+
+  return new Request('http://localhost/mcp', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+async function readRpc(res: Response): Promise<RpcResult> {
+  const text = await res.text();
+  try {
+    return { status: res.status, headers: res.headers, body: JSON.parse(text) };
+  } catch {
+    return { status: res.status, headers: res.headers, body: {} };
+  }
+}
+
+describe('Modern MCP 2.0 Stateless HTTP Lifecycle Suite', () => {
+  let server: NitroStackServer;
+  let handler: { fetch: (req: Request) => Promise<Response>; close: () => Promise<void> };
+  let executionLog: string[] = [];
+
+  beforeAll(async () => {
+    server = new NitroStackServer({
+      name: 'stateless-http-server',
+      version: '2.0.0',
+      protocolVersion: MODERN,
+    });
+
+    server.tool(
+      new Tool({
+        name: 'delayed_echo',
+        description: 'Echo message after delay to test concurrency',
+        inputSchema: z.object({
+          message: z.string(),
+          delayMs: z.number().default(10),
+        }),
+        handler: async (args: any, ctx) => {
+          const clientName = (ctx.clientInfo?.name as string) || 'unknown';
+          executionLog.push(`start:${clientName}:${args.message}`);
+          await new Promise((resolve) => setTimeout(resolve, args.delayMs ?? 10));
+          executionLog.push(`end:${clientName}:${args.message}`);
+          return {
+            echo: args.message,
+            clientName,
+            protocolVersion: ctx.protocolVersion,
+          };
+        },
+      }),
+    );
+
+    server.tool(
+      new Tool({
+        name: 'compute_factorial',
+        description: 'Compute factorial of a number',
+        inputSchema: z.object({
+          n: z.number().min(0).max(20),
+        }),
+        handler: async (args: any) => {
+          let result = 1;
+          for (let i = 2; i <= args.n; i++) result *= i;
+          return { n: args.n, factorial: result };
+        },
+      }),
+    );
+
+    const adapter = await (server as unknown as { getModernAdapter: () => Promise<any> }).getModernAdapter();
+    handler = await adapter.getHttpHandler();
+  });
+
+  afterAll(async () => {
+    await handler?.close?.();
+  });
+
+  it('1. Executes tools/list statelessly without requiring an initialize handshake', async () => {
+    const res = await handler.fetch(createModernRequest('tools/list', {}, { id: 10 }));
+    const { status, headers, body } = await readRpc(res);
+
+    expect(status).toBe(200);
+    expect(headers.get('Mcp-Session-Id')).toBeNull();
+    expect(body.error).toBeUndefined();
+    expect(body.result?.tools).toBeDefined();
+    const tools = body.result?.tools as Array<{ name: string }>;
+    expect(tools.map((t) => t.name)).toContain('delayed_echo');
+    expect(tools.map((t) => t.name)).toContain('compute_factorial');
+  });
+
+  it('2. Independent Client A and Client B execute tool calls without state leakage', async () => {
+    const reqA = createModernRequest(
+      'tools/call',
+      { name: 'delayed_echo', arguments: { message: 'from-Client-A', delayMs: 5 } },
+      { id: 'req-A', clientName: 'Client-Alpha', toolName: 'delayed_echo' },
+    );
+    const reqB = createModernRequest(
+      'tools/call',
+      { name: 'delayed_echo', arguments: { message: 'from-Client-B', delayMs: 5 } },
+      { id: 'req-B', clientName: 'Client-Beta', toolName: 'delayed_echo' },
+    );
+
+    const [resA, resB] = await Promise.all([handler.fetch(reqA), handler.fetch(reqB)]);
+    const [rpcA, rpcB] = await Promise.all([readRpc(resA), readRpc(resB)]);
+
+    expect(rpcA.status).toBe(200);
+    expect(rpcB.status).toBe(200);
+    expect(rpcA.body.id).toBe('req-A');
+    expect(rpcB.body.id).toBe('req-B');
+
+    // Neither response has session IDs
+    expect(rpcA.headers.get('Mcp-Session-Id')).toBeNull();
+    expect(rpcB.headers.get('Mcp-Session-Id')).toBeNull();
+
+    const textA = (rpcA.body.result?.content as Array<{ text: string }>)[0].text;
+    const textB = (rpcB.body.result?.content as Array<{ text: string }>)[0].text;
+
+    expect(textA).toContain('from-Client-A');
+    expect(textA).toContain('Client-Alpha');
+    expect(textB).toContain('from-Client-B');
+    expect(textB).toContain('Client-Beta');
+  });
+
+  it('3. 10 Concurrent requests with identical JSON-RPC IDs execute with full isolation', async () => {
+    const promises = Array.from({ length: 10 }, (_, i) => {
+      const req = createModernRequest(
+        'tools/call',
+        { name: 'compute_factorial', arguments: { n: i + 1 } },
+        { id: 'same-id-999', toolName: 'compute_factorial' },
+      );
+      return handler.fetch(req);
+    });
+
+    const responses = await Promise.all(promises);
+    const results = await Promise.all(responses.map(readRpc));
+
+    for (let i = 0; i < 10; i++) {
+      const r = results[i];
+      expect(r.status).toBe(200);
+      expect(r.body.id).toBe('same-id-999');
+      const text = (r.body.result?.content as Array<{ text: string }>)[0].text;
+      expect(text).toContain(`"n": ${i + 1}`);
+    }
+  });
+
+  it('4. Rejects request with unsupported MCP protocol version with appropriate error', async () => {
+    const req = createModernRequest(
+      'tools/list',
+      {},
+      { id: 404, protocolVersion: '1999-01-01' },
+    );
+    const res = await handler.fetch(req);
+    const { status, body } = await readRpc(res);
+
+    // Modern adapter returns 400 with -32022 Unsupported Protocol Version Error
+    expect(status).toBe(400);
+    expect(body.error).toBeDefined();
+    expect(body.error?.code).toBe(-32022);
+  });
+
+  it('5. Rejects request when required header Mcp-Name is missing on tools/call', async () => {
+    const envelope = {
+      [META_PROTOCOL]: MODERN,
+      [META_CLIENT_CAPS]: {},
+      [META_CLIENT_INFO]: { name: 'test', version: '1.0.0' },
+    };
+
+    // Omit Mcp-Name header
+    const req = new Request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'MCP-Protocol-Version': MODERN,
+        'Mcp-Method': 'tools/call',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 501,
+        method: 'tools/call',
+        params: { name: 'compute_factorial', arguments: { n: 5 }, _meta: envelope },
+      }),
+    });
+
+    const res = await handler.fetch(req);
+    const { status, body } = await readRpc(res);
+
+    expect(status).toBe(400);
+    expect(body.error).toBeDefined();
+    expect(body.error?.code).toBe(-32020);
+  });
+});

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/stdio-transport.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/stdio-transport.test.ts
@@ -1,0 +1,397 @@
+/**
+ * End-to-end STDIO Transport test suite for NitroStack.
+ *
+ * Verifies that:
+ * 1. NitroStackServer can run in pure STDIO mode without any HTTP/SSE listeners.
+ * 2. Real MCP JSON-RPC messages sent over stdin receive valid responses on stdout.
+ * 3. `initialize`, `tools/list`, and `tools/call` execute correctly in both
+ *    Modern (2026-07-28) and Legacy (2025-06-18) protocol eras.
+ * 4. Tool error handling and validation return conforming MCP error structures.
+ * 5. The server terminates cleanly on standard I/O close.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const distIndexPath = resolve(process.cwd(), 'dist/core/index.js');
+
+interface JsonRpcMessage {
+  jsonrpc: string;
+  id?: number | string | null;
+  method?: string;
+  params?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+/** Helper to interact with a child-process MCP server over STDIO */
+class StdioMcpClient {
+  private proc: ChildProcess;
+  private buffer = '';
+  private messageQueue: JsonRpcMessage[] = [];
+  private waiters: Array<(msg: JsonRpcMessage) => void> = [];
+
+  constructor(proc: ChildProcess) {
+    this.proc = proc;
+    this.proc.stdout?.on('data', (chunk: Buffer) => {
+      this.buffer += chunk.toString('utf-8');
+      this.processBuffer();
+    });
+    this.proc.stderr?.on('data', () => {
+      // Diagnostic output on stderr does not corrupt protocol stream
+    });
+  }
+
+  private processBuffer() {
+    const lines = this.buffer.split('\n');
+    // Keep trailing incomplete line in buffer
+    this.buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const parsed = JSON.parse(trimmed) as JsonRpcMessage;
+        if (parsed.jsonrpc === '2.0') {
+          if (this.waiters.length > 0) {
+            const nextWaiter = this.waiters.shift()!;
+            nextWaiter(parsed);
+          } else {
+            this.messageQueue.push(parsed);
+          }
+        }
+      } catch {
+        // Non-JSON output (should not happen on stdout)
+      }
+    }
+  }
+
+  send(message: JsonRpcMessage): void {
+    const payload = JSON.stringify(message) + '\n';
+    this.proc.stdin?.write(payload);
+  }
+
+  async readNext(timeoutMs = 5000): Promise<JsonRpcMessage> {
+    if (this.messageQueue.length > 0) {
+      return this.messageQueue.shift()!;
+    }
+    return new Promise((resolvePromise, rejectPromise) => {
+      const timer = setTimeout(() => {
+        const idx = this.waiters.indexOf(handler);
+        if (idx >= 0) this.waiters.splice(idx, 1);
+        rejectPromise(new Error(`Timeout waiting for STDIO message after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      const handler = (msg: JsonRpcMessage) => {
+        clearTimeout(timer);
+        resolvePromise(msg);
+      };
+
+      this.waiters.push(handler);
+    });
+  }
+
+  async close(): Promise<void> {
+    return new Promise((resolvePromise) => {
+      this.proc.stdin?.end();
+      this.proc.kill('SIGTERM');
+      this.proc.on('exit', () => resolvePromise());
+      setTimeout(() => {
+        this.proc.kill('SIGKILL');
+        resolvePromise();
+      }, 2000);
+    });
+  }
+}
+
+describe('NitroStack STDIO Mode Integration Tests', () => {
+  const serverScript = `
+    import { NitroStackServer, Tool, z } from '${distIndexPath}';
+
+    const server = new NitroStackServer({
+      name: 'test-stdio-server',
+      version: '1.0.0',
+    });
+
+    server.tool(
+      new Tool({
+        name: 'calculate_sum',
+        description: 'Add two numbers together',
+        inputSchema: z.object({
+          a: z.number().describe('First number'),
+          b: z.number().describe('Second number'),
+        }),
+        handler: async (args) => {
+          return { sum: args.a + args.b };
+        },
+      })
+    );
+
+    server.tool(
+      new Tool({
+        name: 'echo',
+        description: 'Echo back input message',
+        inputSchema: z.object({
+          message: z.string(),
+        }),
+        handler: async (args) => {
+          return { echo: args.message };
+        },
+      })
+    );
+
+    await server.start({ transport: 'stdio' });
+  `;
+
+  it('1. Connects, initializes, lists tools, and executes tools over STDIO in Modern (2026-07-28) mode', async () => {
+    const proc = spawn('node', ['--input-type=module', '-e', serverScript], {
+      env: {
+        ...process.env,
+        NITRO_MCP_PROTOCOL_VERSION: '2026-07-28',
+        MCP_TRANSPORT_TYPE: 'stdio',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const client = new StdioMcpClient(proc);
+
+    try {
+      // 1. Send initialize
+      client.send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2026-07-28',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      });
+
+      const initResponse = await client.readNext();
+      expect(initResponse.id).toBe(1);
+      expect(initResponse.error).toBeUndefined();
+      expect(initResponse.result).toBeDefined();
+      expect(initResponse.result?.serverInfo).toMatchObject({
+        name: 'test-stdio-server',
+        version: '1.0.0',
+      });
+      expect(initResponse.result?.capabilities).toBeDefined();
+
+      // Send initialized notification
+      client.send({
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+      });
+
+      // 2. Discover tools via tools/list
+      client.send({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+      });
+
+      const listResponse = await client.readNext();
+      expect(listResponse.id).toBe(2);
+      expect(listResponse.error).toBeUndefined();
+      const tools = listResponse.result?.tools as Array<{ name: string; description: string }>;
+      expect(Array.isArray(tools)).toBe(true);
+      const toolNames = tools.map((t) => t.name);
+      expect(toolNames).toContain('calculate_sum');
+      expect(toolNames).toContain('echo');
+
+      // 3. Execute tool via tools/call with valid arguments
+      client.send({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'calculate_sum',
+          arguments: { a: 15, b: 27 },
+        },
+      });
+
+      const callResponse = await client.readNext();
+      expect(callResponse.id).toBe(3);
+      expect(callResponse.error).toBeUndefined();
+      const content = callResponse.result?.content as Array<{ type: string; text?: string; data?: unknown }>;
+      expect(Array.isArray(content)).toBe(true);
+      expect(content[0].type).toBe('text');
+      expect(content[0].text).toContain('42');
+
+      // 4. Execute tool with second tool
+      client.send({
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: {
+          name: 'echo',
+          arguments: { message: 'hello from stdio' },
+        },
+      });
+
+      const echoResponse = await client.readNext();
+      expect(echoResponse.id).toBe(4);
+      expect(echoResponse.error).toBeUndefined();
+      const echoContent = echoResponse.result?.content as Array<{ type: string; text?: string }>;
+      expect(echoContent[0].text).toContain('hello from stdio');
+
+      // 5. Execute tool with invalid arguments
+      client.send({
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: {
+          name: 'calculate_sum',
+          arguments: { a: 'invalid_number', b: 10 },
+        },
+      });
+
+      const errResponse = await client.readNext();
+      expect(errResponse.id).toBe(5);
+      // Modern protocol validates input schema and returns error result or RPC error
+      const isErr = errResponse.error !== undefined || errResponse.result?.isError === true;
+      expect(isErr).toBe(true);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('2. Connects, initializes, lists tools, and executes tools over STDIO in Legacy (2025-06-18) mode', async () => {
+    const proc = spawn('node', ['--input-type=module', '-e', serverScript], {
+      env: {
+        ...process.env,
+        NITRO_MCP_PROTOCOL_VERSION: '2025-06-18',
+        MCP_TRANSPORT_TYPE: 'stdio',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const client = new StdioMcpClient(proc);
+
+    try {
+      // 1. Send initialize
+      client.send({
+        jsonrpc: '2.0',
+        id: 10,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-06-18',
+          capabilities: {},
+          clientInfo: { name: 'legacy-client', version: '1.0.0' },
+        },
+      });
+
+      const initResponse = await client.readNext();
+      expect(initResponse.id).toBe(10);
+      expect(initResponse.error).toBeUndefined();
+      expect(initResponse.result?.serverInfo).toMatchObject({
+        name: 'test-stdio-server',
+        version: '1.0.0',
+      });
+
+      // Send initialized notification
+      client.send({
+        jsonrpc: '2.0',
+        method: 'notifications/initialized',
+      });
+
+      // 2. Discover tools via tools/list
+      client.send({
+        jsonrpc: '2.0',
+        id: 11,
+        method: 'tools/list',
+      });
+
+      const listResponse = await client.readNext();
+      expect(listResponse.id).toBe(11);
+      expect(listResponse.error).toBeUndefined();
+      const tools = listResponse.result?.tools as Array<{ name: string }>;
+      expect(tools.map((t) => t.name)).toContain('calculate_sum');
+
+      // 3. Execute tool via tools/call
+      client.send({
+        jsonrpc: '2.0',
+        id: 12,
+        method: 'tools/call',
+        params: {
+          name: 'calculate_sum',
+          arguments: { a: 100, b: 200 },
+        },
+      });
+
+      const callResponse = await client.readNext();
+      expect(callResponse.id).toBe(12);
+      expect(callResponse.error).toBeUndefined();
+      const content = callResponse.result?.content as Array<{ type: string; text?: string }>;
+      expect(content[0].text).toContain('300');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('3. Respects server.start({ transport: "stdio" }) programmatic configuration', async () => {
+    const explicitScript = `
+      import { NitroStackServer, Tool, z } from '${distIndexPath}';
+
+      const server = new NitroStackServer({
+        name: 'programmatic-stdio-server',
+        version: '2.0.0',
+      });
+
+      server.tool(
+        new Tool({
+          name: 'hello',
+          description: 'Simple hello tool',
+          inputSchema: z.object({ name: z.string().optional() }),
+          handler: async (args) => ({ message: \`Hello, \${args?.name || 'World'}!\` }),
+        })
+      );
+
+      // Explicitly pass transport: "stdio"
+      await server.start({ transport: 'stdio' });
+    `;
+
+    const proc = spawn('node', ['--input-type=module', '-e', explicitScript], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const client = new StdioMcpClient(proc);
+
+    try {
+      client.send({
+        jsonrpc: '2.0',
+        id: 100,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2026-07-28',
+          capabilities: {},
+          clientInfo: { name: 'programmatic-client', version: '1.0.0' },
+        },
+      });
+
+      const initResponse = await client.readNext();
+      expect(initResponse.id).toBe(100);
+      expect(initResponse.error).toBeUndefined();
+
+      client.send({
+        jsonrpc: '2.0',
+        id: 101,
+        method: 'tools/call',
+        params: {
+          name: 'hello',
+          arguments: { name: 'Developer' },
+        },
+      });
+
+      const callResponse = await client.readNext();
+      expect(callResponse.id).toBe(101);
+      expect(callResponse.error).toBeUndefined();
+      const content = callResponse.result?.content as Array<{ type: string; text?: string }>;
+      expect(content[0].text).toContain('Hello, Developer!');
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/typescript/packages/core/src/core/__tests__/protocol-2026/tasks.integration.test.ts
+++ b/typescript/packages/core/src/core/__tests__/protocol-2026/tasks.integration.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Modern (2026-07-28) MCP Tasks Protocol Integration Test Suite.
+ *
+ * Verifies end-to-end task lifecycle, multi-tenant isolation, cooperative abort,
+ * and single-step embedded result delivery over the modern protocol adapter.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { NitroStackServer } from '../../server.js';
+import { Tool } from '../../tool.js';
+import { z } from 'zod';
+
+const MODERN = '2026-07-28';
+const META_PROTOCOL = 'io.modelcontextprotocol/protocolVersion';
+const META_CLIENT_CAPS = 'io.modelcontextprotocol/clientCapabilities';
+const META_CLIENT_INFO = 'io.modelcontextprotocol/clientInfo';
+
+interface RpcResult {
+  status: number;
+  headers: Headers;
+  body: {
+    jsonrpc?: string;
+    id?: unknown;
+    result?: Record<string, any>;
+    error?: { code: number; message: string; data?: unknown };
+  };
+}
+
+function createModernRequest(
+  method: string,
+  params: Record<string, unknown> = {},
+  options: {
+    id?: number | string;
+    clientName?: string;
+    protocolVersion?: string;
+    toolName?: string;
+    extraHeaders?: Record<string, string>;
+    auth?: { userId?: string; tenantId?: string; sessionId?: string };
+  } = {},
+): Request {
+  const envelope = {
+    [META_PROTOCOL]: options.protocolVersion ?? MODERN,
+    [META_CLIENT_CAPS]: {},
+    [META_CLIENT_INFO]: { name: options.clientName ?? 'jest-modern-task-client', version: '1.0.0' },
+  };
+
+  const body = {
+    jsonrpc: '2.0',
+    id: options.id ?? 1,
+    method,
+    params: {
+      ...params,
+      _meta: envelope,
+    },
+  };
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+    'MCP-Protocol-Version': options.protocolVersion ?? MODERN,
+    'Mcp-Method': method,
+    ...(options.toolName ? { 'Mcp-Name': options.toolName } : {}),
+    ...(options.auth?.sessionId ? { 'Mcp-Session-Id': options.auth.sessionId } : {}),
+    ...(options.extraHeaders ?? {}),
+  };
+
+  const req = new Request('http://localhost/mcp', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (options.auth) {
+    (req as any).auth = {
+      userId: options.auth.userId,
+      tenantId: options.auth.tenantId,
+    };
+  }
+
+  return req;
+}
+
+async function readRpc(res: Response): Promise<RpcResult> {
+  const text = await res.text();
+  try {
+    return { status: res.status, headers: res.headers, body: JSON.parse(text) };
+  } catch {
+    return { status: res.status, headers: res.headers, body: {} };
+  }
+}
+
+describe('Modern MCP 2.0 Tasks Protocol Integration Suite', () => {
+  let server: NitroStackServer;
+  let handler: { fetch: (req: Request) => Promise<Response>; close: () => Promise<void> };
+
+  beforeAll(async () => {
+    server = new NitroStackServer({
+      name: 'modern-task-test-server',
+      version: '1.0.0',
+      protocolVersion: MODERN,
+    });
+
+    // 1. Long running task tool with progress updates
+    server.tool(
+      new Tool({
+        name: 'data_pipeline',
+        description: 'Multi-stage data pipeline',
+        inputSchema: z.object({
+          stages: z.number().default(3),
+          stageDelayMs: z.number().default(30),
+        }),
+        taskSupport: 'optional',
+        handler: async (args: any, ctx) => {
+          const totalStages = args.stages ?? 3;
+          const delay = args.stageDelayMs ?? 30;
+
+          for (let i = 1; i <= totalStages; i++) {
+            if (ctx?.task) {
+              ctx.task.throwIfCancelled();
+              await ctx.task.updateProgress(`Processing stage ${i}/${totalStages}`);
+            }
+            await new Promise((r) => setTimeout(r, delay));
+          }
+
+          return {
+            stagesCompleted: totalStages,
+            outputRecords: 42,
+          };
+        },
+      }),
+    );
+
+    // 2. Mandatory task tool
+    server.tool(
+      new Tool({
+        name: 'mandatory_export',
+        description: 'Export job that strictly requires task augmentation',
+        inputSchema: z.object({ format: z.string() }),
+        taskSupport: 'required',
+        handler: async (args: any) => ({ exported: true, format: args.format }),
+      }),
+    );
+
+    // 3. Forbidden task tool
+    server.tool(
+      new Tool({
+        name: 'instant_lookup',
+        description: 'Instant lookup that strictly forbids task augmentation',
+        inputSchema: z.object({ key: z.string() }),
+        taskSupport: 'forbidden',
+        handler: async (args: any) => ({ value: `val_${args.key}` }),
+      }),
+    );
+
+    const adapter = await (server as unknown as { getModernAdapter: () => Promise<any> }).getModernAdapter();
+    handler = await adapter.getHttpHandler();
+  });
+
+  afterAll(async () => {
+    await handler?.close?.();
+    await server.stop();
+  });
+
+  it('creates task via tools/call returning CreateTaskResult immediately', async () => {
+    const res = await handler.fetch(
+      createModernRequest(
+        'tools/call',
+        {
+          name: 'data_pipeline',
+          arguments: { stages: 2, stageDelayMs: 40 },
+          task: { ttl: 60000 },
+        },
+        { toolName: 'data_pipeline', id: 101 },
+      ),
+    );
+
+    const { status, body } = await readRpc(res);
+    expect(status).toBe(200);
+    expect(body.error).toBeUndefined();
+    expect(body.result?.resultType).toBe('task');
+    expect(body.result?.task?.taskId).toBeDefined();
+    expect(body.result?.task?.status).toBe('working');
+    expect(body.result?.task?.ttl).toBe(60000);
+  });
+
+  it('tracks progress updates and delivers embedded final result via tasks/get', async () => {
+    const createRes = await handler.fetch(
+      createModernRequest(
+        'tools/call',
+        {
+          name: 'data_pipeline',
+          arguments: { stages: 3, stageDelayMs: 40 },
+          task: { ttl: 60000 },
+        },
+        { toolName: 'data_pipeline', id: 102 },
+      ),
+    );
+    const { body: createBody } = await readRpc(createRes);
+    const taskId = createBody.result?.task?.taskId;
+    expect(taskId).toBeDefined();
+
+    // Poll intermediate progress
+    await new Promise((r) => setTimeout(r, 50));
+    const pollRes = await handler.fetch(
+      createModernRequest('tasks/get', { taskId }, { id: 103 }),
+    );
+    const { body: pollBody } = await readRpc(pollRes);
+    expect(pollBody.result?.taskId).toBe(taskId);
+    expect(['working', 'completed']).toContain(pollBody.result?.status);
+
+    // Wait for full completion (3 stages * 40ms = 120ms)
+    await new Promise((r) => setTimeout(r, 150));
+    const finalRes = await handler.fetch(
+      createModernRequest('tasks/get', { taskId }, { id: 104 }),
+    );
+    const { body: finalBody } = await readRpc(finalRes);
+    expect(finalBody.result?.status).toBe('completed');
+    expect(finalBody.result?.result).toEqual({
+      stagesCompleted: 3,
+      outputRecords: 42,
+    });
+  });
+
+  it('cancels an in-progress task cooperatively via tasks/cancel', async () => {
+    // Start long task (10 stages * 100ms = 1000ms)
+    const createRes = await handler.fetch(
+      createModernRequest(
+        'tools/call',
+        {
+          name: 'data_pipeline',
+          arguments: { stages: 10, stageDelayMs: 100 },
+          task: { ttl: 60000 },
+        },
+        { toolName: 'data_pipeline', id: 105 },
+      ),
+    );
+    const { body: createBody } = await readRpc(createRes);
+    const taskId = createBody.result?.task?.taskId;
+    expect(taskId).toBeDefined();
+
+    // Send cancellation request
+    const cancelRes = await handler.fetch(
+      createModernRequest('tasks/cancel', { taskId }, { id: 106 }),
+    );
+    const { body: cancelBody } = await readRpc(cancelRes);
+    expect(cancelBody.result?.status).toBe('cancelled');
+
+    // Confirm tasks/get shows cancelled status
+    const getRes = await handler.fetch(
+      createModernRequest('tasks/get', { taskId }, { id: 107 }),
+    );
+    const { body: getBody } = await readRpc(getRes);
+    expect(getBody.result?.status).toBe('cancelled');
+  });
+
+  it('enforces multi-tenant isolation: Tenant B cannot access Tenant A task', async () => {
+    // Tenant A creates task
+    const tenantAReq = createModernRequest(
+      'tools/call',
+      {
+        name: 'data_pipeline',
+        arguments: { stages: 1, stageDelayMs: 20 },
+        task: { ttl: 60000 },
+      },
+      {
+        toolName: 'data_pipeline',
+        id: 201,
+        auth: { tenantId: 'tenant-alpha', userId: 'user-alice' },
+      },
+    );
+    const createRes = await handler.fetch(tenantAReq);
+    const { body: createBody } = await readRpc(createRes);
+    const taskId = createBody.result?.task?.taskId;
+    expect(taskId).toBeDefined();
+
+    // Tenant B attempts to read Tenant A's task
+    const tenantBGetReq = createModernRequest(
+      'tasks/get',
+      { taskId },
+      {
+        id: 202,
+        auth: { tenantId: 'tenant-beta', userId: 'user-bob' },
+      },
+    );
+    const getResB = await handler.fetch(tenantBGetReq);
+    const { body: getBodyB } = await readRpc(getResB);
+    expect(getBodyB.error).toBeDefined();
+    expect(getBodyB.error?.code).toBe(-32602);
+    expect(getBodyB.error?.message).toContain('Task not found');
+
+    // Tenant B attempts to cancel Tenant A's task
+    const tenantBCancelReq = createModernRequest(
+      'tasks/cancel',
+      { taskId },
+      {
+        id: 203,
+        auth: { tenantId: 'tenant-beta', userId: 'user-bob' },
+      },
+    );
+    const cancelResB = await handler.fetch(tenantBCancelReq);
+    const { body: cancelBodyB } = await readRpc(cancelResB);
+    expect(cancelBodyB.error).toBeDefined();
+    expect(cancelBodyB.error?.code).toBe(-32602);
+
+    // Tenant A reads their task successfully
+    const tenantAGetReq = createModernRequest(
+      'tasks/get',
+      { taskId },
+      {
+        id: 204,
+        auth: { tenantId: 'tenant-alpha', userId: 'user-alice' },
+      },
+    );
+    const getResA = await handler.fetch(tenantAGetReq);
+    const { body: getBodyA } = await readRpc(getResA);
+    expect(getBodyA.error).toBeUndefined();
+    expect(getBodyA.result?.taskId).toBe(taskId);
+  });
+
+  it('enforces mandatory and forbidden task support constraints', async () => {
+    // 1. Mandatory tool without task -> rejected -32600
+    const req1 = createModernRequest(
+      'tools/call',
+      { name: 'mandatory_export', arguments: { format: 'csv' } },
+      { toolName: 'mandatory_export', id: 301 },
+    );
+    const res1 = await handler.fetch(req1);
+    const { body: body1 } = await readRpc(res1);
+    expect(body1.error?.code).toBe(-32600);
+
+    // 2. Mandatory tool with task -> accepted
+    const req2 = createModernRequest(
+      'tools/call',
+      { name: 'mandatory_export', arguments: { format: 'csv' }, task: { ttl: 60000 } },
+      { toolName: 'mandatory_export', id: 302 },
+    );
+    const res2 = await handler.fetch(req2);
+    const { body: body2 } = await readRpc(res2);
+    expect(body2.error).toBeUndefined();
+    expect(body2.result?.resultType).toBe('task');
+
+    // 3. Forbidden tool with task -> rejected -32601
+    const req3 = createModernRequest(
+      'tools/call',
+      { name: 'instant_lookup', arguments: { key: 'foo' }, task: { ttl: 60000 } },
+      { toolName: 'instant_lookup', id: 303 },
+    );
+    const res3 = await handler.fetch(req3);
+    const { body: body3 } = await readRpc(res3);
+    expect(body3.error?.code).toBe(-32601);
+
+    // 4. Forbidden tool without task -> accepted
+    const req4 = createModernRequest(
+      'tools/call',
+      { name: 'instant_lookup', arguments: { key: 'foo' } },
+      { toolName: 'instant_lookup', id: 304 },
+    );
+    const res4 = await handler.fetch(req4);
+    const { body: body4 } = await readRpc(res4);
+    expect(body4.error).toBeUndefined();
+    expect(body4.result?.content).toBeDefined();
+  });
+
+  it('rejects legacy tasks/result and tasks/list with explicit -32601', async () => {
+    const resResult = await handler.fetch(
+      createModernRequest('tasks/result', { taskId: 'any-id' }, { id: 401 }),
+    );
+    const { body: bodyResult } = await readRpc(resResult);
+    expect(bodyResult.error?.code).toBe(-32601);
+    expect(bodyResult.error?.message).toContain('tasks/get');
+
+    const resList = await handler.fetch(
+      createModernRequest('tasks/list', {}, { id: 402 }),
+    );
+    const { body: bodyList } = await readRpc(resList);
+    expect(bodyList.error?.code).toBe(-32601);
+  });
+});

--- a/typescript/packages/core/src/core/__tests__/server.test.ts
+++ b/typescript/packages/core/src/core/__tests__/server.test.ts
@@ -70,6 +70,19 @@ class NotAModule { }
 
 describe('NitroStackServer', () => {
     let server: NitroStackServerType;
+    const originalEnv = process.env.NITRO_MCP_PROTOCOL_VERSION;
+
+    beforeAll(() => {
+        process.env.NITRO_MCP_PROTOCOL_VERSION = '2025-06-18';
+    });
+
+    afterAll(() => {
+        if (originalEnv === undefined) {
+            delete process.env.NITRO_MCP_PROTOCOL_VERSION;
+        } else {
+            process.env.NITRO_MCP_PROTOCOL_VERSION = originalEnv;
+        }
+    });
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/typescript/packages/core/src/core/__tests__/stateful-task.integration.test.ts
+++ b/typescript/packages/core/src/core/__tests__/stateful-task.integration.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Stateful (2025-06-18) MCP Tasks Protocol Integration Test Suite.
+ *
+ * Verifies end-to-end task lifecycle over StreamableHttpTransport:
+ * 1. Session initialization handshake (`initialize` + `notifications/initialized`).
+ * 2. Task creation via `tools/call` with `task: { ttl }`.
+ * 3. Intermediate status polling via `tasks/get`.
+ * 4. Two-step result delivery via `tasks/result`.
+ * 5. Session isolation (Session B cannot poll, read, or cancel Session A tasks).
+ * 6. Cursor-based task listing via `tasks/list`.
+ * 7. Cooperative task cancellation via `tasks/cancel`.
+ * 8. Task support enforcement (`required` vs `forbidden`).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { NitroStackServer } from '../server.js';
+import { Tool } from '../tool.js';
+import { z } from 'zod';
+
+const STATEFUL_PROTOCOL = '2025-06-18';
+const TEST_PORT = 3877;
+const BASE_URL = `http://localhost:${TEST_PORT}/mcp`;
+
+interface RpcResponse {
+  status: number;
+  sessionId: string | null;
+  body: {
+    jsonrpc?: string;
+    id?: unknown;
+    result?: Record<string, any>;
+    error?: { code: number; message: string; data?: unknown };
+  };
+}
+
+async function sendRpc(
+  sessionId: string | null,
+  method: string,
+  params: Record<string, unknown> = {},
+  id: number | string = Date.now(),
+): Promise<RpcResponse> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+  };
+  if (sessionId) {
+    headers['Mcp-Session-Id'] = sessionId;
+  }
+
+  const res = await fetch(BASE_URL, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id,
+      method,
+      params,
+    }),
+  });
+
+  const sid = res.headers.get('mcp-session-id') || sessionId;
+  const text = await res.text();
+
+  let body: any = {};
+  const contentType = res.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = { raw: text };
+    }
+  } else {
+    // SSE stream format
+    const lines = text
+      .split('\n')
+      .filter((l) => l.startsWith('data:'))
+      .map((l) => l.slice('data:'.length).trim());
+    if (lines.length > 0) {
+      try {
+        body = JSON.parse(lines[lines.length - 1]);
+      } catch {
+        body = { raw: text };
+      }
+    }
+  }
+
+  return {
+    status: res.status,
+    sessionId: sid,
+    body,
+  };
+}
+
+describe('Stateful (2025-06-18) MCP Tasks Protocol Integration Suite', () => {
+  let server: NitroStackServer;
+  let sessionA: string;
+  let sessionB: string;
+
+  beforeAll(async () => {
+    server = new NitroStackServer({
+      name: 'stateful-task-test-server',
+      version: '1.0.0',
+      protocolVersion: STATEFUL_PROTOCOL,
+      logging: { level: 'error' },
+    });
+
+    // 1. Multi-stage task tool with cooperative cancellation and progress
+    server.tool(
+      new Tool({
+        name: 'audit_service',
+        description: 'Multi-stage audit service',
+        inputSchema: z.object({
+          stages: z.number().default(3),
+          stageDelayMs: z.number().default(40),
+        }),
+        taskSupport: 'optional',
+        handler: async (args: any, ctx) => {
+          const stages = args.stages ?? 3;
+          const delay = args.stageDelayMs ?? 40;
+
+          for (let i = 1; i <= stages; i++) {
+            if (ctx?.task) {
+              ctx.task.throwIfCancelled();
+              await ctx.task.updateProgress(`Auditing item ${i}/${stages}`);
+            }
+            await new Promise((r) => setTimeout(r, delay));
+          }
+
+          return {
+            audited: true,
+            totalItems: stages,
+          };
+        },
+      }),
+    );
+
+    // 2. Tool requiring task support
+    server.tool(
+      new Tool({
+        name: 'heavy_export',
+        description: 'Export job requiring tasks',
+        inputSchema: z.object({ format: z.string() }),
+        taskSupport: 'required',
+        handler: async (args: any) => ({ exported: true, format: args.format }),
+      }),
+    );
+
+    // 3. Tool forbidding task support
+    server.tool(
+      new Tool({
+        name: 'fast_ping',
+        description: 'Fast ping tool forbidding tasks',
+        inputSchema: z.object({ query: z.string().optional() }),
+        taskSupport: 'forbidden',
+        handler: async (args: any) => ({ pong: true, query: args.query }),
+      }),
+    );
+
+    // Start server in HTTP mode on dedicated port
+    await server.start({
+      transport: 'http',
+      port: TEST_PORT,
+      host: 'localhost',
+      endpoint: '/mcp',
+    });
+
+    // Initialize Session A
+    const initA = await sendRpc(null, 'initialize', {
+      protocolVersion: STATEFUL_PROTOCOL,
+      capabilities: {},
+      clientInfo: { name: 'client-A', version: '1.0.0' },
+    });
+    sessionA = initA.sessionId!;
+    await sendRpc(sessionA, 'notifications/initialized');
+
+    // Initialize Session B
+    const initB = await sendRpc(null, 'initialize', {
+      protocolVersion: STATEFUL_PROTOCOL,
+      capabilities: {},
+      clientInfo: { name: 'client-B', version: '1.0.0' },
+    });
+    sessionB = initB.sessionId!;
+    await sendRpc(sessionB, 'notifications/initialized');
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  it('initializes sessions with valid Mcp-Session-Id headers', () => {
+    expect(sessionA).toBeDefined();
+    expect(sessionB).toBeDefined();
+    expect(sessionA).not.toBe(sessionB);
+  });
+
+  it('creates task via tools/call returning immediate TaskData', async () => {
+    const res = await sendRpc(sessionA, 'tools/call', {
+      name: 'audit_service',
+      arguments: { stages: 2, stageDelayMs: 40 },
+      task: { ttl: 60000 },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.error).toBeUndefined();
+    expect(res.body.result?.task).toBeDefined();
+    expect(res.body.result?.task?.taskId).toBeDefined();
+    expect(res.body.result?.task?.status).toBe('working');
+    expect(res.body.result?.task?.ttl).toBe(60000);
+  });
+
+  it('tracks progress via tasks/get and delivers output via tasks/result (two-step flow)', async () => {
+    const createRes = await sendRpc(sessionA, 'tools/call', {
+      name: 'audit_service',
+      arguments: { stages: 3, stageDelayMs: 40 },
+      task: { ttl: 60000 },
+    });
+    const taskId = createRes.body.result?.task?.taskId;
+    expect(taskId).toBeDefined();
+
+    // 1. Poll intermediate status via tasks/get
+    await new Promise((r) => setTimeout(r, 50));
+    const pollRes = await sendRpc(sessionA, 'tasks/get', { taskId });
+    expect(pollRes.body.error).toBeUndefined();
+    expect(pollRes.body.result?.taskId).toBe(taskId);
+    expect(['working', 'completed']).toContain(pollRes.body.result?.status);
+
+    // 2. In 2025-06-18 stateful mode, tasks/get does NOT embed final tool result
+    // Wait for task completion (3 * 40ms = 120ms)
+    await new Promise((r) => setTimeout(r, 150));
+    const completedGet = await sendRpc(sessionA, 'tasks/get', { taskId });
+    expect(completedGet.body.result?.status).toBe('completed');
+    expect(completedGet.body.result?.result).toBeUndefined();
+
+    // 3. Retrieve final result payload via tasks/result
+    const resultRes = await sendRpc(sessionA, 'tasks/result', { taskId });
+    expect(resultRes.body.error).toBeUndefined();
+    expect(resultRes.body.result).toBeDefined();
+    const resultPayload = resultRes.body.result;
+    expect(resultPayload?.content).toBeDefined();
+  });
+
+  it('enforces strict session isolation: Session B cannot read, poll, or fetch result of Session A task', async () => {
+    // Session A creates task
+    const createRes = await sendRpc(sessionA, 'tools/call', {
+      name: 'audit_service',
+      arguments: { stages: 1, stageDelayMs: 20 },
+      task: { ttl: 60000 },
+    });
+    const taskId = createRes.body.result?.task?.taskId;
+    expect(taskId).toBeDefined();
+
+    // Session B attempts tasks/get on Session A task
+    const getResB = await sendRpc(sessionB, 'tasks/get', { taskId });
+    expect(getResB.body.error).toBeDefined();
+    expect(getResB.body.error?.code).toBe(-32602);
+    expect(getResB.body.error?.message).toContain('Task not found');
+
+    // Session B attempts tasks/result on Session A task
+    const resultResB = await sendRpc(sessionB, 'tasks/result', { taskId });
+    expect(resultResB.body.error).toBeDefined();
+    expect(resultResB.body.error?.code).toBe(-32602);
+
+    // Session B attempts tasks/cancel on Session A task
+    const cancelResB = await sendRpc(sessionB, 'tasks/cancel', { taskId });
+    expect(cancelResB.body.error).toBeDefined();
+    expect(cancelResB.body.error?.code).toBe(-32602);
+
+    // Session A can read task without error
+    const getResA = await sendRpc(sessionA, 'tasks/get', { taskId });
+    expect(getResA.body.error).toBeUndefined();
+    expect(getResA.body.result?.taskId).toBe(taskId);
+  });
+
+  it('supports cursor-based pagination via tasks/list filtered by session', async () => {
+    // Create 2 additional tasks in Session A
+    await sendRpc(sessionA, 'tools/call', {
+      name: 'audit_service',
+      arguments: { stages: 1, stageDelayMs: 10 },
+      task: { ttl: 60000 },
+    });
+    await sendRpc(sessionA, 'tools/call', {
+      name: 'audit_service',
+      arguments: { stages: 1, stageDelayMs: 10 },
+      task: { ttl: 60000 },
+    });
+
+    // List with limit: 2
+    const page1 = await sendRpc(sessionA, 'tasks/list', { limit: 2 });
+    expect(page1.body.error).toBeUndefined();
+    expect(page1.body.result?.tasks.length).toBe(2);
+
+    // All returned tasks must belong to Session A
+    for (const task of page1.body.result?.tasks) {
+      expect(task.sessionId).toBe(sessionA);
+    }
+
+    // Session B list only contains Session B tasks
+    const listB = await sendRpc(sessionB, 'tasks/list', {});
+    expect(listB.body.error).toBeUndefined();
+    for (const task of listB.body.result?.tasks || []) {
+      expect(task.sessionId).toBe(sessionB);
+    }
+  });
+
+  it('cancels an in-progress task cooperatively via tasks/cancel', async () => {
+    const createRes = await sendRpc(sessionA, 'tools/call', {
+      name: 'audit_service',
+      arguments: { stages: 10, stageDelayMs: 100 },
+      task: { ttl: 60000 },
+    });
+    const taskId = createRes.body.result?.task?.taskId;
+    expect(taskId).toBeDefined();
+
+    const cancelRes = await sendRpc(sessionA, 'tasks/cancel', { taskId });
+    expect(cancelRes.body.error).toBeUndefined();
+    expect(cancelRes.body.result?.status).toBe('cancelled');
+
+    const getRes = await sendRpc(sessionA, 'tasks/get', { taskId });
+    expect(getRes.body.result?.status).toBe('cancelled');
+  });
+
+  it('enforces task support constraints in legacy era', async () => {
+    // 1. Mandatory tool without task -> rejected -32600
+    const res1 = await sendRpc(sessionA, 'tools/call', {
+      name: 'heavy_export',
+      arguments: { format: 'json' },
+    });
+    expect(res1.body.error?.code).toBe(-32600);
+
+    // 2. Forbidden tool with task -> rejected -32601
+    const res2 = await sendRpc(sessionA, 'tools/call', {
+      name: 'fast_ping',
+      arguments: {},
+      task: { ttl: 60000 },
+    });
+    expect(res2.body.error?.code).toBe(-32601);
+
+    // 3. Forbidden tool without task -> accepted
+    const res3 = await sendRpc(sessionA, 'tools/call', {
+      name: 'fast_ping',
+      arguments: {},
+    });
+    expect(res3.body.error).toBeUndefined();
+  });
+});

--- a/typescript/packages/core/src/core/__tests__/task.test.ts
+++ b/typescript/packages/core/src/core/__tests__/task.test.ts
@@ -10,6 +10,7 @@ import {
     isTerminalStatus,
     TERMINAL_STATUSES,
     type TaskData,
+    type TaskAccessContext,
 } from '../task.js';
 import type { Logger } from '../types.js';
 
@@ -420,5 +421,162 @@ describe('Task Error Classes', () => {
             expect(err.name).toBe('TaskAugmentationRequiredError');
             expect(err.code).toBe(-32600);
         });
+    });
+});
+
+// ─── Multi-Tenancy & Authorization Isolation Tests ───────────────────────────
+describe('Multi-Tenancy and Authorization Isolation', () => {
+    let manager: TaskManager;
+
+    beforeEach(() => {
+        manager = createManager();
+    });
+
+    afterEach(() => {
+        manager.destroy();
+    });
+
+    it('attaches ownerId, tenantId, and sessionId to task data at creation', () => {
+        const ctx: TaskAccessContext = {
+            userId: 'user-alice',
+            tenantId: 'tenant-acme',
+            sessionId: 'session-123',
+        };
+        const task = manager.createTask({ ttl: 60000 }, 'test_tool', ctx);
+
+        expect(task.ownerId).toBe('user-alice');
+        expect(task.tenantId).toBe('tenant-acme');
+        expect(task.sessionId).toBe('session-123');
+    });
+
+    it('allows owner with matching tenant, user, and session to read task', () => {
+        const ctx: TaskAccessContext = {
+            userId: 'user-alice',
+            tenantId: 'tenant-acme',
+            sessionId: 'session-123',
+        };
+        const task = manager.createTask({ ttl: 60000 }, 'test_tool', ctx);
+
+        const fetched = manager.getTask(task.taskId, ctx);
+        expect(fetched.taskId).toBe(task.taskId);
+        expect(fetched.status).toBe('working');
+    });
+
+    it('throws TaskNotFoundError when user from different tenant attempts getTask()', () => {
+        const aliceCtx: TaskAccessContext = {
+            userId: 'user-alice',
+            tenantId: 'tenant-acme',
+        };
+        const task = manager.createTask({ ttl: 60000 }, 'test_tool', aliceCtx);
+
+        const eveCtx: TaskAccessContext = {
+            userId: 'user-eve',
+            tenantId: 'tenant-evilcorp',
+        };
+
+        expect(() => manager.getTask(task.taskId, eveCtx)).toThrow(TaskNotFoundError);
+    });
+
+    it('throws TaskNotFoundError when different user in same tenant attempts getTask()', () => {
+        const aliceCtx: TaskAccessContext = {
+            userId: 'user-alice',
+            tenantId: 'tenant-acme',
+        };
+        const task = manager.createTask({ ttl: 60000 }, 'test_tool', aliceCtx);
+
+        const bobCtx: TaskAccessContext = {
+            userId: 'user-bob',
+            tenantId: 'tenant-acme',
+        };
+
+        expect(() => manager.getTask(task.taskId, bobCtx)).toThrow(TaskNotFoundError);
+    });
+
+    it('throws TaskNotFoundError when different session attempts getTask()', () => {
+        const session1Ctx: TaskAccessContext = {
+            sessionId: 'session-1',
+        };
+        const task = manager.createTask({ ttl: 60000 }, 'test_tool', session1Ctx);
+
+        const session2Ctx: TaskAccessContext = {
+            sessionId: 'session-2',
+        };
+
+        expect(() => manager.getTask(task.taskId, session2Ctx)).toThrow(TaskNotFoundError);
+    });
+
+    it('prevents unauthorized cancelTask() and preserves working status', () => {
+        const aliceCtx: TaskAccessContext = {
+            userId: 'user-alice',
+            tenantId: 'tenant-acme',
+        };
+        const task = manager.createTask({ ttl: 60000 }, 'test_tool', aliceCtx);
+
+        const eveCtx: TaskAccessContext = {
+            userId: 'user-eve',
+            tenantId: 'tenant-evilcorp',
+        };
+
+        expect(() => manager.cancelTask(task.taskId, eveCtx)).toThrow(TaskNotFoundError);
+
+        // Verify task is still working for Alice
+        const aliceFetched = manager.getTask(task.taskId, aliceCtx);
+        expect(aliceFetched.status).toBe('working');
+    });
+
+    it('allows authorized user to cancel task', () => {
+        const aliceCtx: TaskAccessContext = {
+            userId: 'user-alice',
+            tenantId: 'tenant-acme',
+        };
+        const task = manager.createTask({ ttl: 60000 }, 'test_tool', aliceCtx);
+
+        const cancelled = manager.cancelTask(task.taskId, aliceCtx);
+        expect(cancelled.status).toBe('cancelled');
+    });
+
+    it('prevents unauthorized getResult() on completed task', async () => {
+        const aliceCtx: TaskAccessContext = {
+            userId: 'user-alice',
+            tenantId: 'tenant-acme',
+        };
+        const task = manager.createTask({ ttl: 60000 }, 'test_tool', aliceCtx);
+        manager.completeTask(task.taskId, { confidentialData: 'secret123' }, undefined, aliceCtx);
+
+        const eveCtx: TaskAccessContext = {
+            userId: 'user-eve',
+            tenantId: 'tenant-evilcorp',
+        };
+
+        await expect(manager.getResult(task.taskId, eveCtx)).rejects.toThrow(TaskNotFoundError);
+
+        const aliceResult = await manager.getResult(task.taskId, aliceCtx);
+        expect(aliceResult.result).toEqual({ confidentialData: 'secret123' });
+    });
+
+    it('filters listTasks() strictly by caller tenant and user context', () => {
+        const tenant1Ctx: TaskAccessContext = { tenantId: 'tenant-1', userId: 'user-1' };
+        const tenant2Ctx: TaskAccessContext = { tenantId: 'tenant-2', userId: 'user-2' };
+
+        manager.createTask({ ttl: 60000 }, 'tool_1', tenant1Ctx);
+        manager.createTask({ ttl: 60000 }, 'tool_2', tenant1Ctx);
+        manager.createTask({ ttl: 60000 }, 'tool_3', tenant2Ctx);
+
+        const tenant1List = manager.listTasks(undefined, 50, tenant1Ctx);
+        expect(tenant1List.tasks).toHaveLength(2);
+        expect(tenant1List.tasks.every(t => t.tenantId === 'tenant-1')).toBe(true);
+
+        const tenant2List = manager.listTasks(undefined, 50, tenant2Ctx);
+        expect(tenant2List.tasks).toHaveLength(1);
+        expect(tenant2List.tasks[0].tenantId).toBe('tenant-2');
+    });
+
+    it('hasTask() returns false when probing across tenants', () => {
+        const tenant1Ctx: TaskAccessContext = { tenantId: 'tenant-1' };
+        const task = manager.createTask({ ttl: 60000 }, 'tool', tenant1Ctx);
+
+        const tenant2Ctx: TaskAccessContext = { tenantId: 'tenant-2' };
+        expect(manager.hasTask(task.taskId, tenant1Ctx)).toBe(true);
+        expect(manager.hasTask(task.taskId, tenant2Ctx)).toBe(false);
     });
 });

--- a/typescript/packages/core/src/core/__tests__/task.test.ts
+++ b/typescript/packages/core/src/core/__tests__/task.test.ts
@@ -11,6 +11,9 @@ import {
     TERMINAL_STATUSES,
     type TaskData,
     type TaskAccessContext,
+    type TaskStore,
+    type TaskEntry,
+    InMemoryTaskStore,
 } from '../task.js';
 import type { Logger } from '../types.js';
 
@@ -666,6 +669,84 @@ describe('TTL and Cleanup Eviction Protection', () => {
 
         (manager as any).cleanupExpiredTasks();
         expect(manager.hasTask(task.taskId)).toBe(false);
+    });
+});
+
+// ─── Pluggable TaskStore Abstraction Tests ──────────────────────────────────
+describe('Pluggable TaskStore Abstraction', () => {
+    it('defaults to InMemoryTaskStore when no store is specified', () => {
+        const manager = createManager();
+        expect(manager.getStore()).toBeInstanceOf(InMemoryTaskStore);
+        manager.destroy();
+    });
+
+    it('delegates task storage operations to custom TaskStore', () => {
+        const customItems = new Map<string, TaskEntry>();
+        const setSpy = jest.fn((id: string, entry: TaskEntry) => { customItems.set(id, entry); });
+        const getSpy = jest.fn((id: string) => customItems.get(id));
+        const delSpy = jest.fn((id: string) => customItems.delete(id));
+        const hasSpy = jest.fn((id: string) => customItems.has(id));
+        const listSpy = jest.fn(() => Array.from(customItems.values()));
+
+        const customStore: TaskStore = {
+            get: getSpy,
+            set: setSpy,
+            delete: delSpy,
+            has: hasSpy,
+            list: listSpy,
+        };
+
+        const manager = new TaskManager({
+            logger: createMockLogger(),
+            store: customStore,
+        });
+
+        // 1. Create task
+        const task = manager.createTask({ ttl: 60000 }, 'custom_tool');
+        expect(setSpy).toHaveBeenCalledTimes(1);
+        expect(setSpy).toHaveBeenCalledWith(task.taskId, expect.objectContaining({ data: expect.anything() }));
+
+        // 2. Read task
+        const fetched = manager.getTask(task.taskId);
+        expect(getSpy).toHaveBeenCalledWith(task.taskId);
+        expect(fetched.taskId).toBe(task.taskId);
+
+        // 3. hasTask
+        expect(manager.hasTask(task.taskId)).toBe(true);
+        expect(getSpy).toHaveBeenCalledWith(task.taskId);
+
+        // 4. List tasks
+        const list = manager.listTasks();
+        expect(listSpy).toHaveBeenCalled();
+        expect(list.tasks).toHaveLength(1);
+
+        // 5. Cancel task
+        manager.cancelTask(task.taskId);
+        expect(customItems.get(task.taskId)?.data.status).toBe('cancelled');
+
+        manager.destroy();
+    });
+
+    it('delegates cleanup to custom store cleanupExpired method if defined', () => {
+        const customCleanup = jest.fn<(now: number) => number>().mockReturnValue(3);
+        const customStore: TaskStore = {
+            get: jest.fn<(id: string) => TaskEntry | undefined>(() => undefined),
+            set: jest.fn<(id: string, entry: TaskEntry) => void>(),
+            delete: jest.fn<(id: string) => boolean>(() => false),
+            has: jest.fn<(id: string) => boolean>(() => false),
+            list: jest.fn<() => TaskEntry[]>(() => []),
+            cleanupExpired: customCleanup,
+        };
+
+        const manager = new TaskManager({
+            logger: createMockLogger(),
+            store: customStore,
+        });
+
+        (manager as any).cleanupExpiredTasks();
+        expect(customCleanup).toHaveBeenCalled();
+
+        manager.destroy();
     });
 });
 

--- a/typescript/packages/core/src/core/__tests__/task.test.ts
+++ b/typescript/packages/core/src/core/__tests__/task.test.ts
@@ -580,3 +580,92 @@ describe('Multi-Tenancy and Authorization Isolation', () => {
         expect(manager.hasTask(task.taskId, tenant2Ctx)).toBe(false);
     });
 });
+
+// ─── TTL and Cleanup Eviction Protection Tests ──────────────────────────────
+describe('TTL and Cleanup Eviction Protection', () => {
+    let manager: TaskManager;
+
+    beforeEach(() => {
+        manager = createManager();
+    });
+
+    afterEach(() => {
+        manager.destroy();
+    });
+
+    it('does NOT evict an active task in working status even if duration exceeds TTL', async () => {
+        // Create task with very small TTL (50ms)
+        const task = manager.createTask({ ttl: 50 }, 'long_working_tool');
+
+        // Wait 80ms (longer than TTL) while task is actively working
+        await new Promise(r => setTimeout(r, 80));
+
+        // Trigger sweeper cleanup
+        (manager as any).cleanupExpiredTasks();
+
+        // Verify task was NOT evicted
+        expect(manager.hasTask(task.taskId)).toBe(true);
+        const current = manager.getTask(task.taskId);
+        expect(current.status).toBe('working');
+    });
+
+    it('does NOT evict an active task in input_required status even if duration exceeds TTL', async () => {
+        const task = manager.createTask({ ttl: 50 }, 'input_tool');
+        manager.updateStatus(task.taskId, 'input_required', 'waiting for user');
+
+        await new Promise(r => setTimeout(r, 80));
+
+        (manager as any).cleanupExpiredTasks();
+
+        expect(manager.hasTask(task.taskId)).toBe(true);
+        const current = manager.getTask(task.taskId);
+        expect(current.status).toBe('input_required');
+    });
+
+    it('evicts completed task only after terminal completion time exceeds TTL', async () => {
+        const task = manager.createTask({ ttl: 50 }, 'complete_tool');
+
+        // Complete the task
+        manager.completeTask(task.taskId, { done: true });
+
+        // Run cleanup immediately: must still exist
+        (manager as any).cleanupExpiredTasks();
+        expect(manager.hasTask(task.taskId)).toBe(true);
+
+        // Wait for TTL after completion (80ms)
+        await new Promise(r => setTimeout(r, 80));
+
+        // Run cleanup: must now be evicted
+        (manager as any).cleanupExpiredTasks();
+        expect(manager.hasTask(task.taskId)).toBe(false);
+    });
+
+    it('evicts cancelled task only after terminal cancellation time exceeds TTL', async () => {
+        const task = manager.createTask({ ttl: 50 }, 'cancel_tool');
+        manager.cancelTask(task.taskId);
+
+        // Run cleanup immediately: still exists
+        (manager as any).cleanupExpiredTasks();
+        expect(manager.hasTask(task.taskId)).toBe(true);
+
+        // Wait past TTL
+        await new Promise(r => setTimeout(r, 80));
+
+        (manager as any).cleanupExpiredTasks();
+        expect(manager.hasTask(task.taskId)).toBe(false);
+    });
+
+    it('evicts failed task only after terminal failure time exceeds TTL', async () => {
+        const task = manager.createTask({ ttl: 50 }, 'fail_tool');
+        manager.failTask(task.taskId, { code: -32000, message: 'boom' });
+
+        (manager as any).cleanupExpiredTasks();
+        expect(manager.hasTask(task.taskId)).toBe(true);
+
+        await new Promise(r => setTimeout(r, 80));
+
+        (manager as any).cleanupExpiredTasks();
+        expect(manager.hasTask(task.taskId)).toBe(false);
+    });
+});
+

--- a/typescript/packages/core/src/core/__tests__/transport.http.test.ts
+++ b/typescript/packages/core/src/core/__tests__/transport.http.test.ts
@@ -5,7 +5,7 @@ import { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 
 describe('HttpServerTransport', () => {
     let transport: HttpServerTransport;
-    const port = 3005; // Different port
+    const port = 34505;
     const baseUrl = `http://localhost:${port}/mcp`;
 
     beforeEach(async () => {
@@ -87,8 +87,9 @@ describe('HttpServerTransport', () => {
     });
 
     it('should handle OAuth metadata', async () => {
+        const oauthPort = 34506;
         const oauthTransport = new HttpServerTransport({
-            port: 3006,
+            port: oauthPort,
             oauth: {
                 resourceUri: 'test-res',
                 authorizationServers: ['http://auth.com'],
@@ -97,7 +98,7 @@ describe('HttpServerTransport', () => {
         });
         await oauthTransport.start();
 
-        const res = await fetch(`http://localhost:3006/.well-known/oauth-protected-resource`);
+        const res = await fetch(`http://localhost:${oauthPort}/.well-known/oauth-protected-resource`);
         expect(res.status).toBe(200);
         const data = await res.json() as any;
         expect(data.resource).toBe('test-res');
@@ -110,7 +111,7 @@ describe('HttpServerTransport', () => {
 describe('DiscoveryHttpServer', () => {
     let discovery: DiscoveryHttpServer;
     const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn() };
-    const port = 3007;
+    const port = 34507;
 
     beforeEach(async () => {
         // Support both old (number) and new (options) API
@@ -157,23 +158,23 @@ describe('DiscoveryHttpServer with options', () => {
     });
 
     it('should support options-based constructor', async () => {
-        discovery = new DiscoveryHttpServer({ port: 3008, autoRetry: false }, logger as any);
+        discovery = new DiscoveryHttpServer({ port: 34508, autoRetry: false }, logger as any);
         await discovery.start();
-        expect(discovery.getPort()).toBe(3008);
+        expect(discovery.getPort()).toBe(34508);
     });
 
     it('should auto-retry to find available port when enabled', async () => {
         // Start first server on specific port
-        const first = new DiscoveryHttpServer({ port: 3009, autoRetry: false }, logger as any);
+        const first = new DiscoveryHttpServer({ port: 34509, autoRetry: false }, logger as any);
         await first.start();
         
         // Start second server with auto-retry, should find next available port
-        discovery = new DiscoveryHttpServer({ port: 3009, autoRetry: true, maxRetries: 5 }, logger as any);
+        discovery = new DiscoveryHttpServer({ port: 34509, autoRetry: true, maxRetries: 5 }, logger as any);
         await discovery.start();
         
         // Should have found a different port
-        expect(discovery.getPort()).toBeGreaterThan(3009);
-        expect(discovery.getPort()).toBeLessThanOrEqual(3014); // 3009 + 5 retries
+        expect(discovery.getPort()).toBeGreaterThan(34509);
+        expect(discovery.getPort()).toBeLessThanOrEqual(34514); // 34509 + 5 retries
         
         await first.stop();
     });

--- a/typescript/packages/core/src/core/app-decorator.ts
+++ b/typescript/packages/core/src/core/app-decorator.ts
@@ -73,8 +73,8 @@ export interface McpAppOptions {
     version?: string;
     /**
      * MCP protocol era to serve (additive; env `NITRO_MCP_PROTOCOL_VERSION`
-     * wins). Unset ⇒ current 2025-era path. `2026-07-28` / `auto` engage the
-     * modern adapter.
+     * wins). Unset ⇒ 'auto' (serves modern 2026-07-28 stateless with legacy fallback).
+     * `2026-07-28` enforces pure modern; `2025-06-18` / `legacy` selects sessionful legacy.
      */
     protocolVersion?: string;
     /**

--- a/typescript/packages/core/src/core/app-decorator.ts
+++ b/typescript/packages/core/src/core/app-decorator.ts
@@ -403,8 +403,8 @@ export class McpApplicationFactory {
       };
     }
 
-    // Auto-detect transport type based on configuration
-    let transportType: 'stdio' | 'http' | 'dual' = 'stdio';
+    // Auto-detect transport type based on configuration (leave undefined by default so server.start() resolves based on NODE_ENV)
+    let transportType: 'stdio' | 'http' | 'dual' | undefined = undefined;
     let transportOptions: TransportOptions | undefined = undefined;
     
     // Check explicit transport configuration
@@ -460,11 +460,15 @@ export class McpApplicationFactory {
     
     // Store transport configuration on server for later use
     const serverInternal = server as unknown as { 
-      _transportType: 'stdio' | 'http' | 'dual';
-      _transportOptions: TransportOptions | undefined;
+      _transportType?: 'stdio' | 'http' | 'dual';
+      _transportOptions?: TransportOptions;
     };
-    serverInternal._transportType = transportType;
-    serverInternal._transportOptions = transportOptions;
+    if (transportType !== undefined) {
+      serverInternal._transportType = transportType;
+    }
+    if (transportOptions !== undefined) {
+      serverInternal._transportOptions = transportOptions;
+    }
 
     // Register graceful-shutdown signal handlers so shutdown lifecycle hooks run
     // on SIGTERM/SIGINT. Opt-out via `shutdownHooks: false`.

--- a/typescript/packages/core/src/core/app-decorator.ts
+++ b/typescript/packages/core/src/core/app-decorator.ts
@@ -421,13 +421,22 @@ export class McpApplicationFactory {
       // This allows Studio to connect via STDIO while exposing OAuth metadata via HTTP
       transportType = 'dual';
       
-      // Extract port from resourceUri (e.g., http://localhost:3002)
-      let port = 3000;
-      try {
-        const resourceUrl = new URL(oauthConfig.resourceUri);
-        port = resourceUrl.port ? parseInt(resourceUrl.port) : (resourceUrl.protocol === 'https:' ? 443 : 80);
-      } catch (error) {
-        logger.warn(`Failed to parse resourceUri for port, using default 3000`);
+      // Extract port: explicit config > process.env.PORT > resourceUri explicit port > default 3000
+      let port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
+      if (oauthConfig.resourceUri) {
+        try {
+          const resourceUrl = new URL(oauthConfig.resourceUri);
+          if (resourceUrl.port) {
+            port = parseInt(resourceUrl.port, 10);
+          }
+        } catch (error) {
+          logger.warn(`Failed to parse resourceUri for port, using default ${port}`);
+        }
+      }
+      
+      // Override with process.env.PORT if set (environment takes precedence over resourceUri URL)
+      if (process.env.PORT) {
+        port = parseInt(process.env.PORT, 10);
       }
       
       // Override with explicit config if provided

--- a/typescript/packages/core/src/core/app-decorator.ts
+++ b/typescript/packages/core/src/core/app-decorator.ts
@@ -71,6 +71,16 @@ export interface McpAppOptions {
   server?: {
     name?: string;
     version?: string;
+    /**
+     * MCP protocol era to serve (additive; env `NITRO_MCP_PROTOCOL_VERSION`
+     * wins). Unset ⇒ current 2025-era path. `2026-07-28` / `auto` engage the
+     * modern adapter.
+     */
+    protocolVersion?: string;
+    /**
+     * Extra extensions to advertise on the 2026-07-28 `server/discover` map.
+     */
+    extensions?: Record<string, Record<string, unknown>>;
   };
   
   /**
@@ -271,6 +281,8 @@ export class McpApplicationFactory {
     const server = createServer({
       name: options.server?.name || 'mcp-server',
       version: options.server?.version || '1.0.0',
+      ...(options.server?.protocolVersion ? { protocolVersion: options.server.protocolVersion } : {}),
+      ...(options.server?.extensions ? { extensions: options.server.extensions } : {}),
     });
 
     // Now register and add dynamic modules (from forRoot() calls) to server

--- a/typescript/packages/core/src/core/builders.ts
+++ b/typescript/packages/core/src/core/builders.ts
@@ -20,6 +20,7 @@ import { getMiddlewareMetadata } from './middleware/middleware.decorator.js';
 import { getInterceptorMetadata } from './interceptors/interceptor.decorator.js';
 import { getPipeMetadata } from './pipes/pipe.decorator.js';
 import { getExceptionFilterMetadata } from './filters/exception-filter.decorator.js';
+import { getCacheMetadata } from './decorators/cache.decorator.js';
 import { DIContainer } from './di/container.js';
 /**
  * Controller instance type
@@ -56,6 +57,9 @@ export function buildTool(
   const interceptors = getInterceptorMetadata(prototype, methodName);
   const pipes = getPipeMetadata(prototype, methodName);
   const filters = getExceptionFilterMetadata(prototype, methodName);
+  // @Cache({ ttl }) on the method becomes the SEP-2549 cache-hint source used
+  // on the 2026-07-28 tools/list result (no effect on the legacy path).
+  const cacheMeta = getCacheMetadata(prototype, methodName);
 
   // Create tool with all metadata
   const tool = new Tool({
@@ -77,6 +81,7 @@ export function buildTool(
     outputTemplate: widgetRoute,
     isInitial,
     taskSupport: options.taskSupport,
+    cacheTtlSeconds: cacheMeta?.ttl,
   });
 
   // Create and attach component if widget route is specified

--- a/typescript/packages/core/src/core/errors.ts
+++ b/typescript/packages/core/src/core/errors.ts
@@ -80,6 +80,16 @@ export class ToolExecutionError extends McpError {
 }
 
 /**
+ * Task unauthorized / access denied error
+ */
+export class TaskUnauthorizedError extends McpError {
+  constructor(taskId: string, message: string = 'Access denied to task') {
+    super(`Task '${taskId}': ${message}`, 'TASK_UNAUTHORIZED', 403);
+    this.name = 'TaskUnauthorizedError';
+  }
+}
+
+/**
  * Format error for response
  */
 export function formatError(error: Error): {

--- a/typescript/packages/core/src/core/guards/oauth.guard.ts
+++ b/typescript/packages/core/src/core/guards/oauth.guard.ts
@@ -1,13 +1,11 @@
+import type { Guard } from './guard.interface.js';
+import type { ExecutionContext } from '../types.js';
+import { OAuthModule } from '../oauth-module.js';
+
 /**
  * OAuth Token Payload Interface
  * 
  * Standard OAuth 2.1 / JWT claims (RFC 9068)
- * 
- * This is exported from the SDK for type definitions.
- * The actual OAuthGuard implementation should be in your project's guards folder.
- * 
- * @example
- * See templates/typescript-oauth/src/guards/oauth.guard.ts for implementation
  */
 export interface OAuthTokenPayload {
   /** Subject - typically the user ID */
@@ -40,6 +38,110 @@ export interface OAuthTokenPayload {
   
   /** Custom claims */
   [key: string]: unknown;
+}
+
+/**
+ * Built-in Standard OAuth 2.1 Guard
+ */
+export class OAuthGuard implements Guard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // 1. If request is already authenticated (via HTTP Bearer middleware or SDK metadata extraction), pass immediately
+    if (context.auth?.authenticated || context.auth?.subject) {
+      return true;
+    }
+
+    // 2. Extract token from metadata or Authorization header
+    const authHeader = (context.metadata?.authorization || context.metadata?.Authorization) as string | undefined;
+    const metaToken = (context.metadata?._oauth || context.metadata?.token || context.metadata?.jwtToken) as string | undefined;
+    const inputMetaToken = (context as any).input?._meta?.jwtToken ||
+      (context as any).input?._meta?.token ||
+      (context as any).params?._meta?.jwtToken ||
+      (context as any).params?._meta?.token;
+
+    let token: string | null = null;
+    if (authHeader?.startsWith('Bearer ')) {
+      token = authHeader.substring(7);
+    } else if (authHeader) {
+      token = authHeader;
+    } else if (metaToken) {
+      token = metaToken;
+    } else if (inputMetaToken) {
+      token = inputMetaToken;
+    }
+
+    // 3. If OAuth is not enforced (dev mode), allow through
+    if (!OAuthModule.isAuthRequired()) {
+      if (token) {
+        const result = await OAuthModule.validateToken(token);
+        if (result.valid && result.payload) {
+          const payload = result.payload as unknown as OAuthTokenPayload;
+          context.auth = {
+            authenticated: true,
+            subject: payload.sub,
+            scopes: this.extractScopes(payload),
+            clientId: payload.client_id,
+            tokenPayload: payload,
+          };
+        }
+      }
+      return true;
+    }
+
+    if (!token) {
+      throw new Error(
+        'OAuth token required. Please authenticate or provide a valid Bearer token in Authorization header: "Bearer <token>"'
+      );
+    }
+
+    const result = await OAuthModule.validateToken(token);
+    if (!result.valid || !result.payload) {
+      throw new Error(`OAuth token validation failed: ${result.error || 'Invalid token'}`);
+    }
+
+    const payload = result.payload as unknown as OAuthTokenPayload;
+    context.auth = {
+      authenticated: true,
+      subject: payload.sub,
+      scopes: this.extractScopes(payload),
+      clientId: payload.client_id,
+      tokenPayload: payload,
+    };
+
+    return true;
+  }
+
+  private extractScopes(payload: OAuthTokenPayload): string[] {
+    if (payload.scopes && Array.isArray(payload.scopes)) {
+      return payload.scopes;
+    }
+    if (payload.scope && typeof payload.scope === 'string') {
+      return payload.scope.split(' ').filter(s => s.length > 0);
+    }
+    return [];
+  }
+}
+
+/**
+ * Scope Guard Factory
+ */
+export function createScopeGuard(requiredScopes: string[]): new () => Guard {
+  return class ScopeGuard implements Guard {
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+      const userScopes = context.auth?.scopes || [];
+      const missingScopes = requiredScopes.filter(
+        scope => !userScopes.includes(scope)
+      );
+
+      if (missingScopes.length > 0) {
+        throw new Error(
+          `Insufficient scope. Required: ${requiredScopes.join(', ')}. ` +
+          `Missing: ${missingScopes.join(', ')}`
+        );
+      }
+
+      return true;
+    }
+  };
 }
 
 

--- a/typescript/packages/core/src/core/index.ts
+++ b/typescript/packages/core/src/core/index.ts
@@ -142,6 +142,7 @@ export type { Guard, GuardConstructor } from './guards/guard.interface.js';
 export { UseGuards, getGuardsMetadata as getGuardsMetadataFromDecorator } from './guards/use-guards.decorator.js';
 export type { JWTPayload } from './guards/jwt.guard.js';
 export type { ApiKeyMetadata } from './guards/apikey.guard.js';
+export { OAuthGuard, createScopeGuard } from './guards/oauth.guard.js';
 export type { OAuthTokenPayload } from './guards/oauth.guard.js';
 
 // ========== V3 JWT Module ==========

--- a/typescript/packages/core/src/core/index.ts
+++ b/typescript/packages/core/src/core/index.ts
@@ -27,6 +27,25 @@ export { createComponent, Component } from './component.js';
 // Logger
 export { createLogger, defaultLogger } from './logger.js';
 
+// ========== MCP Protocol (2025-era + 2026-07-28 dual spec) ==========
+export {
+  resolveProtocolEra,
+  normalizeProtocolEra,
+  needsModernEngine,
+  needsLegacyEngine,
+  protocolVersionForEra,
+  MODERN_PROTOCOL_VERSION,
+  LEGACY_PROTOCOL_VERSION,
+  PROTOCOL_ENV_VAR,
+} from './protocol/version.js';
+export type { ProtocolEra } from './protocol/version.js';
+// Multi Round-Trip Request (MRTR) helpers — additive, era-agnostic.
+export { inputRequired, acceptedContent, isInputRequired } from './protocol/features/mrtr.js';
+export type { NitroInputRequest, NitroInputRequiredResult } from './protocol/features/mrtr.js';
+// Extension identifiers (SEP-2133).
+export { EXT_APP, EXT_TASKS, buildExtensionsMap } from './protocol/features/extensions.js';
+export type { ProtocolAdapter, ProtocolRegistry } from './protocol/adapter.js';
+
 // Errors
 export * from './errors.js';
 

--- a/typescript/packages/core/src/core/oauth-module.ts
+++ b/typescript/packages/core/src/core/oauth-module.ts
@@ -462,8 +462,14 @@ export class OAuthModule {
     };
 
     // Add optional fields
-    if (this.config.scopesSupported && this.config.scopesSupported.length > 0) {
-      metadata.scopes_supported = this.config.scopesSupported;
+    const resolvedScopes = (this.config.scopesSupported && this.config.scopesSupported.length > 0)
+      ? this.config.scopesSupported
+      : (process.env.COGNERD_SCOPE || process.env.AUTH_SCOPES || '')
+          .split(/[\s,]+/)
+          .filter(Boolean);
+
+    if (resolvedScopes.length > 0) {
+      metadata.scopes_supported = resolvedScopes;
     }
 
     res.writeHead(200, headers);

--- a/typescript/packages/core/src/core/oauth-module.ts
+++ b/typescript/packages/core/src/core/oauth-module.ts
@@ -93,6 +93,11 @@ export interface OAuthModuleConfig {
    * Disabled by default. When disabled, the endpoint responds 404 and
    * `registration_endpoint` is omitted from advertised metadata.
    * Can also be enabled via the OAUTH_ENABLE_CLIENT_REGISTRATION=true env var.
+   *
+   * @deprecated on MCP 2026-07-28: the final authorization spec deprecates DCR
+   * in favor of Client ID Metadata Documents (CIMD, see `auth/cimd.ts`). DCR
+   * remains supported on the legacy path and as an explicit opt-in; prefer CIMD
+   * for new 2026-07-28 deployments.
    */
   enableClientRegistration?: boolean;
 

--- a/typescript/packages/core/src/core/oauth-module.ts
+++ b/typescript/packages/core/src/core/oauth-module.ts
@@ -218,7 +218,6 @@ interface DiscoveryResponse {
   end: (data: string) => void;
 }
 
-@Injectable()
 export class OAuthModule {
   private static config: OAuthModuleConfig | null = null;
   private static discoveryInfo: OAuthDiscoveryInfo | null = null;

--- a/typescript/packages/core/src/core/oauth-module.ts
+++ b/typescript/packages/core/src/core/oauth-module.ts
@@ -766,10 +766,16 @@ export class OAuthModule {
       return { valid: false, error: 'OAuth module not configured' };
     }
 
+    if (!token || typeof token !== 'string') {
+      return { valid: false, error: 'Token is required' };
+    }
+
+    const cleanToken = token.startsWith('Bearer ') ? token.substring(7).trim() : token.trim();
+
     try {
       // Decode the header to check token type and provide helpful error message
       try {
-        const headerPart = token.split('.')[0];
+        const headerPart = cleanToken.split('.')[0];
         const decodedHeader = JSON.parse(Buffer.from(headerPart, 'base64').toString());
 
         // Check if we received a JWE (encrypted) token instead of JWT
@@ -785,7 +791,7 @@ export class OAuthModule {
 
       // If introspection or JWKS is configured, delegate to token-validation.ts pipeline
       if (this.config.tokenIntrospectionEndpoint || this.config.jwksUri) {
-        const result = await authValidateToken(token, this.config);
+        const result = await authValidateToken(cleanToken, this.config);
 
         if (!result.valid || !result.introspection) {
           return { valid: false, error: result.error || 'Invalid token' };

--- a/typescript/packages/core/src/core/oauth-module.ts
+++ b/typescript/packages/core/src/core/oauth-module.ts
@@ -462,11 +462,13 @@ export class OAuthModule {
     };
 
     // Add optional fields
-    const resolvedScopes = (this.config.scopesSupported && this.config.scopesSupported.length > 0)
-      ? this.config.scopesSupported
-      : (process.env.COGNERD_SCOPE || process.env.AUTH_SCOPES || '')
-          .split(/[\s,]+/)
-          .filter(Boolean);
+    const envScopes = (process.env.COGNERD_SCOPE || process.env.AUTH_SCOPES || '')
+      .split(/[\s,]+/)
+      .filter(Boolean);
+
+    const resolvedScopes = envScopes.length > 0
+      ? envScopes
+      : (this.config.scopesSupported || []);
 
     if (resolvedScopes.length > 0) {
       metadata.scopes_supported = resolvedScopes;

--- a/typescript/packages/core/src/core/protocol/adapter.ts
+++ b/typescript/packages/core/src/core/protocol/adapter.ts
@@ -1,0 +1,104 @@
+/**
+ * Protocol adapter contract.
+ *
+ * NitroStack owns the registry (tools / resources / prompts / tasks / config).
+ * A protocol adapter binds that registry to a concrete MCP wire implementation:
+ *
+ * - the **legacy** adapter is today's `@modelcontextprotocol/sdk` v1 path,
+ *   embodied by `NitroStackServer` itself and its `StreamableHttpTransport`.
+ * - the **modern** adapter is the official `@modelcontextprotocol/server` v2
+ *   engine (`createMcpHandler` + `serveStdio`), loaded lazily only when the
+ *   selector resolves to `2026-07-28` or `auto`.
+ *
+ * The adapter never imports NitroStack decorators or DI; it consumes the
+ * read-only `ProtocolRegistry` surface below. This keeps the user-facing
+ * framework layer (decorators, modules, guards, pipes) unchanged regardless of
+ * which era is served.
+ *
+ * @module
+ */
+
+import type { Express } from 'express';
+import type { Tool } from '../tool.js';
+import type { Resource, ResourceTemplate } from '../resource.js';
+import type { Prompt } from '../prompt.js';
+import type { TaskManager } from '../task.js';
+import type { ExecutionContext, Logger, McpServerConfig, JsonValue } from '../types.js';
+
+/**
+ * Read-only view of a NitroStack application's registry that a protocol adapter
+ * needs in order to serve requests. Implemented by `NitroStackServer`.
+ */
+export interface ProtocolRegistry {
+  /** Server identity/config (name, version, description). */
+  readonly config: McpServerConfig;
+  /** Shared logger. */
+  readonly logger: Logger;
+  /** Registered tools keyed by name. */
+  getTools(): Map<string, Tool>;
+  /** Registered static resources keyed by URI. */
+  getResources(): Map<string, Resource>;
+  /** Registered resource templates keyed by URI template. */
+  getResourceTemplates(): Map<string, ResourceTemplate>;
+  /** Resource instances backing a template, keyed by URI template. */
+  getTemplateResources(): Map<string, Resource>;
+  /** Registered prompts keyed by name. */
+  getPrompts(): Map<string, Prompt>;
+  /** In-process task manager. */
+  getTaskManager(): TaskManager;
+  /**
+   * Build an execution context for a request. `extra` is merged into the
+   * context so adapters can attach era-specific fields (protocolVersion,
+   * requestState, inputResponses, trace, clientInfo, clientCapabilities).
+   */
+  createExecutionContext(options?: {
+    metadata?: Record<string, JsonValue>;
+    toolName?: string;
+    extra?: Partial<ExecutionContext>;
+  }): ExecutionContext;
+}
+
+/**
+ * Options passed to a protocol adapter when it starts a transport.
+ */
+export interface ProtocolTransportOptions {
+  port?: number;
+  host?: string;
+  endpoint?: string;
+  enableCors?: boolean;
+}
+
+/**
+ * A protocol adapter binds the registry to a concrete transport implementation.
+ * The legacy path is served directly by `NitroStackServer`; the modern path is
+ * served by `ModernProtocolAdapter`.
+ */
+export interface ProtocolAdapter {
+  /** The era this adapter serves. */
+  readonly era: 'modern';
+
+  /**
+   * Serve the modern protocol over HTTP by mounting a handler on the provided
+   * Express app at `endpoint`. Returns when routes are attached (the caller
+   * owns `app.listen`).
+   */
+  attachHttp(app: Express, options: ProtocolTransportOptions): Promise<void>;
+
+  /**
+   * Serve the modern protocol over stdio. Resolves once the connection-pinned
+   * stdio server is listening.
+   */
+  serveStdio(): Promise<void>;
+
+  /** Publish a tools/list changed event on the modern notify bus. */
+  notifyToolsListChanged(): void;
+  /** Publish a resources/list changed event on the modern notify bus. */
+  notifyResourcesListChanged(): void;
+  /** Publish a prompts/list changed event on the modern notify bus. */
+  notifyPromptsListChanged(): void;
+  /** Publish a resources/updated event for a specific URI on the modern notify bus. */
+  notifyResourceUpdated(uri: string): void;
+
+  /** Tear down any modern transport resources. */
+  close(): Promise<void>;
+}

--- a/typescript/packages/core/src/core/protocol/features/cache-hints.ts
+++ b/typescript/packages/core/src/core/protocol/features/cache-hints.ts
@@ -1,0 +1,93 @@
+/**
+ * SEP-2549 cache hints (`ttlMs` / `cacheScope`).
+ *
+ * On the 2026-07-28 revision, `tools/list`, `prompts/list`, `resources/list`,
+ * `resources/templates/list`, `resources/read`, and `server/discover` results
+ * carry `ttlMs` (freshness hint in ms) and `cacheScope` (`public` | `private`).
+ *
+ * NitroStack maps its existing caching signals onto these hints:
+ * - a tool's `@Cache({ ttl })` (seconds) or explicit `cacheHint` → per-tool hint
+ * - a resource's `metadata.cacheMaxAge` (seconds) or explicit `cacheHint` → hint
+ *
+ * The 2025-era path never emits these fields, so this module is only consulted
+ * by the modern adapter. The conservative default (`ttlMs: 0`,
+ * `cacheScope: 'private'`) is left to the SDK when no hint is resolved.
+ *
+ * @module
+ */
+
+/**
+ * Cache scope for a cacheable result (SEP-2549).
+ */
+export type CacheScope = 'public' | 'private';
+
+/**
+ * A NitroStack cache hint. Mirrors the v2 SDK `CacheHint` shape so it can be
+ * handed to `registerResource(..., { cacheHint })` / `ServerOptions.cacheHints`
+ * without coupling non-modern code to the v2 types.
+ */
+export interface NitroCacheHint {
+  /** Cache lifetime in milliseconds (non-negative). */
+  ttlMs?: number;
+  /** Whether shared caches may store the result. */
+  cacheScope?: CacheScope;
+}
+
+/**
+ * Minimal shape of a tool for hint resolution (avoids importing the Tool class
+ * to keep this feature dependency-light and testable).
+ */
+export interface CacheHintToolLike {
+  cacheHint?: NitroCacheHint;
+  /** Seconds — typically propagated from `@Cache({ ttl })`. */
+  cacheTtlSeconds?: number;
+}
+
+/**
+ * Minimal shape of a resource for hint resolution.
+ */
+export interface CacheHintResourceLike {
+  cacheHint?: NitroCacheHint;
+  metadata?: { cacheable?: boolean; cacheMaxAge?: number };
+}
+
+/**
+ * Resolve a cache hint for a tool, or `undefined` when it has no caching signal.
+ */
+export function resolveToolCacheHint(tool: CacheHintToolLike): NitroCacheHint | undefined {
+  if (tool.cacheHint && (tool.cacheHint.ttlMs !== undefined || tool.cacheHint.cacheScope !== undefined)) {
+    return normalizeHint(tool.cacheHint);
+  }
+  if (typeof tool.cacheTtlSeconds === 'number' && tool.cacheTtlSeconds > 0) {
+    return { ttlMs: Math.round(tool.cacheTtlSeconds * 1000), cacheScope: 'private' };
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a cache hint for a resource, or `undefined` when it has none.
+ */
+export function resolveResourceCacheHint(resource: CacheHintResourceLike): NitroCacheHint | undefined {
+  if (resource.cacheHint && (resource.cacheHint.ttlMs !== undefined || resource.cacheHint.cacheScope !== undefined)) {
+    return normalizeHint(resource.cacheHint);
+  }
+  const maxAge = resource.metadata?.cacheMaxAge;
+  if (typeof maxAge === 'number' && maxAge > 0) {
+    return { ttlMs: Math.round(maxAge * 1000), cacheScope: 'private' };
+  }
+  return undefined;
+}
+
+/**
+ * Clamp/validate a hint into safe values.
+ */
+export function normalizeHint(hint: NitroCacheHint): NitroCacheHint {
+  const out: NitroCacheHint = {};
+  if (typeof hint.ttlMs === 'number' && Number.isFinite(hint.ttlMs) && hint.ttlMs >= 0) {
+    out.ttlMs = Math.floor(hint.ttlMs);
+  }
+  if (hint.cacheScope === 'public' || hint.cacheScope === 'private') {
+    out.cacheScope = hint.cacheScope;
+  }
+  return out;
+}

--- a/typescript/packages/core/src/core/protocol/features/errors.ts
+++ b/typescript/packages/core/src/core/protocol/features/errors.ts
@@ -1,0 +1,64 @@
+/**
+ * Era-aware JSON-RPC error mapping.
+ *
+ * The 2026-07-28 revision changed the error for a missing resource
+ * (SEP-2164): `resources/read` on an unknown URI now returns `-32602`
+ * (Invalid Params) instead of the 2025-era `-32002` (Resource Not Found).
+ * NitroStack keeps the 2025 mapping on the legacy path; the modern adapter
+ * uses `mapToJsonRpcError` so its handlers throw the right code.
+ *
+ * @module
+ */
+
+import {
+  McpError,
+  ValidationError,
+  ToolNotFoundError,
+  ResourceNotFoundError,
+  PromptNotFoundError,
+  RateLimitError,
+} from '../../errors.js';
+
+/** Standard JSON-RPC / MCP error codes. */
+export const JSON_RPC = {
+  PARSE_ERROR: -32700,
+  INVALID_REQUEST: -32600,
+  METHOD_NOT_FOUND: -32601,
+  INVALID_PARAMS: -32602,
+  INTERNAL_ERROR: -32603,
+  /** SEP-2243: request header/body mismatch. */
+  HEADER_BODY_MISMATCH: -32020,
+} as const;
+
+/** A JSON-RPC error object. */
+export interface JsonRpcError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+/**
+ * Map a thrown error to a JSON-RPC error for the modern (2026-07-28) path.
+ *
+ * Key difference vs legacy: `ResourceNotFoundError` → `-32602` (SEP-2164).
+ */
+export function mapToJsonRpcError(error: unknown): JsonRpcError {
+  if (error instanceof ResourceNotFoundError) {
+    // SEP-2164: unknown resource is Invalid Params on 2026-07-28.
+    return { code: JSON_RPC.INVALID_PARAMS, message: error.message };
+  }
+  if (error instanceof ValidationError) {
+    return { code: JSON_RPC.INVALID_PARAMS, message: error.message, data: error.details };
+  }
+  if (error instanceof ToolNotFoundError || error instanceof PromptNotFoundError) {
+    return { code: JSON_RPC.METHOD_NOT_FOUND, message: error.message };
+  }
+  if (error instanceof RateLimitError) {
+    return { code: JSON_RPC.INTERNAL_ERROR, message: error.message };
+  }
+  if (error instanceof McpError) {
+    return { code: JSON_RPC.INTERNAL_ERROR, message: error.message, data: error.details };
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return { code: JSON_RPC.INTERNAL_ERROR, message };
+}

--- a/typescript/packages/core/src/core/protocol/features/extensions.ts
+++ b/typescript/packages/core/src/core/protocol/features/extensions.ts
@@ -1,0 +1,61 @@
+/**
+ * SEP-2133 extensions map (modern path).
+ *
+ * On 2026-07-28, capabilities that used to be baked into the core spec are
+ * negotiated as named extensions advertised on `server/discover`. NitroStack
+ * derives this map from what the app actually registered:
+ *
+ * - `io.modelcontextprotocol/app` — advertised when any tool ships a UI
+ *   component / `@Widget` (MCP Apps).
+ * - `io.modelcontextprotocol/tasks` — advertised when any tool declares
+ *   `taskSupport` other than `forbidden`.
+ *
+ * Apps may declare extra extensions via `@McpApp({ extensions })`, which are
+ * merged in verbatim.
+ *
+ * @module
+ */
+
+/** Canonical extension identifier for MCP Apps. */
+export const EXT_APP = 'io.modelcontextprotocol/app';
+/** Canonical extension identifier for the Tasks extension. */
+export const EXT_TASKS = 'io.modelcontextprotocol/tasks';
+
+/** Per-extension advertisement payload (opaque capability object). */
+export type ExtensionEntry = Record<string, unknown>;
+
+/** The `extensions` capabilities map advertised on `server/discover`. */
+export type ExtensionsMap = Record<string, ExtensionEntry>;
+
+/** Inputs used to derive the advertised extensions. */
+export interface ExtensionSignals {
+  /** True when at least one tool is task-capable. */
+  hasTasks: boolean;
+  /** True when at least one tool ships a UI component/widget. */
+  hasApps: boolean;
+  /** Extra extensions declared by the app author. */
+  declared?: ExtensionsMap;
+}
+
+/**
+ * Build the extensions capability map for `server/discover`.
+ */
+export function buildExtensionsMap(signals: ExtensionSignals): ExtensionsMap {
+  const map: ExtensionsMap = {};
+
+  if (signals.hasApps) {
+    map[EXT_APP] = { version: '2026-07-28' };
+  }
+  if (signals.hasTasks) {
+    // Tasks extension: server-directed task creation is supported; the
+    // in-process TaskManager answers tasks/get, tasks/update, tasks/cancel.
+    map[EXT_TASKS] = { version: '2026-07-28' };
+  }
+  if (signals.declared) {
+    for (const [id, entry] of Object.entries(signals.declared)) {
+      map[id] = { ...(map[id] || {}), ...entry };
+    }
+  }
+
+  return map;
+}

--- a/typescript/packages/core/src/core/protocol/features/mrtr.ts
+++ b/typescript/packages/core/src/core/protocol/features/mrtr.ts
@@ -1,0 +1,106 @@
+/**
+ * SEP-2322 Multi Round-Trip Requests (MRTR).
+ *
+ * On 2026-07-28 a handler can pause and ask the client for more input without a
+ * persistent connection: it returns an `input_required` result carrying
+ * `inputRequests` and an opaque `requestState`; the client re-invokes the same
+ * request with `inputResponses` (plus the echoed `requestState`).
+ *
+ * NitroStack has no elicitation/sampling handlers today, so this is a net-new,
+ * additive API. Handlers are written **once**: they call `inputRequired(...)`
+ * and read prior answers with `acceptedContent(...)`. These helpers produce an
+ * era-agnostic marker object; the modern adapter translates it into the real
+ * v2 `InputRequiredResult`, while the legacy adapter surfaces it via the
+ * session stream (or treats it as an error result if the client cannot elicit).
+ *
+ * @module
+ */
+
+import type { JsonValue } from '../../types.js';
+
+/** Marker symbol identifying a NitroStack input-required result. */
+export const NITRO_INPUT_REQUIRED = Symbol.for('nitrostack.inputRequired');
+
+/**
+ * A single request for client-provided input (elicitation-style).
+ */
+export interface NitroInputRequest {
+  /** Identifier the client echoes back in `inputResponses`. */
+  id: string;
+  /** Human-facing message describing what is being asked. */
+  message?: string;
+  /** JSON Schema describing the expected response shape. */
+  schema?: Record<string, JsonValue>;
+  /** Optional request kind (defaults to form elicitation). */
+  kind?: 'form' | 'url';
+  /** For `url` elicitations, the URL the user must visit. */
+  url?: string;
+}
+
+/**
+ * The era-agnostic input-required marker returned by `inputRequired()`.
+ */
+export interface NitroInputRequiredResult {
+  [NITRO_INPUT_REQUIRED]: true;
+  inputRequests: NitroInputRequest[];
+  /** Opaque state echoed to the client and returned on retry. */
+  requestState?: JsonValue;
+  /** Optional message shown alongside the requests. */
+  message?: string;
+}
+
+/**
+ * Signal that a handler needs more input from the client before it can finish.
+ *
+ * @example
+ * ```ts
+ * if (!acceptedContent(ctx.inputResponses, 'confirm')) {
+ *   return inputRequired({
+ *     requests: [{ id: 'confirm', message: 'Delete all rows?', schema: { type: 'boolean' } }],
+ *     requestState: { pendingDelete: table },
+ *   });
+ * }
+ * ```
+ */
+export function inputRequired(spec: {
+  requests: NitroInputRequest[];
+  requestState?: JsonValue;
+  message?: string;
+}): NitroInputRequiredResult {
+  return {
+    [NITRO_INPUT_REQUIRED]: true,
+    inputRequests: spec.requests,
+    requestState: spec.requestState,
+    message: spec.message,
+  };
+}
+
+/**
+ * Type guard for the input-required marker.
+ */
+export function isInputRequired(value: unknown): value is NitroInputRequiredResult {
+  return !!value && typeof value === 'object' && (value as Record<symbol, unknown>)[NITRO_INPUT_REQUIRED] === true;
+}
+
+/**
+ * Read a previously-supplied input response by id from `ctx.inputResponses`.
+ * Returns `undefined` when the client has not answered that request yet, which
+ * is the signal to return `inputRequired(...)`.
+ */
+export function acceptedContent<T = JsonValue>(
+  inputResponses: Record<string, unknown> | undefined,
+  id: string,
+): T | undefined {
+  if (!inputResponses || typeof inputResponses !== 'object') {
+    return undefined;
+  }
+  const entry = inputResponses[id];
+  if (entry === undefined || entry === null) {
+    return undefined;
+  }
+  // Responses may be bare values or `{ content: ... }` wrappers.
+  if (typeof entry === 'object' && entry !== null && 'content' in (entry as object)) {
+    return (entry as { content: T }).content;
+  }
+  return entry as T;
+}

--- a/typescript/packages/core/src/core/protocol/features/schema.ts
+++ b/typescript/packages/core/src/core/protocol/features/schema.ts
@@ -98,6 +98,9 @@ export async function convertToModernJsonSchema(
     } else if (json.type && json.type !== 'object') {
       json.type = 'object';
     }
+    // Allow additionalProperties on input schemas so clients (ChatGPT, Codex, Studio)
+    // passing _meta and other contextual parameters are not rejected with INVALID_ARGUMENT (-32602).
+    json.additionalProperties = true;
   }
 
   return json;

--- a/typescript/packages/core/src/core/protocol/features/schema.ts
+++ b/typescript/packages/core/src/core/protocol/features/schema.ts
@@ -1,0 +1,104 @@
+/**
+ * SEP-2106 full JSON Schema 2020-12 for tools (modern path only).
+ *
+ * The legacy path converts Zod with `target: 'jsonSchema7'` and inlines refs
+ * (`$refStrategy: 'none'`), forcing `type: "object"` on both input and output —
+ * unchanged so 2025-era clients never see unexpected keywords.
+ *
+ * On 2026-07-28 tool schemas are lifted to full JSON Schema 2020-12:
+ * - input keeps an object root but may carry `oneOf`/`anyOf`/`allOf`,
+ *   conditionals, and `$ref`/`$defs`
+ * - output is unrestricted (not forced to an object)
+ * - external `$ref` URIs are never auto-dereferenced and schema depth is bounded
+ *
+ * @module
+ */
+
+import { z } from 'zod';
+
+/** JSON Schema object (loose). */
+export type JsonSchemaObject = Record<string, unknown>;
+
+/** Maximum schema nesting depth accepted on the modern path (DoS guard). */
+export const MAX_SCHEMA_DEPTH = 64;
+
+function isZodSchema(schema: unknown): schema is z.ZodSchema {
+  return !!schema && typeof schema === 'object' && '_def' in (schema as object);
+}
+
+/**
+ * Bound the depth of a JSON schema object, replacing anything deeper than
+ * `maxDepth` with a permissive `{}` so a pathological `$defs` graph cannot blow
+ * the stack or the validator. External `$ref` URIs are left intact but are
+ * never dereferenced by NitroStack.
+ */
+export function boundSchemaDepth(value: unknown, maxDepth = MAX_SCHEMA_DEPTH, depth = 0): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (depth >= maxDepth) {
+    return {};
+  }
+  if (Array.isArray(value)) {
+    return value.map((v) => boundSchemaDepth(v, maxDepth, depth + 1));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = boundSchemaDepth(v, maxDepth, depth + 1);
+  }
+  return out;
+}
+
+/**
+ * Convert a Zod or JSON schema to JSON Schema 2020-12 for the modern era,
+ * preserving composition (`oneOf`/`anyOf`/`allOf`), conditionals, and
+ * `$ref`/`$defs`.
+ *
+ * @param schema - Zod schema or a pre-built JSON schema.
+ * @param opts.root - `'input'` forces an object root (spec requirement for tool
+ *   input); `'output'` leaves the schema unrestricted.
+ */
+export async function convertToModernJsonSchema(
+  schema: unknown,
+  opts: { root: 'input' | 'output' },
+): Promise<JsonSchemaObject> {
+  let json: JsonSchemaObject;
+
+  if (isZodSchema(schema)) {
+    try {
+      const mod = await import('zod-to-json-schema');
+      const zodToJsonSchema = (mod as { zodToJsonSchema?: unknown; default?: unknown }).zodToJsonSchema
+        || (mod as { default?: unknown }).default;
+      // 2019-09 target keeps $ref/$defs and composition (closest widely-supported
+      // preset to 2020-12 in zod-to-json-schema); root strategy emits $defs.
+      json = (zodToJsonSchema as (s: unknown, o: unknown) => JsonSchemaObject)(schema, {
+        target: 'jsonSchema2019-09',
+        $refStrategy: 'root',
+      });
+      // Advertise the 2020-12 dialect explicitly (SEP-2106). zod-to-json-schema
+      // stamps a 2019-09 `$schema`; the emitted keywords are 2020-12-compatible
+      // for tool schemas, so relabel to the revision the spec requires.
+      json.$schema = 'https://json-schema.org/draft/2020-12/schema';
+    } catch {
+      json = { type: 'object', properties: {}, additionalProperties: true };
+    }
+  } else if (schema && typeof schema === 'object') {
+    json = { ...(schema as JsonSchemaObject) };
+  } else {
+    json = {};
+  }
+
+  json = boundSchemaDepth(json) as JsonSchemaObject;
+
+  if (opts.root === 'input') {
+    // Input schema root must be an object per spec; composition/refs are allowed
+    // alongside it but the root type stays 'object'.
+    if (!('type' in json) && !('$ref' in json)) {
+      json.type = 'object';
+    } else if (json.type && json.type !== 'object') {
+      json.type = 'object';
+    }
+  }
+
+  return json;
+}

--- a/typescript/packages/core/src/core/protocol/features/trace-context.ts
+++ b/typescript/packages/core/src/core/protocol/features/trace-context.ts
@@ -1,0 +1,59 @@
+/**
+ * SEP-414 W3C Trace Context propagation.
+ *
+ * On the 2026-07-28 revision, distributed-tracing keys travel in the per-request
+ * `_meta` envelope under fixed names: `traceparent`, `tracestate`, `baggage`.
+ * NitroStack lifts them into `ExecutionContext.trace` so guards, interceptors,
+ * and loggers can correlate a tool call across the host, this server, and any
+ * downstream call — without NitroStack introducing its own tracing backend.
+ *
+ * @module
+ */
+
+/**
+ * W3C Trace Context extracted from a request `_meta` envelope.
+ */
+export interface TraceContext {
+  /** `traceparent` header value (W3C Trace Context). */
+  traceparent?: string;
+  /** `tracestate` header value. */
+  tracestate?: string;
+  /** `baggage` header value (W3C Baggage). */
+  baggage?: string;
+}
+
+const TRACEPARENT_KEY = 'io.modelcontextprotocol/traceparent';
+const TRACESTATE_KEY = 'io.modelcontextprotocol/tracestate';
+const BAGGAGE_KEY = 'io.modelcontextprotocol/baggage';
+
+/**
+ * Extract a `TraceContext` from an envelope/meta object, or `undefined` when no
+ * trace keys are present. Accepts either the lifted `_meta` envelope
+ * (`ctx.mcpReq.envelope`) or a raw `_meta` record; both the bare
+ * (`traceparent`) and reverse-DNS (`io.modelcontextprotocol/traceparent`)
+ * forms are recognized.
+ */
+export function extractTraceContext(
+  source: Record<string, unknown> | undefined | null,
+): TraceContext | undefined {
+  if (!source || typeof source !== 'object') {
+    return undefined;
+  }
+  const pick = (bare: string, prefixed: string): string | undefined => {
+    const v = source[prefixed] ?? source[bare];
+    return typeof v === 'string' && v.length > 0 ? v : undefined;
+  };
+
+  const traceparent = pick('traceparent', TRACEPARENT_KEY);
+  const tracestate = pick('tracestate', TRACESTATE_KEY);
+  const baggage = pick('baggage', BAGGAGE_KEY);
+
+  if (!traceparent && !tracestate && !baggage) {
+    return undefined;
+  }
+  const trace: TraceContext = {};
+  if (traceparent) trace.traceparent = traceparent;
+  if (tracestate) trace.tracestate = tracestate;
+  if (baggage) trace.baggage = baggage;
+  return trace;
+}

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -478,7 +478,18 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
 
     const nodeHandler = node.toNodeHandler(handler);
     return (req: ExpressRequest, res: ExpressResponse) => {
-      Promise.resolve(nodeHandler(req, res)).catch((err: unknown) => {
+      // Express bodyParser/json middleware may have already consumed the request
+      // stream and populated `req.body`. Pass `req.body` so `toWebRequest` uses
+      // the parsed body rather than reading an already-drained request stream.
+      const parsedBody =
+        (req as AnyRecord).body !== undefined &&
+        (req as AnyRecord).body !== null &&
+        typeof (req as AnyRecord).body === 'object' &&
+        Object.keys((req as AnyRecord).body).length > 0
+          ? (req as AnyRecord).body
+          : undefined;
+
+      Promise.resolve(nodeHandler(req, res, parsedBody)).catch((err: unknown) => {
         this.registry.logger.error('Modern MCP request failed', {
           error: err instanceof Error ? err.message : String(err),
         });

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -34,6 +34,7 @@ import { isInputRequired } from './features/mrtr.js';
 import { isMcpAppMode, isOpenAiMode } from '../app-mode.js';
 import type { Tool } from '../tool.js';
 import type { ExecutionContext, JsonValue } from '../types.js';
+import { TaskManager, TaskContext, type TaskAccessContext } from '../task.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type AnyRecord = Record<string, any>;
@@ -60,17 +61,25 @@ interface ServerSdk {
   InternalError?: new (message: string, data?: unknown) => Error;
 }
 
+export interface ModernProtocolAdapterOptions {
+  legacyMode?: 'stateless' | 'reject';
+  taskManager?: TaskManager;
+}
+
 export class ModernProtocolAdapter implements ProtocolAdapter {
   readonly era = 'modern' as const;
 
   private handler?: AnyRecord;
   private stdioHandle?: AnyRecord;
   private serverSdkPromise?: Promise<ServerSdk>;
+  private readonly taskManager?: TaskManager;
 
   constructor(
     private readonly registry: ProtocolRegistry,
-    private readonly options: { legacyMode: 'stateless' | 'reject' } = { legacyMode: 'reject' },
-  ) {}
+    private readonly options: ModernProtocolAdapterOptions = { legacyMode: 'reject' },
+  ) {
+    this.taskManager = options.taskManager;
+  }
 
   private loadServerSdk(): Promise<ServerSdk> {
     if (!this.serverSdkPromise) {
@@ -589,11 +598,162 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
               });
             }
           }
+
+          // Pre-dispatch wire interceptor for tasks methods and task-augmented tools/call
+          if (this.taskManager) {
+            try {
+              const clone = request.clone();
+              const body = (await clone.json()) as AnyRecord;
+              const taskResponse = await this.handleTaskPreDispatch(body, request);
+              if (taskResponse) {
+                return new Response(JSON.stringify(taskResponse), {
+                  status: 200,
+                  headers: { 'Content-Type': 'application/json' },
+                });
+              }
+            } catch {
+              // Not JSON or cannot intercept; let rawFetch handle
+            }
+          }
+
           return rawFetch(request, requestOptions);
         },
       };
     }
     return this.handler;
+  }
+
+  private extractAccessContext(req: unknown, parsedBody?: AnyRecord): TaskAccessContext | undefined {
+    const reqAny = req as any;
+    const auth = reqAny?.auth || reqAny?.user;
+    const userId = auth?.sub || auth?.userId || auth?.id;
+    const tenantId = auth?.tenantId || auth?.orgId;
+    const sessionId = reqAny?.headers?.['mcp-session-id'] || reqAny?.get?.('mcp-session-id');
+
+    if (!userId && !tenantId && !sessionId) {
+      return undefined;
+    }
+    return { userId, tenantId, sessionId };
+  }
+
+  private async handleTaskPreDispatch(body: AnyRecord, req: unknown): Promise<AnyRecord | null> {
+    if (!this.taskManager || !body || typeof body !== 'object') return null;
+
+    const { method, params, id } = body;
+    const accessContext = this.extractAccessContext(req, body);
+
+    // 1. tasks/get
+    if (method === 'tasks/get') {
+      const taskId = params?.taskId;
+      if (!taskId) {
+        return { jsonrpc: '2.0', id: id ?? null, error: { code: -32602, message: 'Invalid params: taskId is required' } };
+      }
+      try {
+        const entry = this.taskManager.getEntry(taskId, accessContext);
+        const resultPayload: Record<string, unknown> = { ...entry.data };
+        if (entry.data.status === 'completed' && entry.result !== undefined) {
+          resultPayload.result = entry.result;
+        }
+        if (entry.data.status === 'failed' && entry.error !== undefined) {
+          resultPayload.error = entry.error;
+        }
+        return { jsonrpc: '2.0', id: id ?? null, result: resultPayload };
+      } catch (err: any) {
+        return { jsonrpc: '2.0', id: id ?? null, error: { code: err.code || -32602, message: err.message || 'Task not found' } };
+      }
+    }
+
+    // 2. tasks/cancel
+    if (method === 'tasks/cancel') {
+      const taskId = params?.taskId;
+      if (!taskId) {
+        return { jsonrpc: '2.0', id: id ?? null, error: { code: -32602, message: 'Invalid params: taskId is required' } };
+      }
+      try {
+        const taskData = this.taskManager.cancelTask(taskId, accessContext);
+        return { jsonrpc: '2.0', id: id ?? null, result: taskData };
+      } catch (err: any) {
+        return { jsonrpc: '2.0', id: id ?? null, error: { code: err.code || -32602, message: err.message || 'Task not found' } };
+      }
+    }
+
+    // 3. tasks/update
+    if (method === 'tasks/update') {
+      const taskId = params?.taskId;
+      if (!taskId) {
+        return { jsonrpc: '2.0', id: id ?? null, error: { code: -32602, message: 'Invalid params: taskId is required' } };
+      }
+      try {
+        const taskData = this.taskManager.updateStatus(taskId, params.status || 'working', params.statusMessage, accessContext);
+        return { jsonrpc: '2.0', id: id ?? null, result: taskData };
+      } catch (err: any) {
+        return { jsonrpc: '2.0', id: id ?? null, error: { code: err.code || -32602, message: err.message || 'Failed to update task' } };
+      }
+    }
+
+    // 4. tools/call with task augmentation OR mandatory task support check
+    if (method === 'tools/call' && params) {
+      const toolName = params.name;
+      const tool = this.registry.getTools().get(toolName);
+      if (!tool) return null; // Let standard flow handle tool not found
+
+      const isTaskAugmented = params.task !== undefined;
+
+      // Enforcement: if taskSupport === 'required' and not task-augmented
+      if (!isTaskAugmented && tool.taskSupport === 'required') {
+        return {
+          jsonrpc: '2.0',
+          id: id ?? null,
+          error: { code: -32600, message: `Task augmentation required for tools/call requests on tool '${toolName}'` },
+        };
+      }
+
+      // If task-augmented:
+      if (isTaskAugmented) {
+        if (tool.taskSupport === 'forbidden') {
+          return {
+            jsonrpc: '2.0',
+            id: id ?? null,
+            error: { code: -32601, message: `Tool '${toolName}' does not support task augmentation` },
+          };
+        }
+
+        const taskData = this.taskManager.createTask(params.task, toolName, accessContext);
+        const taskId = taskData.taskId;
+
+        const taskContext = new TaskContext(this.taskManager, taskId);
+        const executionContext = this.registry.createExecutionContext({
+          toolName,
+          extra: {
+            task: taskContext,
+          },
+        });
+        (executionContext as any).task = taskContext;
+
+        const tm = this.taskManager;
+        // Run tool asynchronously in the background
+        Promise.resolve().then(async () => {
+          try {
+            const toolResult = await tool.execute(params.arguments || {}, executionContext);
+            tm.completeTask(taskId, toolResult, undefined, accessContext);
+          } catch (err: any) {
+            tm.failTask(taskId, { code: err.code || -32603, message: err.message || String(err) }, undefined, accessContext);
+          }
+        });
+
+        // Return CreateTaskResult immediately
+        return {
+          jsonrpc: '2.0',
+          id: id ?? null,
+          result: {
+            task: taskData,
+            resultType: 'task',
+          },
+        };
+      }
+    }
+
+    return null;
   }
 
   async createNodeHandler(): Promise<(req: ExpressRequest, res: ExpressResponse) => void> {
@@ -622,6 +782,28 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
           result: {},
         });
         return;
+      }
+
+      // Pre-dispatch wire interceptor for tasks methods and task-augmented tools/call
+      if (parsedBody && this.taskManager) {
+        const taskResponsePromise = this.handleTaskPreDispatch(parsedBody, req);
+        if (taskResponsePromise) {
+          Promise.resolve(taskResponsePromise).then((resp) => {
+            if (resp) {
+              res.setHeader('Content-Type', 'application/json');
+              res.status(200).json(resp);
+            } else {
+              nodeHandler(req, res, parsedBody);
+            }
+          }).catch((err) => {
+            res.status(500).json({
+              jsonrpc: '2.0',
+              id: parsedBody.id ?? null,
+              error: { code: -32603, message: err instanceof Error ? err.message : String(err) },
+            });
+          });
+          return;
+        }
       }
 
       Promise.resolve(nodeHandler(req, res, parsedBody)).catch((err: unknown) => {

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -524,10 +524,18 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
     const trace = extractTraceContext({ ...meta, ...envelope });
     const inputResponses = mcpReq.inputResponses as Record<string, JsonValue> | undefined;
 
-    const authInfo = ctx?.http?.authInfo ?? mcpReq?.http?.authInfo;
+    const authInfo = ctx?.http?.authInfo ?? mcpReq?.http?.authInfo ?? ctx?.authInfo ?? ctx?.auth;
+
+    const metadata: AnyRecord = {
+      ...(typeof mcpReq.headers === 'object' ? mcpReq.headers : {}),
+      ...(typeof ctx?.headers === 'object' ? ctx.headers : {}),
+      ...(authInfo?.token ? { authorization: `Bearer ${authInfo.token}`, token: authInfo.token } : {}),
+      ...meta,
+    };
 
     return this.registry.createExecutionContext({
       toolName: opts.toolName,
+      metadata,
       extra: {
         protocolVersion,
         clientInfo,
@@ -541,12 +549,16 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
   }
 
   private mapAuthInfo(authInfo: AnyRecord): ExecutionContext['auth'] {
+    const user = authInfo.user || authInfo.tokenPayload || authInfo;
     return {
-      subject: authInfo.clientId ?? authInfo.extra?.sub,
-      clientId: authInfo.clientId,
-      scopes: authInfo.scopes,
-      claims: authInfo.extra ?? authInfo.claims,
-      tokenPayload: authInfo,
+      subject: authInfo.subject ?? user.sub ?? authInfo.clientId ?? authInfo.client_id ?? authInfo.extra?.sub,
+      clientId: authInfo.clientId ?? authInfo.client_id ?? user.client_id,
+      scopes: authInfo.scopes ?? (typeof authInfo.scope === 'string' ? authInfo.scope.split(' ') : authInfo.scope) ?? [],
+      claims: authInfo.claims ?? authInfo.extra ?? user,
+      tokenPayload: authInfo.tokenPayload ?? user,
+      exp: authInfo.exp ?? user.exp,
+      iat: authInfo.iat ?? user.iat,
+      iss: authInfo.iss ?? user.iss,
     };
   }
 

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -383,7 +383,9 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
     }
 
     try {
-      const result = await tool.execute(args, context);
+      const argsRecord = (args || {}) as Record<string, unknown>;
+      const { _meta: _, ...toolArgs } = argsRecord;
+      const result = await tool.execute(toolArgs, context);
 
       // MRTR: a handler may pause and ask for more input.
       if (isInputRequired(result)) {
@@ -783,7 +785,9 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
         // Run tool asynchronously in the background
         Promise.resolve().then(async () => {
           try {
-            const toolResult = await tool.execute(params.arguments || {}, executionContext);
+            const argsRecord = (params.arguments || {}) as Record<string, unknown>;
+            const { _meta: _, ...toolArgs } = argsRecord;
+            const toolResult = await tool.execute(toolArgs, executionContext);
             if (tm.hasTask(taskId)) {
               const current = tm.getTask(taskId);
               if (current.status !== 'cancelled') {

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -126,8 +126,51 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
       if (outputSchema) config.outputSchema = outputSchema;
       if (tool.annotations) config.annotations = tool.annotations;
 
+      const meta: AnyRecord = {};
       const cacheHint = resolveToolCacheHint(tool);
-      if (cacheHint) config._meta = { 'io.modelcontextprotocol/cacheHint': cacheHint };
+      if (cacheHint) meta['io.modelcontextprotocol/cacheHint'] = cacheHint;
+
+      if (tool.hasComponent && tool.hasComponent()) {
+        const component = tool.getComponent()!;
+        const resourceUri = component.getResourceUri();
+        const componentMeta = component.getResourceMetadata() as Record<string, unknown> | undefined;
+
+        meta['ui/template'] = resourceUri;
+        meta['openai/outputTemplate'] = resourceUri;
+        meta['ui'] = { resourceUri };
+        if (componentMeta) {
+          if (componentMeta['openai/widgetCSP'] !== undefined) {
+            meta['openai/widgetCSP'] = componentMeta['openai/widgetCSP'];
+          }
+          if (componentMeta['openai/widgetDescription'] !== undefined) {
+            meta['openai/widgetDescription'] = componentMeta['openai/widgetDescription'];
+          }
+          if (componentMeta['openai/widgetPrefersBorder'] !== undefined) {
+            meta['openai/widgetPrefersBorder'] = componentMeta['openai/widgetPrefersBorder'];
+          }
+          if (componentMeta['openai/widgetDomain'] !== undefined) {
+            meta['openai/widgetDomain'] = componentMeta['openai/widgetDomain'];
+          }
+        }
+      } else if (tool.widget?.route || tool.outputTemplate) {
+        const route = tool.widget?.route || tool.outputTemplate;
+        const normalized = route?.startsWith('/') ? route : `/${route}`;
+        const resourceUri = `/widgets${normalized}`;
+        meta['ui/template'] = resourceUri;
+        meta['openai/outputTemplate'] = resourceUri;
+        meta['ui'] = { resourceUri };
+      }
+
+      if (tool.examples) {
+        meta['tool/examples'] = tool.examples;
+      }
+      if (tool.isInitial) {
+        meta['tool/initial'] = true;
+      }
+
+      if (Object.keys(meta).length > 0) {
+        config._meta = meta;
+      }
 
       server.registerTool(
         tool.name,
@@ -188,6 +231,63 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
           error: err instanceof Error ? err.message : String(err),
         });
       }
+    }
+
+    // Modern SDK v2 strictly validates URIs using `new URL(uri)`. To support custom
+    // or relative URI schemes such as `/widgets/*` used by NitroStudio and MCP Apps,
+    // attach a fallback resources/read handler on the underlying MCP server.
+    if (server.server && typeof server.server.setRequestHandler === 'function') {
+      const rawResources = this.registry.getResources();
+      server.server.setRequestHandler('resources/read', async (request: AnyRecord, ctx: AnyRecord) => {
+        const reqUri = String(request?.params?.uri ?? '');
+        // 1. Check exact match in registered resources (including path-based URIs like /widgets/...)
+        const matchingResource = rawResources.get(reqUri);
+        if (matchingResource) {
+          const resResult = await this.readResource(reqUri, matchingResource, sdk);
+          const cacheHint = resolveResourceCacheHint(matchingResource);
+          if (cacheHint) {
+            return { ...resResult, cacheHint };
+          }
+          return resResult;
+        }
+
+        // 2. Try URL parsing for standard schemes (mcp://, ui://, http://)
+        let parsedUrl: URL | undefined;
+        try {
+          parsedUrl = new URL(reqUri);
+        } catch {
+          // If not parseable as standard URL, check if any resource matches
+          for (const [uri, res] of rawResources.entries()) {
+            if (uri === reqUri || uri.endsWith(reqUri) || reqUri.endsWith(uri)) {
+              return this.readResource(reqUri, res, sdk);
+            }
+          }
+        }
+
+        if (parsedUrl) {
+          const registered =
+            server._registeredResources?.[parsedUrl.toString()] ||
+            rawResources.get(parsedUrl.toString());
+          if (registered) {
+            if (typeof registered.readCallback === 'function') {
+              return registered.readCallback(parsedUrl, ctx);
+            }
+            return this.readResource(reqUri, registered, sdk);
+          }
+        }
+
+        // 3. Check template resources
+        if (server._registeredResourceTemplates) {
+          for (const template of Object.values(server._registeredResourceTemplates) as AnyRecord[]) {
+            const variables = template.resourceTemplate?.uriTemplate?.match?.(reqUri);
+            if (variables) {
+              return template.readCallback(reqUri, variables, ctx);
+            }
+          }
+        }
+
+        throw this.toSdkError(new Error(`Resource not found: ${reqUri}`), sdk);
+      });
     }
   }
 

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -235,9 +235,10 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
 
     // Modern SDK v2 strictly validates URIs using `new URL(uri)`. To support custom
     // or relative URI schemes such as `/widgets/*` used by NitroStudio and MCP Apps,
-    // attach a fallback resources/read handler on the underlying MCP server.
-    if (server.server && typeof server.server.setRequestHandler === 'function') {
-      const rawResources = this.registry.getResources();
+    // attach a fallback resources/read handler on the underlying MCP server only when
+    // the server actually has resources registered (otherwise SDK throws capability error).
+    const rawResources = this.registry.getResources();
+    if ((rawResources.size > 0 || templateResources.size > 0) && server.server && typeof server.server.setRequestHandler === 'function') {
       server.server.setRequestHandler('resources/read', async (request: AnyRecord, ctx: AnyRecord) => {
         const reqUri = String(request?.params?.uri ?? '');
         // 1. Check exact match in registered resources (including path-based URIs like /widgets/...)

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -562,12 +562,35 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
   async getHttpHandler(): Promise<AnyRecord> {
     if (!this.handler) {
       const sdk = await this.loadServerSdk();
-      this.handler = sdk.createMcpHandler(() => this.buildServer(), {
+      const rawHandler = sdk.createMcpHandler(() => this.buildServer(), {
         legacy: this.options.legacyMode,
         onerror: (error: Error) => {
           this.registry.logger.error('Modern MCP handler error', { error: error.message });
         },
       });
+
+      const rawFetch = rawHandler.fetch;
+      this.handler = {
+        ...rawHandler,
+        fetch: async (request: Request, requestOptions?: AnyRecord) => {
+          if (request.headers.get('mcp-method') === 'ping') {
+            try {
+              const clone = request.clone();
+              const json = (await clone.json()) as AnyRecord;
+              return new Response(JSON.stringify({ jsonrpc: '2.0', id: json?.id ?? null, result: {} }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              });
+            } catch {
+              return new Response(JSON.stringify({ jsonrpc: '2.0', id: null, result: {} }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              });
+            }
+          }
+          return rawFetch(request, requestOptions);
+        },
+      };
     }
     return this.handler;
   }
@@ -588,6 +611,17 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
         Object.keys((req as AnyRecord).body).length > 0
           ? (req as AnyRecord).body
           : undefined;
+
+      // Handle ping directly for studio heartbeat / health monitoring
+      if (parsedBody && parsedBody.method === 'ping') {
+        res.setHeader('Content-Type', 'application/json');
+        res.status(200).json({
+          jsonrpc: '2.0',
+          id: parsedBody.id ?? null,
+          result: {},
+        });
+        return;
+      }
 
       Promise.resolve(nodeHandler(req, res, parsedBody)).catch((err: unknown) => {
         this.registry.logger.error('Modern MCP request failed', {

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -384,7 +384,21 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
 
     try {
       const argsRecord = (args || {}) as Record<string, unknown>;
-      const { _meta: _, ...toolArgs } = argsRecord;
+      const { _meta: metaFromArgs, ...toolArgs } = argsRecord;
+      if (metaFromArgs && typeof metaFromArgs === 'object') {
+        context.metadata = context.metadata || {};
+        const argMeta = metaFromArgs as Record<string, unknown>;
+        const rawAuth = argMeta.authorization || argMeta.Authorization;
+        if (rawAuth) {
+          context.metadata.authorization = rawAuth as any;
+          context.metadata.Authorization = rawAuth as any;
+        }
+        const rawToken = argMeta.token || argMeta._oauth || argMeta.jwtToken;
+        if (rawToken) {
+          context.metadata.token = rawToken as any;
+          context.metadata._oauth = rawToken as any;
+        }
+      }
       const result = await tool.execute(toolArgs, context);
 
       // MRTR: a handler may pause and ask for more input.
@@ -526,14 +540,32 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
     const trace = extractTraceContext({ ...meta, ...envelope });
     const inputResponses = mcpReq.inputResponses as Record<string, JsonValue> | undefined;
 
-    const authInfo = ctx?.http?.authInfo ?? mcpReq?.http?.authInfo ?? ctx?.authInfo ?? ctx?.auth;
+    const authInfo =
+      (readEnvelope('auth', 'io.modelcontextprotocol/auth') as AnyRecord | undefined) ??
+      (ctx?.http?.authInfo as AnyRecord | undefined) ??
+      (mcpReq?.http?.authInfo as AnyRecord | undefined) ??
+      (ctx?.authInfo as AnyRecord | undefined) ??
+      (ctx?.auth as AnyRecord | undefined);
 
-    const metadata: AnyRecord = {
+    const rawHeaders: AnyRecord = {
       ...(typeof mcpReq.headers === 'object' ? mcpReq.headers : {}),
       ...(typeof ctx?.headers === 'object' ? ctx.headers : {}),
-      ...(authInfo?.token ? { authorization: `Bearer ${authInfo.token}`, token: authInfo.token } : {}),
+    };
+    const rawAuth = rawHeaders.authorization || rawHeaders.Authorization || (authInfo?.token ? `Bearer ${authInfo.token}` : undefined) || (meta?.authorization as string) || (meta?.Authorization as string);
+    const rawToken = (authInfo?.token as string) || (meta?.token as string) || (meta?._oauth as string) || (meta?.jwtToken as string) || (meta?._meta as any)?.jwtToken || (meta?._meta as any)?.token;
+
+    const metadata: AnyRecord = {
+      ...rawHeaders,
       ...meta,
     };
+    if (rawAuth) {
+      metadata.authorization = rawAuth;
+      metadata.Authorization = rawAuth;
+    }
+    if (rawToken) {
+      metadata.token = rawToken;
+      metadata._oauth = rawToken;
+    }
 
     return this.registry.createExecutionContext({
       toolName: opts.toolName,

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -34,7 +34,7 @@ import { isInputRequired } from './features/mrtr.js';
 import { isMcpAppMode, isOpenAiMode } from '../app-mode.js';
 import type { Tool } from '../tool.js';
 import type { ExecutionContext, JsonValue } from '../types.js';
-import { TaskManager, TaskContext, TaskAugmentationRequiredError, type TaskAccessContext } from '../task.js';
+import { TaskManager, TaskContext, TaskAugmentationRequiredError, type TaskData, type TaskAccessContext } from '../task.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type AnyRecord = Record<string, any>;
@@ -922,6 +922,14 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
   }
   notifyResourceUpdated(uri: string): void {
     this.handler?.notify?.resourceUpdated?.(uri);
+  }
+  notifyTaskStatus(taskData: TaskData): void {
+    try {
+      this.handler?.notify?.custom?.('notifications/tasks/status', taskData);
+      this.handler?.bus?.emit?.('task_status', taskData);
+    } catch {
+      /* ignore delivery error if no subscriber is active */
+    }
   }
 
   async close(): Promise<void> {

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -547,12 +547,59 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
       (ctx?.authInfo as AnyRecord | undefined) ??
       (ctx?.auth as AnyRecord | undefined);
 
-    const rawHeaders: AnyRecord = {
-      ...(typeof mcpReq.headers === 'object' ? mcpReq.headers : {}),
-      ...(typeof ctx?.headers === 'object' ? ctx.headers : {}),
-    };
-    const rawAuth = rawHeaders.authorization || rawHeaders.Authorization || (authInfo?.token ? `Bearer ${authInfo.token}` : undefined) || (meta?.authorization as string) || (meta?.Authorization as string);
-    const rawToken = (authInfo?.token as string) || (meta?.token as string) || (meta?._oauth as string) || (meta?.jwtToken as string) || (meta?._meta as any)?.jwtToken || (meta?._meta as any)?.token;
+    const rawHeaders: AnyRecord = {};
+    const reqHeaders: any =
+      ctx?.http?.req?.headers ||
+      ctx?.http?.headers ||
+      ctx?.headers ||
+      mcpReq?.headers ||
+      ctx?.req?.headers;
+
+    if (reqHeaders) {
+      if (typeof reqHeaders.forEach === 'function') {
+        reqHeaders.forEach((val: string, key: string) => {
+          rawHeaders[key.toLowerCase()] = val;
+          rawHeaders[key] = val;
+        });
+      } else if (typeof reqHeaders.entries === 'function') {
+        for (const [k, v] of reqHeaders.entries()) {
+          rawHeaders[k.toLowerCase()] = v;
+          rawHeaders[k] = v;
+        }
+      } else if (typeof reqHeaders === 'object') {
+        for (const [k, v] of Object.entries(reqHeaders)) {
+          rawHeaders[k.toLowerCase()] = String(v);
+          rawHeaders[k] = String(v);
+        }
+      }
+    }
+
+    if (ctx?.http?.req?.headers?.get && typeof ctx.http.req.headers.get === 'function') {
+      const authHeader = ctx.http.req.headers.get('authorization') || ctx.http.req.headers.get('Authorization');
+      if (authHeader) {
+        rawHeaders.authorization = authHeader;
+        rawHeaders.Authorization = authHeader;
+      }
+    }
+
+    const rawAuth =
+      rawHeaders.authorization ||
+      rawHeaders.Authorization ||
+      (authInfo?.token ? `Bearer ${authInfo.token}` : undefined) ||
+      (meta?.authorization as string) ||
+      (meta?.Authorization as string);
+
+    let rawToken =
+      (authInfo?.token as string) ||
+      (meta?.token as string) ||
+      (meta?._oauth as string) ||
+      (meta?.jwtToken as string) ||
+      (meta?._meta as any)?.jwtToken ||
+      (meta?._meta as any)?.token;
+
+    if (!rawToken && rawAuth && typeof rawAuth === 'string' && rawAuth.startsWith('Bearer ')) {
+      rawToken = rawAuth.substring(7).trim();
+    }
 
     const metadata: AnyRecord = {
       ...rawHeaders,
@@ -565,6 +612,7 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
     if (rawToken) {
       metadata.token = rawToken;
       metadata._oauth = rawToken;
+      metadata.jwtToken = rawToken;
     }
 
     return this.registry.createExecutionContext({

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -1,0 +1,543 @@
+/**
+ * Modern (2026-07-28) protocol adapter.
+ *
+ * Binds the NitroStack registry to the official `@modelcontextprotocol/server`
+ * v2 engine:
+ *
+ * - HTTP: `createMcpHandler(() => buildServer())` wrapped with
+ *   `toNodeHandler(...)` from `@modelcontextprotocol/node`, mounted on the
+ *   Express app. Stateless per-request serving, `server/discover`, per-request
+ *   `_meta` envelope, `Mcp-Method`/`Mcp-Name` headers, and cache hints are all
+ *   provided by the SDK.
+ * - stdio: `serveStdio(() => buildServer())` from `@modelcontextprotocol/server/stdio`.
+ *
+ * The SDK stamps `_meta['io.modelcontextprotocol/serverInfo']` on every 2026
+ * response from the `Implementation` handed to `new McpServer(...)`.
+ *
+ * The v2 packages are loaded lazily (dynamic `import`) so a default (legacy)
+ * install never touches them and existing Jest suites never load v2. The SDK's
+ * types use minified re-exports, so this file types the SDK surface loosely at
+ * the boundary while keeping NitroStack's own objects strongly typed.
+ *
+ * @module
+ */
+
+import type { Express, Request as ExpressRequest, Response as ExpressResponse } from 'express';
+import type { ProtocolAdapter, ProtocolRegistry, ProtocolTransportOptions } from './adapter.js';
+import { MODERN_PROTOCOL_VERSION } from './version.js';
+import { resolveToolCacheHint, resolveResourceCacheHint } from './features/cache-hints.js';
+import { convertToModernJsonSchema } from './features/schema.js';
+import { extractTraceContext } from './features/trace-context.js';
+import { buildExtensionsMap } from './features/extensions.js';
+import { mapToJsonRpcError } from './features/errors.js';
+import { isInputRequired } from './features/mrtr.js';
+import { isMcpAppMode, isOpenAiMode } from '../app-mode.js';
+import type { Tool } from '../tool.js';
+import type { ExecutionContext, JsonValue } from '../types.js';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type AnyRecord = Record<string, any>;
+
+/** Meta-key constants (SEP-2575 / SEP-414) used to read the request envelope. */
+const META = {
+  PROTOCOL_VERSION: 'io.modelcontextprotocol/protocolVersion',
+  CLIENT_INFO: 'io.modelcontextprotocol/clientInfo',
+  CLIENT_CAPABILITIES: 'io.modelcontextprotocol/clientCapabilities',
+} as const;
+
+/**
+ * The v2 SDK module surface this adapter relies on. Kept intentionally loose.
+ */
+interface ServerSdk {
+  McpServer: new (info: { name: string; version: string }, options?: AnyRecord) => AnyRecord;
+  createMcpHandler: (factory: (ctx: AnyRecord) => any, options?: AnyRecord) => AnyRecord;
+  inputRequired: (spec: AnyRecord) => any;
+  fromJsonSchema?: (schema: AnyRecord) => any;
+  /** SDK error classes used to surface the correct JSON-RPC code (SEP-2164). */
+  ResourceNotFoundError?: new (message: string, data?: unknown) => Error;
+  InvalidParamsError?: new (message: string, data?: unknown) => Error;
+  MethodNotFoundError?: new (message: string, data?: unknown) => Error;
+  InternalError?: new (message: string, data?: unknown) => Error;
+}
+
+export class ModernProtocolAdapter implements ProtocolAdapter {
+  readonly era = 'modern' as const;
+
+  private handler?: AnyRecord;
+  private stdioHandle?: AnyRecord;
+  private serverSdkPromise?: Promise<ServerSdk>;
+
+  constructor(
+    private readonly registry: ProtocolRegistry,
+    private readonly options: { legacyMode: 'stateless' | 'reject' } = { legacyMode: 'reject' },
+  ) {}
+
+  private loadServerSdk(): Promise<ServerSdk> {
+    if (!this.serverSdkPromise) {
+      this.serverSdkPromise = import('@modelcontextprotocol/server') as unknown as Promise<ServerSdk>;
+    }
+    return this.serverSdkPromise;
+  }
+
+  // ==========================================================================
+  // Server construction (called per request by the SDK factory)
+  // ==========================================================================
+
+  private async buildServer(): Promise<AnyRecord> {
+    const sdk = await this.loadServerSdk();
+    const config = this.registry.config;
+
+    const extensions = this.advertisedExtensions();
+    const serverOptions: AnyRecord = {
+      cacheHints: this.buildServerCacheHints(),
+    };
+    if (Object.keys(extensions).length > 0) {
+      // Advertise the SEP-2133 extensions map on server/discover capabilities.
+      serverOptions.capabilities = { extensions };
+    }
+
+    const server = new sdk.McpServer({ name: config.name, version: config.version }, serverOptions);
+
+    await this.registerTools(server, sdk);
+    await this.registerResources(server, sdk);
+    await this.registerPrompts(server);
+
+    return server;
+  }
+
+  /** Server-level per-operation cache hints for list/discover results. */
+  private buildServerCacheHints(): AnyRecord | undefined {
+    // Conservative shared default for list surfaces; per-resource hints still win.
+    return undefined;
+  }
+
+  private async registerTools(server: AnyRecord, sdk: ServerSdk): Promise<void> {
+    for (const tool of this.registry.getTools().values()) {
+      const inputSchema = await this.toModernSchema(tool.inputSchema, 'input', sdk);
+      const outputSchema = tool.outputSchema
+        ? await this.toModernSchema(tool.outputSchema, 'output', sdk)
+        : undefined;
+
+      const config: AnyRecord = {
+        description: tool.description,
+        inputSchema,
+      };
+      if (tool.title) config.title = tool.title;
+      if (outputSchema) config.outputSchema = outputSchema;
+      if (tool.annotations) config.annotations = tool.annotations;
+
+      const cacheHint = resolveToolCacheHint(tool);
+      if (cacheHint) config._meta = { 'io.modelcontextprotocol/cacheHint': cacheHint };
+
+      server.registerTool(
+        tool.name,
+        config,
+        async (args: AnyRecord, ctx: AnyRecord) => this.runTool(tool, args, ctx, sdk),
+      );
+    }
+  }
+
+  private async registerResources(server: AnyRecord, sdk: ServerSdk): Promise<void> {
+    // Static resources and template resources both flow through registerResource.
+    const templateResources = this.registry.getTemplateResources();
+    for (const resource of this.registry.getResources().values()) {
+      // A template resource is registered via its template URI, not the static map.
+      const isTemplate = resource.uri.includes('{') && resource.uri.includes('}');
+      if (isTemplate) continue;
+
+      const cacheHint = resolveResourceCacheHint(resource);
+      const config: AnyRecord = {
+        description: resource.description,
+        mimeType: resource.mimeType,
+      };
+      if (resource.title) config.title = resource.title;
+      if (cacheHint) config.cacheHint = cacheHint;
+
+      server.registerResource(
+        resource.name,
+        resource.uri,
+        config,
+        async (uri: AnyRecord) => this.readResource(String(uri?.href ?? uri), resource, sdk),
+      );
+    }
+
+    // Template resources keyed by uri template.
+    for (const [uriTemplate, resource] of templateResources.entries()) {
+      const cacheHint = resolveResourceCacheHint(resource);
+      const config: AnyRecord = {
+        description: resource.description,
+        mimeType: resource.mimeType,
+      };
+      if (resource.title) config.title = resource.title;
+      if (cacheHint) config.cacheHint = cacheHint;
+
+      try {
+        const ResourceTemplateCtor = (sdk as AnyRecord).ResourceTemplate;
+        const template = ResourceTemplateCtor
+          ? new ResourceTemplateCtor(uriTemplate, { list: undefined })
+          : uriTemplate;
+        server.registerResource(
+          resource.name,
+          template,
+          config,
+          async (uri: AnyRecord) => this.readResource(String(uri?.href ?? uri), resource, sdk),
+        );
+      } catch (err) {
+        this.registry.logger.warn('Failed to register modern resource template', {
+          uriTemplate,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  private async registerPrompts(server: AnyRecord): Promise<void> {
+    for (const prompt of this.registry.getPrompts().values()) {
+      const config: AnyRecord = { description: prompt.description };
+      server.registerPrompt(
+        prompt.name,
+        config,
+        async (args: AnyRecord, ctx: AnyRecord) => {
+          const context = this.buildContext(ctx, { toolName: prompt.name });
+          const messages = await prompt.execute(args || {}, context);
+          return {
+            description: prompt.description,
+            messages: messages.map((m) => ({
+              role: m.role,
+              content: { type: 'text', text: m.content },
+            })),
+          };
+        },
+      );
+    }
+  }
+
+  // ==========================================================================
+  // Handlers
+  // ==========================================================================
+
+  private async runTool(tool: Tool, args: AnyRecord, ctx: AnyRecord, sdk: ServerSdk): Promise<AnyRecord> {
+    const context = this.buildContext(ctx, { toolName: tool.name });
+    try {
+      const result = await tool.execute(args, context);
+
+      // MRTR: a handler may pause and ask for more input.
+      if (isInputRequired(result)) {
+        return sdk.inputRequired({
+          inputRequests: result.inputRequests,
+          requestState: result.requestState,
+          message: result.message,
+        });
+      }
+
+      const response: AnyRecord = {
+        content: [
+          {
+            type: 'text',
+            text: typeof result === 'string' ? result : JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+
+      if (tool.hasComponent()) {
+        const component = tool.getComponent()!;
+        response.structuredContent = (await component.transformData(result, context)) as JsonValue;
+        const widgetMeta = ((await component.getWidgetMeta(result, context)) || {}) as AnyRecord;
+        response._meta = widgetMeta;
+        if (isMcpAppMode()) {
+          if (!widgetMeta.ui) {
+            widgetMeta.ui = { resourceUri: component.getResourceUri() };
+          } else if (typeof widgetMeta.ui === 'object' && !('resourceUri' in widgetMeta.ui)) {
+            widgetMeta.ui.resourceUri = component.getResourceUri();
+          }
+        }
+        if (isOpenAiMode() && !widgetMeta['openai/outputTemplate']) {
+          widgetMeta['openai/outputTemplate'] = component.getResourceUri();
+        }
+      }
+
+      return response;
+    } catch (error) {
+      const mapped = mapToJsonRpcError(error);
+      context.logger.error(`Tool execution failed (modern): ${tool.name}`, { error: mapped.message });
+      // Tool failures are returned as isError results, not JSON-RPC errors.
+      return {
+        content: [{ type: 'text', text: `Error: ${mapped.message}` }],
+        isError: true,
+      };
+    }
+  }
+
+  /**
+   * Translate a NitroStack/handler error into an SDK error carrying the right
+   * JSON-RPC code for the modern era. Prefers the v2 SDK error classes (so the
+   * SDK serializes `error.code` correctly); falls back to a plain `Error` with
+   * a numeric `code` property the SDK also recognizes.
+   */
+  private toSdkError(error: unknown, sdk: ServerSdk): Error {
+    const mapped = mapToJsonRpcError(error);
+    // -32602 is the SEP-2164 code for a missing resource and for invalid params;
+    // InvalidParamsError takes a message and serializes with the right code.
+    const Ctor =
+      mapped.code === -32602
+        ? sdk.InvalidParamsError || sdk.ResourceNotFoundError
+        : mapped.code === -32601
+          ? sdk.MethodNotFoundError
+          : sdk.InternalError;
+    if (Ctor) {
+      try {
+        return new Ctor(mapped.message, mapped.data);
+      } catch {
+        /* fall through */
+      }
+    }
+    const err = new Error(mapped.message) as Error & { code?: number; data?: unknown };
+    err.code = mapped.code;
+    if (mapped.data !== undefined) err.data = mapped.data;
+    return err;
+  }
+
+  private async readResource(uri: string, resource: AnyRecord, sdk: ServerSdk): Promise<AnyRecord> {
+    const context = this.registry.createExecutionContext({
+      extra: { protocolVersion: MODERN_PROTOCOL_VERSION },
+    });
+    let content: AnyRecord;
+    try {
+      content = await resource.fetch(context, uri);
+    } catch (error) {
+      // SEP-2164: surface the correct JSON-RPC code on the modern path
+      // (ResourceNotFound → -32602 Invalid Params, not the 2025-era -32002).
+      throw this.toSdkError(error, sdk);
+    }
+    const mimeType = resource.mimeType || 'text/plain';
+    let entry: AnyRecord;
+    switch (content.type) {
+      case 'text':
+        entry = { uri, mimeType, text: content.data };
+        break;
+      case 'binary':
+        entry = { uri, mimeType: resource.mimeType || 'application/octet-stream', blob: content.data.toString('base64') };
+        break;
+      case 'json':
+        entry = { uri, mimeType: resource.mimeType || 'application/json', text: JSON.stringify(content.data, null, 2) };
+        break;
+      default:
+        entry = { uri, mimeType: resource.mimeType || 'application/json', text: JSON.stringify(content, null, 2) };
+    }
+    const widgetMeta = resource.getWidgetReadMeta?.();
+    if (widgetMeta && Object.keys(widgetMeta).length > 0) {
+      entry._meta = widgetMeta;
+    }
+    return { contents: [entry] };
+  }
+
+  // ==========================================================================
+  // Context bridging (per-request envelope → ExecutionContext)
+  // ==========================================================================
+
+  private buildContext(ctx: AnyRecord, opts: { toolName?: string }): ExecutionContext {
+    const mcpReq: AnyRecord = ctx?.mcpReq ?? {};
+    const meta: AnyRecord = mcpReq._meta ?? {};
+    const envelope: AnyRecord = mcpReq.envelope ?? {};
+
+    const readEnvelope = (bareKey: string, prefixedKey: string): unknown =>
+      envelope[prefixedKey] ?? envelope[bareKey] ?? meta[prefixedKey] ?? meta[bareKey];
+
+    const protocolVersion =
+      (readEnvelope('protocolVersion', META.PROTOCOL_VERSION) as string | undefined) ?? MODERN_PROTOCOL_VERSION;
+    const clientInfo = readEnvelope('clientInfo', META.CLIENT_INFO) as ExecutionContext['clientInfo'];
+    const clientCapabilities = readEnvelope('clientCapabilities', META.CLIENT_CAPABILITIES) as
+      | Record<string, JsonValue>
+      | undefined;
+
+    let requestState: JsonValue | undefined;
+    try {
+      requestState = typeof mcpReq.requestState === 'function' ? mcpReq.requestState() : mcpReq.requestState;
+    } catch {
+      requestState = undefined;
+    }
+
+    const trace = extractTraceContext({ ...meta, ...envelope });
+    const inputResponses = mcpReq.inputResponses as Record<string, JsonValue> | undefined;
+
+    const authInfo = ctx?.http?.authInfo ?? mcpReq?.http?.authInfo;
+
+    return this.registry.createExecutionContext({
+      toolName: opts.toolName,
+      extra: {
+        protocolVersion,
+        clientInfo,
+        clientCapabilities,
+        requestState,
+        inputResponses,
+        trace,
+        auth: authInfo ? this.mapAuthInfo(authInfo) : undefined,
+      },
+    });
+  }
+
+  private mapAuthInfo(authInfo: AnyRecord): ExecutionContext['auth'] {
+    return {
+      subject: authInfo.clientId ?? authInfo.extra?.sub,
+      clientId: authInfo.clientId,
+      scopes: authInfo.scopes,
+      claims: authInfo.extra ?? authInfo.claims,
+      tokenPayload: authInfo,
+    };
+  }
+
+  private async toModernSchema(schema: unknown, root: 'input' | 'output', sdk: ServerSdk): Promise<AnyRecord> {
+    // NitroStack ships Zod v3, which the v2 SDK cannot ingest directly (it only
+    // accepts Zod >= 4.2.0 or a `fromJsonSchema(...)`-wrapped JSON Schema). So
+    // always lift the schema (Zod or pre-built JSON) to JSON Schema 2020-12
+    // (SEP-2106, preserving composition/$defs) and wrap it with `fromJsonSchema`
+    // when available so the SDK validates against it.
+    const json = await convertToModernJsonSchema(schema, { root });
+    if (sdk.fromJsonSchema) {
+      try {
+        return sdk.fromJsonSchema(json);
+      } catch {
+        /* fall through to raw json */
+      }
+    }
+    return json;
+  }
+
+  // ==========================================================================
+  // Transport wiring
+  // ==========================================================================
+
+  /**
+   * Build the stateless per-request Node HTTP handler for the modern engine.
+   * Returned so an existing Express host (NitroStack's `StreamableHttpTransport`)
+   * can route its `/mcp` endpoint to it, keeping one Express app and one set of
+   * OAuth/docs routes.
+   */
+  /**
+   * Build (once) the web-standard v2 handler `{ fetch, close, notify, bus }`
+   * returned by `createMcpHandler`. Idempotent: repeated calls reuse the same
+   * handler so a single notify bus backs `subscriptions/listen`.
+   */
+  async getHttpHandler(): Promise<AnyRecord> {
+    if (!this.handler) {
+      const sdk = await this.loadServerSdk();
+      this.handler = sdk.createMcpHandler(() => this.buildServer(), {
+        legacy: this.options.legacyMode,
+        onerror: (error: Error) => {
+          this.registry.logger.error('Modern MCP handler error', { error: error.message });
+        },
+      });
+    }
+    return this.handler;
+  }
+
+  async createNodeHandler(): Promise<(req: ExpressRequest, res: ExpressResponse) => void> {
+    const node = (await import('@modelcontextprotocol/node')) as AnyRecord;
+    const handler = await this.getHttpHandler();
+
+    const nodeHandler = node.toNodeHandler(handler);
+    return (req: ExpressRequest, res: ExpressResponse) => {
+      Promise.resolve(nodeHandler(req, res)).catch((err: unknown) => {
+        this.registry.logger.error('Modern MCP request failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        if (!res.headersSent) {
+          res.status(500).json({
+            jsonrpc: '2.0',
+            error: { code: -32603, message: 'Internal error' },
+            id: null,
+          });
+        }
+      });
+    };
+  }
+
+  async attachHttp(app: Express, options: ProtocolTransportOptions): Promise<void> {
+    const nodeHandler = await this.createNodeHandler();
+    const endpoint = options.endpoint || '/mcp';
+
+    if (options.enableCors !== false) {
+      app.use(endpoint, (req: ExpressRequest, res: ExpressResponse, next: () => void) => {
+        this.applyCorsHeaders(req, res);
+        if (req.method === 'OPTIONS') {
+          res.status(204).end();
+          return;
+        }
+        next();
+      });
+    }
+
+    app.all(endpoint, nodeHandler);
+    this.registry.logger.info(`Modern MCP (${MODERN_PROTOCOL_VERSION}) mounted at ${endpoint}`);
+  }
+
+  /**
+   * SEP-2243/SEP-2575 CORS: expose and allow the new required request headers
+   * (`MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`, and `Mcp-Param-*`).
+   */
+  private applyCorsHeaders(req: ExpressRequest, res: ExpressResponse): void {
+    const origin = req.headers.origin;
+    res.setHeader('Access-Control-Allow-Origin', origin || '*');
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      [
+        'Content-Type',
+        'Authorization',
+        'MCP-Protocol-Version',
+        'Mcp-Method',
+        'Mcp-Name',
+        'Mcp-Param-*',
+        'Last-Event-ID',
+      ].join(', '),
+    );
+    res.setHeader('Access-Control-Expose-Headers', ['MCP-Protocol-Version', 'Mcp-Method', 'Mcp-Name'].join(', '));
+  }
+
+  async serveStdio(): Promise<void> {
+    const stdio = (await import('@modelcontextprotocol/server/stdio')) as AnyRecord;
+    this.stdioHandle = stdio.serveStdio(() => this.buildServer());
+    this.registry.logger.info(`Modern MCP (${MODERN_PROTOCOL_VERSION}) serving over stdio`);
+  }
+
+  // ==========================================================================
+  // Notifications (subscriptions/listen bus)
+  // ==========================================================================
+
+  notifyToolsListChanged(): void {
+    this.handler?.notify?.toolsChanged?.();
+  }
+  notifyResourcesListChanged(): void {
+    this.handler?.notify?.resourcesChanged?.();
+  }
+  notifyPromptsListChanged(): void {
+    this.handler?.notify?.promptsChanged?.();
+  }
+  notifyResourceUpdated(uri: string): void {
+    this.handler?.notify?.resourceUpdated?.(uri);
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.handler?.close?.();
+    } catch {
+      /* ignore */
+    }
+    try {
+      await this.stdioHandle?.close?.();
+    } catch {
+      /* ignore */
+    }
+    this.handler = undefined;
+    this.stdioHandle = undefined;
+  }
+
+  /** The extensions map this adapter would advertise (for diagnostics/notes). */
+  advertisedExtensions(): Record<string, Record<string, unknown>> {
+    const tools = this.registry.getTools();
+    const hasTasks = Array.from(tools.values()).some((t) => t.taskSupport && t.taskSupport !== 'forbidden');
+    const hasApps = Array.from(tools.values()).some((t) => t.hasComponent());
+    return buildExtensionsMap({ hasTasks, hasApps, declared: this.registry.config.extensions });
+  }
+}

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -772,9 +772,19 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
         Promise.resolve().then(async () => {
           try {
             const toolResult = await tool.execute(params.arguments || {}, executionContext);
-            tm.completeTask(taskId, toolResult, undefined, accessContext);
+            if (tm.hasTask(taskId)) {
+              const current = tm.getTask(taskId);
+              if (current.status !== 'cancelled') {
+                tm.completeTask(taskId, toolResult, undefined, accessContext);
+              }
+            }
           } catch (err: any) {
-            tm.failTask(taskId, { code: err.code || -32603, message: err.message || String(err) }, undefined, accessContext);
+            if (tm.hasTask(taskId)) {
+              const current = tm.getTask(taskId);
+              if (current.status !== 'cancelled') {
+                tm.failTask(taskId, { code: err.code || -32603, message: err.message || String(err) }, undefined, accessContext);
+              }
+            }
           }
         });
 

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -34,7 +34,7 @@ import { isInputRequired } from './features/mrtr.js';
 import { isMcpAppMode, isOpenAiMode } from '../app-mode.js';
 import type { Tool } from '../tool.js';
 import type { ExecutionContext, JsonValue } from '../types.js';
-import { TaskManager, TaskContext, type TaskAccessContext } from '../task.js';
+import { TaskManager, TaskContext, TaskAugmentationRequiredError, type TaskAccessContext } from '../task.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type AnyRecord = Record<string, any>;
@@ -369,6 +369,19 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
 
   private async runTool(tool: Tool, args: AnyRecord, ctx: AnyRecord, sdk: ServerSdk): Promise<AnyRecord> {
     const context = this.buildContext(ctx, { toolName: tool.name });
+    const isTaskAugmented = ctx?.task !== undefined || ctx?.mcpReq?.params?.task !== undefined;
+
+    // Enforce tool-level task support negotiation
+    if (tool.taskSupport === 'required' && !isTaskAugmented) {
+      throw this.toSdkError(new TaskAugmentationRequiredError(), sdk);
+    }
+    if (tool.taskSupport === 'forbidden' && isTaskAugmented) {
+      throw this.toSdkError({
+        code: -32601,
+        message: `Tool '${tool.name}' does not support task augmentation`,
+      }, sdk);
+    }
+
     try {
       const result = await tool.execute(args, context);
 

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -100,7 +100,7 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
 
     await this.registerTools(server, sdk);
     await this.registerResources(server, sdk);
-    await this.registerPrompts(server);
+    await this.registerPrompts(server, sdk);
 
     return server;
   }
@@ -191,24 +191,65 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
     }
   }
 
-  private async registerPrompts(server: AnyRecord): Promise<void> {
+  private async registerPrompts(server: AnyRecord, sdk: ServerSdk): Promise<void> {
     for (const prompt of this.registry.getPrompts().values()) {
+      const args = prompt.arguments;
       const config: AnyRecord = { description: prompt.description };
-      server.registerPrompt(
-        prompt.name,
-        config,
-        async (args: AnyRecord, ctx: AnyRecord) => {
-          const context = this.buildContext(ctx, { toolName: prompt.name });
-          const messages = await prompt.execute(args || {}, context);
-          return {
-            description: prompt.description,
-            messages: messages.map((m) => ({
-              role: m.role,
-              content: { type: 'text', text: m.content },
-            })),
+      if (prompt.title) config.title = prompt.title;
+
+      if (args && args.length > 0) {
+        const properties: Record<string, unknown> = {};
+        const required: string[] = [];
+        for (const arg of args) {
+          properties[arg.name] = {
+            type: 'string',
+            description: arg.description,
           };
-        },
-      );
+          if (arg.required) {
+            required.push(arg.name);
+          }
+        }
+        const rawSchema: AnyRecord = {
+          type: 'object',
+          properties,
+        };
+        if (required.length > 0) {
+          rawSchema.required = required;
+        }
+        config.argsSchema = sdk.fromJsonSchema ? sdk.fromJsonSchema(rawSchema) : rawSchema;
+
+        server.registerPrompt(
+          prompt.name,
+          config,
+          async (promptArgs: AnyRecord, ctx: AnyRecord) => {
+            const context = this.buildContext(ctx, { toolName: prompt.name });
+            const messages = await prompt.execute(promptArgs || {}, context);
+            return {
+              description: prompt.description,
+              messages: messages.map((m) => ({
+                role: m.role,
+                content: { type: 'text', text: m.content },
+              })),
+            };
+          },
+        );
+      } else {
+        server.registerPrompt(
+          prompt.name,
+          config,
+          async (ctx: AnyRecord) => {
+            const context = this.buildContext(ctx, { toolName: prompt.name });
+            const messages = await prompt.execute({}, context);
+            return {
+              description: prompt.description,
+              messages: messages.map((m) => ({
+                role: m.role,
+                content: { type: 'text', text: m.content },
+              })),
+            };
+          },
+        );
+      }
     }
   }
 

--- a/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
+++ b/typescript/packages/core/src/core/protocol/modern-v2.adapter.ts
@@ -704,7 +704,31 @@ export class ModernProtocolAdapter implements ProtocolAdapter {
       }
     }
 
-    // 4. tools/call with task augmentation OR mandatory task support check
+    // 4. tasks/result (legacy 2025-06-18 only; rejected in modern 2026-07-28)
+    if (method === 'tasks/result') {
+      return {
+        jsonrpc: '2.0',
+        id: id ?? null,
+        error: {
+          code: -32601,
+          message: "Method 'tasks/result' is not supported in MCP 2026-07-28; use 'tasks/get' with embedded results.",
+        },
+      };
+    }
+
+    // 5. tasks/list (removed in modern 2026-07-28)
+    if (method === 'tasks/list') {
+      return {
+        jsonrpc: '2.0',
+        id: id ?? null,
+        error: {
+          code: -32601,
+          message: "Method 'tasks/list' is not supported in modern stateless MCP 2026-07-28.",
+        },
+      };
+    }
+
+    // 6. tools/call with task augmentation OR mandatory task support check
     if (method === 'tools/call' && params) {
       const toolName = params.name;
       const tool = this.registry.getTools().get(toolName);

--- a/typescript/packages/core/src/core/protocol/version.ts
+++ b/typescript/packages/core/src/core/protocol/version.ts
@@ -5,17 +5,17 @@
  *
  * - **legacy** — the 2025-era wire (documented by NitroStack as `2025-06-18`):
  *   sessionful Streamable HTTP with the `initialize` handshake and
- *   `Mcp-Session-Id`, implemented on `@modelcontextprotocol/sdk` v1. This is the
- *   default and stays byte-for-byte identical to prior releases.
+ *   `Mcp-Session-Id`, implemented on `@modelcontextprotocol/sdk` v1. Stays
+ *   byte-for-byte identical to prior releases.
  * - **modern** — the 2026-07-28 wire: stateless HTTP, `server/discover`,
  *   per-request `_meta` envelope, `Mcp-Method`/`Mcp-Name` headers, cache hints,
  *   multi-round-trip requests, and the Tasks/Apps extensions. Implemented on the
  *   official `@modelcontextprotocol/server` v2 packages.
- * - **auto** — serve both eras from one process, for validation against mixed
- *   clients.
+ * - **auto** — serve both eras from one process with modern engine & stateless
+ *   legacy fallback (default).
  *
  * Selection precedence (env wins over config so ops can flip a deployed app):
- *   `NITRO_MCP_PROTOCOL_VERSION` env → `McpServerConfig.protocolVersion` → legacy.
+ *   `NITRO_MCP_PROTOCOL_VERSION` env → `McpServerConfig.protocolVersion` → `auto`.
  *
  * @module
  */
@@ -46,28 +46,31 @@ export const PROTOCOL_ENV_VAR = 'NITRO_MCP_PROTOCOL_VERSION';
  *
  * Accepts (case-insensitive, trimmed):
  * - modern: `2026-07-28`, `2026`, `modern`, `latest`
- * - auto:   `auto`, `both`, `dual-spec`
- * - legacy: `2025-06-18`, `2025-11-25`, `2025`, `legacy`, unset/empty/unknown
+ * - auto:   `auto`, `both`, `dual`, `dual-spec`, unset/empty/unknown (default)
+ * - legacy: `2025-06-18`, `2025-11-25`, `2025`, `legacy`
  */
 export function normalizeProtocolEra(value: string | undefined | null): ProtocolEra {
   const raw = value?.toLowerCase().trim();
   if (!raw) {
-    return 'legacy';
+    return 'auto';
   }
   if (raw === '2026-07-28' || raw === '2026' || raw === 'modern' || raw === 'latest') {
     return 'modern';
   }
+  if (raw === '2025-06-18' || raw === '2025-11-25' || raw === '2025' || raw === 'legacy') {
+    return 'legacy';
+  }
   if (raw === 'auto' || raw === 'both' || raw === 'dual' || raw === 'dual-spec') {
     return 'auto';
   }
-  // 2025-06-18 / 2025-11-25 / 2025 / legacy / anything unrecognized → legacy.
-  return 'legacy';
+  // Anything unrecognized defaults to auto.
+  return 'auto';
 }
 
 /**
  * Resolve the active protocol era from the environment and optional config.
  * The environment variable always wins so a deployed app can be flipped
- * without a code change.
+ * without a code change. Defaults to 'auto' when unset.
  *
  * @param configValue - Optional `protocolVersion` from `McpServerConfig` / `@McpApp`.
  */
@@ -76,7 +79,10 @@ export function resolveProtocolEra(configValue?: string): ProtocolEra {
   if (fromEnv && fromEnv.trim()) {
     return normalizeProtocolEra(fromEnv);
   }
-  return normalizeProtocolEra(configValue);
+  if (configValue && configValue.trim()) {
+    return normalizeProtocolEra(configValue);
+  }
+  return 'auto';
 }
 
 /**

--- a/typescript/packages/core/src/core/protocol/version.ts
+++ b/typescript/packages/core/src/core/protocol/version.ts
@@ -1,0 +1,105 @@
+/**
+ * Protocol version selection for NitroStack.
+ *
+ * NitroStack speaks two protocol eras:
+ *
+ * - **legacy** — the 2025-era wire (documented by NitroStack as `2025-06-18`):
+ *   sessionful Streamable HTTP with the `initialize` handshake and
+ *   `Mcp-Session-Id`, implemented on `@modelcontextprotocol/sdk` v1. This is the
+ *   default and stays byte-for-byte identical to prior releases.
+ * - **modern** — the 2026-07-28 wire: stateless HTTP, `server/discover`,
+ *   per-request `_meta` envelope, `Mcp-Method`/`Mcp-Name` headers, cache hints,
+ *   multi-round-trip requests, and the Tasks/Apps extensions. Implemented on the
+ *   official `@modelcontextprotocol/server` v2 packages.
+ * - **auto** — serve both eras from one process, for validation against mixed
+ *   clients.
+ *
+ * Selection precedence (env wins over config so ops can flip a deployed app):
+ *   `NITRO_MCP_PROTOCOL_VERSION` env → `McpServerConfig.protocolVersion` → legacy.
+ *
+ * @module
+ */
+
+/**
+ * Resolved protocol era used to pick a transport adapter.
+ */
+export type ProtocolEra = 'legacy' | 'modern' | 'auto';
+
+/**
+ * The wire revision string NitroStack advertises for the modern era.
+ */
+export const MODERN_PROTOCOL_VERSION = '2026-07-28';
+
+/**
+ * The wire revision string NitroStack has historically advertised for the
+ * legacy era (health page, docs, startup logs).
+ */
+export const LEGACY_PROTOCOL_VERSION = '2025-06-18';
+
+/**
+ * Environment variable that selects the protocol era.
+ */
+export const PROTOCOL_ENV_VAR = 'NITRO_MCP_PROTOCOL_VERSION';
+
+/**
+ * Normalize any user-supplied protocol string into an era.
+ *
+ * Accepts (case-insensitive, trimmed):
+ * - modern: `2026-07-28`, `2026`, `modern`, `latest`
+ * - auto:   `auto`, `both`, `dual-spec`
+ * - legacy: `2025-06-18`, `2025-11-25`, `2025`, `legacy`, unset/empty/unknown
+ */
+export function normalizeProtocolEra(value: string | undefined | null): ProtocolEra {
+  const raw = value?.toLowerCase().trim();
+  if (!raw) {
+    return 'legacy';
+  }
+  if (raw === '2026-07-28' || raw === '2026' || raw === 'modern' || raw === 'latest') {
+    return 'modern';
+  }
+  if (raw === 'auto' || raw === 'both' || raw === 'dual' || raw === 'dual-spec') {
+    return 'auto';
+  }
+  // 2025-06-18 / 2025-11-25 / 2025 / legacy / anything unrecognized → legacy.
+  return 'legacy';
+}
+
+/**
+ * Resolve the active protocol era from the environment and optional config.
+ * The environment variable always wins so a deployed app can be flipped
+ * without a code change.
+ *
+ * @param configValue - Optional `protocolVersion` from `McpServerConfig` / `@McpApp`.
+ */
+export function resolveProtocolEra(configValue?: string): ProtocolEra {
+  const fromEnv = process.env[PROTOCOL_ENV_VAR];
+  if (fromEnv && fromEnv.trim()) {
+    return normalizeProtocolEra(fromEnv);
+  }
+  return normalizeProtocolEra(configValue);
+}
+
+/**
+ * Whether the modern (2026-07-28) engine must be loaded for the given era.
+ * True for both `modern` and `auto`.
+ */
+export function needsModernEngine(era: ProtocolEra): boolean {
+  return era === 'modern' || era === 'auto';
+}
+
+/**
+ * Whether the legacy (2025-era) engine must be loaded for the given era.
+ * True for both `legacy` and `auto`.
+ */
+export function needsLegacyEngine(era: ProtocolEra): boolean {
+  return era === 'legacy' || era === 'auto';
+}
+
+/**
+ * The wire revision advertised for a given era (used in health/docs/logs).
+ * `auto` reports the modern revision because a modern-capable deployment
+ * advertises the newest revision it supports.
+ */
+export function protocolVersionForEra(era: ProtocolEra): string {
+  return era === 'legacy' ? LEGACY_PROTOCOL_VERSION : MODERN_PROTOCOL_VERSION;
+}

--- a/typescript/packages/core/src/core/resource.ts
+++ b/typescript/packages/core/src/core/resource.ts
@@ -110,6 +110,21 @@ export class Resource {
   }
 
   /**
+   * Caching metadata (`cacheable` / `cacheMaxAge`). Used to derive the
+   * SEP-2549 cache hint on the 2026-07-28 path.
+   */
+  get metadata(): { cacheable?: boolean; cacheMaxAge?: number } | undefined {
+    return this.definition.metadata;
+  }
+
+  /**
+   * Explicit SEP-2549 cache hint (2026-07-28 path only).
+   */
+  get cacheHint(): { ttlMs?: number; cacheScope?: 'public' | 'private' } | undefined {
+    return this.definition.cacheHint;
+  }
+
+  /**
    * Add a subscriber to this resource
    */
   subscribe(subscriberId: string): void {

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -1589,18 +1589,47 @@ export class NitroStackServer {
    */
   private sendTaskStatusNotification(taskData: TaskData): void {
     try {
+      // 1. If task is bound to a legacy SSE session, deliver notification to that session's McpServer
+      if (taskData.sessionId && this.legacySdkSseSessions.has(taskData.sessionId)) {
+        const session = this.legacySdkSseSessions.get(taskData.sessionId);
+        const sessionMcp = session?.server as unknown as {
+          notification?: (params: { method: string; params: unknown }) => Promise<void>;
+        };
+        if (sessionMcp?.notification) {
+          sessionMcp.notification({
+            method: 'notifications/tasks/status',
+            params: taskData,
+          }).catch((err) =>
+            this.logger.debug('Failed to send task status notification to session SSE', {
+              sessionId: taskData.sessionId,
+              error: err instanceof Error ? err.message : String(err),
+            })
+          );
+          return;
+        }
+      }
+
+      // 2. If modern protocol adapter is running, notify via modern adapter
+      if (this.modernAdapter) {
+        (this.modernAdapter as any).notifyTaskStatus?.(taskData);
+        return;
+      }
+
+      // 3. Fallback to global mcpServer (used by STDIO transport)
       const mcpServerWithNotification = this.mcpServer as unknown as {
         notification?: (params: { method: string; params: unknown }) => Promise<void>;
       };
-      if (mcpServerWithNotification.notification) {
+      if (mcpServerWithNotification?.notification) {
         mcpServerWithNotification.notification({
           method: 'notifications/tasks/status',
           params: taskData,
-        }).catch(err =>
-          this.logger.error('Failed to send task status notification', {
-            error: err instanceof Error ? err.message : String(err),
-          })
-        );
+        }).catch((err) => {
+          // In stateless HTTP mode, global mcpServer is not connected to a single persistent client
+          const errMsg = err instanceof Error ? err.message : String(err);
+          if (!errMsg.includes('Not connected')) {
+            this.logger.error('Failed to send task status notification', { error: errMsg });
+          }
+        });
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -58,6 +58,7 @@ import type { ProtocolRegistry } from './protocol/adapter.js';
 import type { ModernProtocolAdapter } from './protocol/modern-v2.adapter.js';
 import { isInputRequired } from './protocol/features/mrtr.js';
 import type { SessionContext } from './transports/streamable-http.js';
+import { extractBearerToken } from '../auth/token-validation.js';
 
 /**
  * Controller instance type
@@ -714,11 +715,43 @@ export class NitroStackServer {
     toolName?: string;
     extra?: Partial<ExecutionContext>;
   }): ExecutionContext {
+    const metadata = options?.metadata || {};
+    let auth = options?.extra?.auth;
+
+    if (!auth) {
+      const authHeader = (metadata.authorization || metadata.Authorization) as string | undefined;
+      const metaToken = (metadata._oauth || metadata.token || metadata.jwtToken || metadata._meta?.jwtToken || metadata._meta?.token) as string | undefined;
+      const token = extractBearerToken(authHeader) || (typeof metaToken === 'string' ? extractBearerToken(metaToken) || metaToken : null);
+      if (token) {
+        let subject = 'authenticated-user';
+        let tokenPayload: any = undefined;
+        try {
+          const parts = token.split('.');
+          if (parts.length === 3) {
+            tokenPayload = JSON.parse(Buffer.from(parts[1], 'base64').toString('utf8'));
+            if (tokenPayload?.sub) {
+              subject = tokenPayload.sub;
+            }
+          }
+        } catch {
+          // ignore parse errors
+        }
+        auth = {
+          authenticated: true,
+          subject,
+          clientId: tokenPayload?.client_id || tokenPayload?.azp,
+          scopes: typeof tokenPayload?.scope === 'string' ? tokenPayload.scope.split(' ') : [],
+          tokenInfo: tokenPayload,
+        };
+      }
+    }
+
     return {
       logger: this.logger,
       requestId: uuidv4(),
       toolName: options?.toolName,
-      metadata: options?.metadata || {},
+      metadata,
+      auth,
       // Additive 2026-07-28 fields (protocolVersion, requestState, inputResponses,
       // trace, clientInfo, clientCapabilities, auth) supplied by the modern adapter.
       ...(options?.extra || {}),
@@ -806,7 +839,7 @@ export class NitroStackServer {
         (context as ExecutionContext & { task?: TaskContext }).task = taskContext;
 
         // Execute the tool asynchronously (fire-and-forget)
-        this.runTaskAsync(tool, args, context, taskId, name);
+        this.runTaskAsync(tool, toolArgs, context, taskId, name);
 
         // Return CreateTaskResult immediately
         return {
@@ -818,8 +851,8 @@ export class NitroStackServer {
       // Normal synchronous path
       // ----------------------------------------------------------------
       try {
-        // Pass original args (including _meta) to tool
-        const result = await tool.execute(args, context);
+        // Pass sanitized toolArgs to tool (protocol _meta is preserved in context.metadata)
+        const result = await tool.execute(toolArgs, context);
 
         // MRTR (SEP-2322) is a 2026-07-28 feature. On the legacy path there is
         // no client round-trip mechanism, so surface it as a clear error rather
@@ -1491,7 +1524,9 @@ export class NitroStackServer {
     toolName: string,
   ): Promise<void> {
     try {
-      const result = await tool.execute(args, context);
+      const argsRecord = (args || {}) as Record<string, JsonValue>;
+      const { _meta: _, ...toolArgs } = argsRecord;
+      const result = await tool.execute(toolArgs, context);
       this.stats.toolCalls++;
 
       // Build the tool response (same shape as the sync path)

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -26,6 +26,7 @@ import {
   JsonValue,
   ClassConstructor,
   ResourceTemplateDefinition,
+  ServerStartOptions,
 } from './types.js';
 import { buildResourceReadContentsMeta } from './widget-mcp-meta.js';
 import { getWidgetMimeType, isMcpAppMode, isOpenAiMode, getAppMode } from './app-mode.js';
@@ -128,6 +129,9 @@ export class NitroStackServer {
 
   /** Transport type used by the server */
   private _transportType?: 'stdio' | 'http' | 'dual';
+
+  /** Transport options configured during application creation */
+  private _transportOptions?: { port?: number; host?: string; endpoint?: string; enableCors?: boolean };
 
   /** HTTP transport instance (when using http or dual mode) */
   private _httpTransport?: HttpTransport;
@@ -1199,17 +1203,26 @@ export class NitroStackServer {
    * - NODE_ENV=development or unset → stdio mode
    * - NODE_ENV=production → dual mode (STDIO + HTTP)
    */
-  async start(): Promise<void> {
+  /**
+   * Start the server.
+   *
+   * Transport determination precedence:
+   * 1. Explicit `options.transport` passed to `start({ transport: 'stdio' })`
+   * 2. `MCP_TRANSPORT_TYPE` environment variable
+   * 3. Configured `this._transportType` (from `@McpApp` / `McpApplicationFactory`)
+   * 4. Default: `NODE_ENV=development` or unset → 'stdio', `production` → 'dual'
+   */
+  async start(options?: ServerStartOptions): Promise<void> {
     // Check for explicit transport type override
-    const explicitTransport = process.env.MCP_TRANSPORT_TYPE as 'stdio' | 'http' | 'dual' | undefined;
+    const explicitTransport = options?.transport || (process.env.MCP_TRANSPORT_TYPE as 'stdio' | 'http' | 'dual' | undefined);
 
     // Determine if we're in development mode
     // On Windows, NODE_ENV might not be passed correctly, so we're more lenient
     const nodeEnv = process.env.NODE_ENV?.toLowerCase();
     const isDevelopment = nodeEnv === 'development' || nodeEnv === 'dev' || !nodeEnv;
 
-    // Use explicit transport if set, otherwise infer from NODE_ENV
-    const transportType = explicitTransport || (isDevelopment ? 'stdio' : 'dual');
+    // Use explicit transport if set, otherwise check configured instance transport, then fallback based on NODE_ENV
+    const transportType = explicitTransport || this._transportType || (isDevelopment ? 'stdio' : 'dual');
     this._transportType = transportType;
     this.logger.debug(`NitroStackServer.start(): NODE_ENV=${process.env.NODE_ENV}, MCP_TRANSPORT_TYPE=${explicitTransport}, transportType=${transportType}`);
 
@@ -1226,20 +1239,23 @@ export class NitroStackServer {
     const initializedInstances = new Set(DIContainer.getInstance().getInstances());
     await triggerLifecycleHook([...initializedInstances], 'onModuleInit');
 
+    // Resolve port/host/endpoint/cors
+    const port = options?.port ?? (this._transportOptions?.port !== undefined ? this._transportOptions.port : parseInt(process.env.PORT || '3000'));
+    const host = options?.host || this._transportOptions?.host || process.env.HOST || 'localhost';
+    const endpoint = options?.endpoint || this._transportOptions?.endpoint || '/mcp';
+    const enableCors = options?.enableCors ?? (this._transportOptions?.enableCors !== undefined ? this._transportOptions.enableCors : process.env.ENABLE_CORS !== 'false');
+
     // If HTTP transport is needed (dual or http mode), set it up BEFORE calling module.start()
     // This allows modules like OAuthModule to register endpoints/middleware on the HTTP server
     if (transportType === 'dual' || transportType === 'http') {
-      const port = parseInt(process.env.PORT || '3000');
-      const host = process.env.HOST || 'localhost';
-
       // Create HTTP transport first (do not start listening yet)
       const { StreamableHttpTransport } = await import('./transports/streamable-http.js');
       const httpTransport = new StreamableHttpTransport({
-        port: port,
-        host: host,
-        endpoint: '/mcp',
+        port,
+        host,
+        endpoint,
         enableSessions: transportType === 'http', // Sessions ONLY in pure http mode
-        enableCors: process.env.ENABLE_CORS !== 'false',
+        enableCors,
         ...getStreamableHttpEnvOptions(),
       });
 
@@ -1300,14 +1316,11 @@ export class NitroStackServer {
     }
 
     // Now complete the transport setup (connect MCP server) using the determined transportType
-    const port = parseInt(process.env.PORT || '3000');
-    const host = process.env.HOST || 'localhost';
-
     await this.startWithTransport(transportType, {
       port,
       host,
-      endpoint: '/mcp',
-      enableCors: process.env.ENABLE_CORS !== 'false',
+      endpoint,
+      enableCors,
     });
   }
 

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -200,7 +200,7 @@ export class NitroStackServer {
     });
 
     // Resolve the protocol era. Env NITRO_MCP_PROTOCOL_VERSION wins over the
-    // optional config.protocolVersion; unset ⇒ 'legacy' (unchanged behavior).
+    // optional config.protocolVersion; unset ⇒ 'auto' (dual modern/legacy support).
     this.protocolEra = resolveProtocolEra(this.config.protocolVersion);
     if (this.protocolEra !== 'legacy') {
       this.logger.info(`MCP protocol era: ${this.protocolEra} (${protocolVersionForEra(this.protocolEra)})`);
@@ -1330,18 +1330,8 @@ export class NitroStackServer {
         ...getStreamableHttpEnvOptions(),
       });
 
-      if (needsModernEngine(this.protocolEra)) {
-        // Modern (2026-07-28) path: delegate /mcp to the stateless v2 handler.
-        // The Express host still owns CORS, OAuth discovery, and the docs page.
-        const modernAdapter = await this.getModernAdapter();
-        const nodeHandler = await modernAdapter.createNodeHandler();
-        httpTransport.setModernHandler(nodeHandler);
-        httpTransport.setProtocolVersionLabel(protocolVersionForEra(this.protocolEra));
-      } else {
-        // Legacy path: delegate /mcp protocol handling to the official SDK
-        // transport; each session gets its own configured MCP server.
-        httpTransport.setMcpServerFactory((sessionContext) => this.createConfiguredMcpServer(sessionContext));
-      }
+      // Delegate /mcp protocol handling to the correct protocol engine.
+      await this.configureTransportForProtocol(httpTransport as HttpTransport);
 
       // Set up tools callback and server config for documentation page
       httpTransport.setToolsCallback(async () => {

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -982,14 +982,14 @@ export class NitroStackServer {
     // Lists tasks with cursor-based pagination.
     // ----------------------------------------------------------------
     this.registerCustomHandler(mcp, 'tasks/list', async (params) => {
-      const { cursor } = (params || {}) as { cursor?: string };
+      const { cursor, limit } = (params || {}) as { cursor?: string; limit?: number };
       try {
         const accessContext: TaskAccessContext | undefined = sessionContext ? {
           sessionId: (sessionContext as any).sessionId,
           userId: (sessionContext as any).userId,
           tenantId: (sessionContext as any).tenantId,
         } : undefined;
-        return this.taskManager.listTasks(cursor, 50, accessContext);
+        return this.taskManager.listTasks(cursor, limit ?? 50, accessContext);
       } catch (err) {
         if (err instanceof TaskNotFoundError) {
           // Invalid cursor
@@ -1536,29 +1536,31 @@ export class NitroStackServer {
         }
       }
 
-      this.taskManager.completeTask(taskId, response);
+      if (this.taskManager.hasTask(taskId)) {
+        this.taskManager.completeTask(taskId, response);
+      }
     } catch (error) {
       this.stats.errors++;
       const errorMessage = error instanceof Error ? error.message : String(error);
       context.logger.error(`Task tool execution failed: ${toolName}`, { error: errorMessage, taskId });
 
-      // Check if due to cancellation
-      const taskData = this.taskManager.hasTask(taskId)
-        ? this.taskManager.getTask(taskId)
-        : null;
-      if (taskData?.status === 'cancelled') {
-        return; // Already cancelled — don't overwrite status
+      // Check if task exists and is not cancelled
+      if (this.taskManager.hasTask(taskId)) {
+        const taskData = this.taskManager.getTask(taskId);
+        if (taskData?.status === 'cancelled') {
+          return; // Already cancelled — don't overwrite status
+        }
+
+        const formattedError = error instanceof ValidationError || error instanceof ToolExecutionError
+          ? error
+          : new ToolExecutionError(toolName, error as Error);
+
+        this.taskManager.failTask(
+          taskId,
+          { code: -32603, message: formattedError.message },
+          formattedError.message,
+        );
       }
-
-      const formattedError = error instanceof ValidationError || error instanceof ToolExecutionError
-        ? error
-        : new ToolExecutionError(toolName, error as Error);
-
-      this.taskManager.failTask(
-        taskId,
-        { code: -32603, message: formattedError.message },
-        formattedError.message,
-      );
     }
   }
 

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -813,8 +813,15 @@ export class NitroStackServer {
       };
       // Bridge the transport-captured HTTP Authorization header so OAuth
       // guards can authenticate remote HTTP/SSE clients. Explicit _meta wins.
-      if (sessionContext?.authHeader && combinedMeta['authorization'] === undefined) {
-        combinedMeta['authorization'] = sessionContext.authHeader;
+      const rawAuth = combinedMeta['authorization'] || combinedMeta['Authorization'] || sessionContext?.authHeader;
+      if (rawAuth) {
+        combinedMeta['authorization'] = rawAuth;
+        combinedMeta['Authorization'] = rawAuth;
+      }
+      const rawToken = combinedMeta['token'] || combinedMeta['_oauth'] || combinedMeta['jwtToken'] || (combinedMeta['_meta'] as any)?.jwtToken || (combinedMeta['_meta'] as any)?.token;
+      if (rawToken) {
+        combinedMeta['token'] = rawToken;
+        combinedMeta['_oauth'] = rawToken;
       }
       const context = this.createContext({
         metadata: combinedMeta,

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -437,40 +437,35 @@ export class NitroStackServer {
       handler: async (uri: string, context) => {
         context.logger.info(`Serving component: ${uri}`);
 
-        // In production, serve the bundled HTML file if available
-        if (process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'prod') {
-          try {
-            // Check if we have a bundled file for this component
-            // The component ID usually matches the widget output name
-            const widgetId = component.id;
-            // We need to find where the widgets are located relative to the running server
-            // In production, we expect them in src/widgets/out or dist/widgets/out
+        // Serve the bundled HTML file if available
+        try {
+          const widgetId = component.id;
+          const cleanId = widgetId.replace(/^next-/, '');
+          const fs = await import('fs');
+          const path = await import('path');
 
-            // Try to find the bundled file
-            const fs = await import('fs');
-            const path = await import('path');
+          const possiblePaths = [
+            path.join(process.cwd(), 'src/widgets/out', `${cleanId}.html`),
+            path.join(process.cwd(), 'src/widgets/out', `${widgetId}.html`),
+            path.join(process.cwd(), 'dist/widgets/out', `${cleanId}.html`),
+            path.join(process.cwd(), 'dist/widgets/out', `${widgetId}.html`),
+            path.join(process.cwd(), 'widgets/out', `${cleanId}.html`),
+            path.join(process.cwd(), 'widgets/out', `${widgetId}.html`),
+          ];
 
-            // Possible locations for bundled widgets
-            const possiblePaths = [
-              path.join(process.cwd(), 'src/widgets/out', `${widgetId}.html`),
-              path.join(process.cwd(), 'dist/widgets/out', `${widgetId}.html`),
-              path.join(process.cwd(), 'widgets/out', `${widgetId}.html`)
-            ];
-
-            for (const p of possiblePaths) {
-              if (fs.existsSync(p)) {
-                const html = fs.readFileSync(p, 'utf-8');
-                return {
-                  type: 'text' as const,
-                  data: html
-                };
-              }
+          for (const p of possiblePaths) {
+            if (fs.existsSync(p)) {
+              const html = fs.readFileSync(p, 'utf-8');
+              return {
+                type: 'text' as const,
+                data: html,
+              };
             }
-
-            context.logger.warn(`Bundled widget not found for ${widgetId}, falling back to default bundle`);
-          } catch (error) {
-            context.logger.error(`Error serving bundled widget: ${error}`);
           }
+
+          context.logger.warn(`Bundled widget not found for ${widgetId} (${cleanId}), falling back to default bundle`);
+        } catch (error) {
+          context.logger.error(`Error serving bundled widget: ${error}`);
         }
 
         return {

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -45,6 +45,7 @@ import {
   TaskAlreadyTerminalError,
   TaskAugmentationRequiredError,
   type TaskAccessContext,
+  type TaskStore,
 } from './task.js';
 import { triggerLifecycleHook } from './lifecycle.js';
 import {
@@ -188,6 +189,9 @@ export class NitroStackServer {
     // Initialize task manager for MCP Tasks support
     this.taskManager = new TaskManager({
       logger: this.logger,
+      store: (this.config as any).taskStore ?? (this.config as any).tasks?.store,
+      defaultTtl: (this.config as any).tasks?.defaultTtl,
+      defaultPollInterval: (this.config as any).tasks?.defaultPollInterval,
       onStatusChange: (taskData: TaskData) => {
         // Send notifications/tasks/status when task status changes
         this.sendTaskStatusNotification(taskData);
@@ -1642,6 +1646,23 @@ export class NitroStackServer {
    */
   getTaskManager(): TaskManager {
     return this.taskManager;
+  }
+
+  /**
+   * Configure a custom TaskStore (e.g., Redis, SQL, DynamoDB) for distributed task state
+   */
+  setTaskStore(store: TaskStore): this {
+    this.taskManager.destroy();
+    this.taskManager = new TaskManager({
+      logger: this.logger,
+      store,
+      defaultTtl: (this.config as any).tasks?.defaultTtl,
+      defaultPollInterval: (this.config as any).tasks?.defaultPollInterval,
+      onStatusChange: (taskData: TaskData) => {
+        this.sendTaskStatusNotification(taskData);
+      },
+    });
+    return this;
   }
 
   /**

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -2,7 +2,6 @@ import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import type { Express, Response } from 'express';
-import type { SessionContext } from './transports/streamable-http.js';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import {
   CallToolRequestSchema,
@@ -46,6 +45,16 @@ import {
   TaskAugmentationRequiredError,
 } from './task.js';
 import { triggerLifecycleHook } from './lifecycle.js';
+import {
+  resolveProtocolEra,
+  needsModernEngine,
+  protocolVersionForEra,
+  type ProtocolEra,
+} from './protocol/version.js';
+import type { ProtocolRegistry } from './protocol/adapter.js';
+import type { ModernProtocolAdapter } from './protocol/modern-v2.adapter.js';
+import { isInputRequired } from './protocol/features/mrtr.js';
+import type { SessionContext } from './transports/streamable-http.js';
 
 /**
  * Controller instance type
@@ -71,6 +80,10 @@ interface HttpTransport {
   close(): Promise<void>;
   /** Provide the factory used to build a configured MCP server per /mcp session. */
   setMcpServerFactory?(factory: (sessionContext?: SessionContext) => McpServer): void;
+  /** Delegate /mcp to a modern (2026-07-28) stateless handler. */
+  setModernHandler?(handler: (req: unknown, res: Response) => void): void;
+  /** Set the protocol revision label used on health/logs. */
+  setProtocolVersionLabel?(label: string): void;
   setLegacySseHandler?(handler: (req: unknown, res: Response) => Promise<void>): void;
   setToolsCallback?(callback: () => Promise<unknown[]>): void;
   setServerConfig?(config: { name: string; version: string; description?: string }): void;
@@ -123,7 +136,7 @@ export class NitroStackServer {
   private _legacySseRoutesAttached = false;
 
   /** Active sessions for @modelcontextprotocol/sdk SSEServerTransport clients */
-  private readonly legacySdkSseSessions = new Map<
+  private legacySdkSseSessions = new Map<
     string,
     { server: McpServer; transport: SSEServerTransport; sessionContext: SessionContext }
   >();
@@ -136,6 +149,15 @@ export class NitroStackServer {
 
   /** Guards stop() so double signals / repeated calls don't re-run teardown */
   private _stopping?: Promise<void>;
+
+  /**
+   * Resolved MCP protocol era. `legacy` (default) keeps the current 2025-era
+   * sessionful path unchanged; `modern` / `auto` engage the 2026-07-28 adapter.
+   */
+  private protocolEra: ProtocolEra;
+
+  /** Lazily constructed modern (2026-07-28) adapter (only on modern/auto). */
+  private modernAdapter?: ModernProtocolAdapter;
 
   constructor(config?: McpServerConfig) {
     // Default config if not provided (e.g., when instantiated by DI container)
@@ -167,6 +189,13 @@ export class NitroStackServer {
       },
     });
 
+    // Resolve the protocol era. Env NITRO_MCP_PROTOCOL_VERSION wins over the
+    // optional config.protocolVersion; unset ⇒ 'legacy' (unchanged behavior).
+    this.protocolEra = resolveProtocolEra(this.config.protocolVersion);
+    if (this.protocolEra !== 'legacy') {
+      this.logger.info(`MCP protocol era: ${this.protocolEra} (${protocolVersionForEra(this.protocolEra)})`);
+    }
+
     this.mcpServer = new McpServer(
       {
         name: this.config.name,
@@ -176,6 +205,55 @@ export class NitroStackServer {
     );
 
     this.setupHandlersOn(this.mcpServer);
+  }
+
+  /**
+   * Build the read-only registry view the modern protocol adapter consumes.
+   * Captures `this` so the adapter never imports NitroStack internals.
+   */
+  private buildProtocolRegistry(): ProtocolRegistry {
+    return {
+      config: this.config,
+      logger: this.logger,
+      getTools: () => this.tools,
+      getResources: () => this.resources,
+      getResourceTemplates: () => this.resourceTemplates,
+      getTemplateResources: () => this.templateResources,
+      getPrompts: () => this.prompts,
+      getTaskManager: () => this.taskManager,
+      createExecutionContext: (options) => this.createContext(options),
+    };
+  }
+
+  /**
+   * Lazily create the modern (2026-07-28) protocol adapter. `auto` uses the v2
+   * stateless legacy fallback so a single endpoint serves both eras for
+   * validation; `modern` rejects legacy-classified traffic.
+   */
+  private async getModernAdapter(): Promise<ModernProtocolAdapter> {
+    if (!this.modernAdapter) {
+      const { ModernProtocolAdapter } = await import('./protocol/modern-v2.adapter.js');
+      this.modernAdapter = new ModernProtocolAdapter(this.buildProtocolRegistry(), {
+        legacyMode: this.protocolEra === 'auto' ? 'stateless' : 'reject',
+      });
+    }
+    return this.modernAdapter;
+  }
+
+  /**
+   * Bind an HTTP transport's /mcp endpoint to the correct protocol engine:
+   * the modern stateless handler on modern/auto, or the legacy per-session
+   * SDK factory otherwise.
+   */
+  private async configureTransportForProtocol(transport: HttpTransport): Promise<void> {
+    if (needsModernEngine(this.protocolEra) && transport.setModernHandler) {
+      const adapter = await this.getModernAdapter();
+      const nodeHandler = await adapter.createNodeHandler();
+      transport.setModernHandler(nodeHandler as (req: unknown, res: Response) => void);
+      transport.setProtocolVersionLabel?.(protocolVersionForEra(this.protocolEra));
+    } else if (transport.setMcpServerFactory) {
+      transport.setMcpServerFactory((sessionContext) => this.createConfiguredMcpServer(sessionContext));
+    }
   }
 
   /** Shared MCP server constructor options (main + per legacy SSE session) */
@@ -289,13 +367,11 @@ export class NitroStackServer {
         res.status(404).send('Unknown session');
         return;
       }
+      const authHeader = req.get('authorization');
+      if (authHeader) {
+        session.sessionContext.authHeader = authHeader;
+      }
       try {
-        // Refresh the session auth header on every message POST so tool
-        // handlers see the caller's current credential.
-        const authHeader = req.get('authorization');
-        if (authHeader) {
-          session.sessionContext.authHeader = authHeader;
-        }
         await session.transport.handlePostMessage(
           req as unknown as IncomingMessage,
           res as unknown as ServerResponse,
@@ -318,9 +394,8 @@ export class NitroStackServer {
     }
     // Cursor opens GET /mcp without mcp-session-id; fall back to legacy SSE on that path.
     if (typeof transport.setLegacySseHandler === 'function') {
-      transport.setLegacySseHandler(async (req, res) => {
-        const authHeader = (req as { get?: (name: string) => string | undefined }).get?.('authorization');
-        await this.startLegacySdkSseSession(res, '/mcp/messages', authHeader);
+      transport.setLegacySseHandler(async (_req, res) => {
+        await this.startLegacySdkSseSession(res, '/mcp/messages');
       });
     }
   }
@@ -460,6 +535,7 @@ export class NitroStackServer {
    * Notify clients that the list of resources has changed
    */
   notifyResourcesListChanged(): void {
+    this.modernAdapter?.notifyResourcesListChanged();
     try {
       // Send notification through the MCP server
       const mcpServerWithNotification = this.mcpServer as unknown as {
@@ -479,6 +555,7 @@ export class NitroStackServer {
    * Notify clients that the list of prompts has changed
    */
   notifyPromptsListChanged(): void {
+    this.modernAdapter?.notifyPromptsListChanged();
     try {
       const mcpServerWithNotification = this.mcpServer as unknown as {
         notification?: (params: { method: string }) => Promise<void>
@@ -497,6 +574,7 @@ export class NitroStackServer {
    * Notify clients that the list of tools has changed
    */
   notifyToolsListChanged(): void {
+    this.modernAdapter?.notifyToolsListChanged();
     try {
       const mcpServerWithNotification = this.mcpServer as unknown as {
         notification?: (params: { method: string }) => Promise<void>
@@ -515,6 +593,7 @@ export class NitroStackServer {
    * Notify subscribers that a resource has been updated
    */
   notifyResourceUpdated(uri: string): void {
+    this.modernAdapter?.notifyResourceUpdated(uri);
     try {
       const resource = this.resources.get(uri);
       if (!resource || !resource.hasSubscribers()) return;
@@ -625,12 +704,19 @@ export class NitroStackServer {
   /**
    * Create execution context
    */
-  private createContext(options?: { metadata?: Record<string, any>; toolName?: string }): ExecutionContext {
+  private createContext(options?: {
+    metadata?: Record<string, any>;
+    toolName?: string;
+    extra?: Partial<ExecutionContext>;
+  }): ExecutionContext {
     return {
       logger: this.logger,
       requestId: uuidv4(),
       toolName: options?.toolName,
       metadata: options?.metadata || {},
+      // Additive 2026-07-28 fields (protocolVersion, requestState, inputResponses,
+      // trace, clientInfo, clientCapabilities, auth) supplied by the modern adapter.
+      ...(options?.extra || {}),
     };
   }
 
@@ -724,6 +810,21 @@ export class NitroStackServer {
       try {
         // Pass original args (including _meta) to tool
         const result = await tool.execute(args, context);
+
+        // MRTR (SEP-2322) is a 2026-07-28 feature. On the legacy path there is
+        // no client round-trip mechanism, so surface it as a clear error rather
+        // than leaking the marker's serialized shape.
+        if (isInputRequired(result)) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'This tool requires multi-round-trip input (MCP 2026-07-28). Set NITRO_MCP_PROTOCOL_VERSION=2026-07-28 to enable it.',
+              },
+            ],
+            isError: true,
+          };
+        }
 
         this.stats.toolCalls++;
 
@@ -1147,9 +1248,18 @@ export class NitroStackServer {
         ...getStreamableHttpEnvOptions(),
       });
 
-      // Delegate /mcp protocol handling to the official SDK transport: each
-      // session gets its own configured MCP server built via this factory.
-      httpTransport.setMcpServerFactory((sessionContext) => this.createConfiguredMcpServer(sessionContext));
+      if (needsModernEngine(this.protocolEra)) {
+        // Modern (2026-07-28) path: delegate /mcp to the stateless v2 handler.
+        // The Express host still owns CORS, OAuth discovery, and the docs page.
+        const modernAdapter = await this.getModernAdapter();
+        const nodeHandler = await modernAdapter.createNodeHandler();
+        httpTransport.setModernHandler(nodeHandler);
+        httpTransport.setProtocolVersionLabel(protocolVersionForEra(this.protocolEra));
+      } else {
+        // Legacy path: delegate /mcp protocol handling to the official SDK
+        // transport; each session gets its own configured MCP server.
+        httpTransport.setMcpServerFactory((sessionContext) => this.createConfiguredMcpServer(sessionContext));
+      }
 
       // Set up tools callback and server config for documentation page
       httpTransport.setToolsCallback(async () => {
@@ -1244,7 +1354,7 @@ export class NitroStackServer {
             enableCors: transportOptions?.enableCors !== false, // Enable CORS by default for web clients
             ...getStreamableHttpEnvOptions(),
           });
-          transport.setMcpServerFactory((sessionContext) => this.createConfiguredMcpServer(sessionContext));
+          await this.configureTransportForProtocol(transport as HttpTransport);
           this.attachLegacySdkSseIfNeeded(transport as HttpTransport);
           await transport.start();
           httpTransport = transport as HttpTransport;
@@ -1252,8 +1362,12 @@ export class NitroStackServer {
         }
 
         // 2. Connect the primary MCP server via STDIO for direct connections.
-        const stdioTransport = new StdioServerTransport();
-        await this.mcpServer.connect(stdioTransport);
+        if (needsModernEngine(this.protocolEra)) {
+          await (await this.getModernAdapter()).serveStdio();
+        } else {
+          const stdioTransport = new StdioServerTransport();
+          await this.mcpServer.connect(stdioTransport);
+        }
 
         this.logger.info(`${this.config.name} started successfully (DUAL MODE)`);
         this.logger.info(`✨ Mode: ${getAppMode().toUpperCase()} (via NITROSTACK_APP_MODE)`);
@@ -1275,8 +1389,8 @@ export class NitroStackServer {
             ...getStreamableHttpEnvOptions(),
           });
 
-          // Delegate /mcp protocol handling to the official SDK transport.
-          transport.setMcpServerFactory((sessionContext) => this.createConfiguredMcpServer(sessionContext));
+          // Delegate /mcp protocol handling to the correct protocol engine.
+          await this.configureTransportForProtocol(transport as HttpTransport);
 
           // Set up tools callback and server config for documentation page
           transport.setToolsCallback(async () => {
@@ -1308,8 +1422,12 @@ export class NitroStackServer {
         this.logger.info(`🌐 Legacy SDK SSE: http://${transportOptions?.host || 'localhost'}:${transportOptions?.port || 3000}/sse`);
       } else {
         // STDIO-only transport (default)
-        const transport = new StdioServerTransport();
-        await this.mcpServer.connect(transport);
+        if (needsModernEngine(this.protocolEra)) {
+          await (await this.getModernAdapter()).serveStdio();
+        } else {
+          const transport = new StdioServerTransport();
+          await this.mcpServer.connect(transport);
+        }
 
         this.logger.info(`${this.config.name} started successfully (STDIO transport)`);
         this.logger.info(`✨ Mode: ${getAppMode().toUpperCase()} (via NITROSTACK_APP_MODE)`);
@@ -1543,6 +1661,12 @@ export class NitroStackServer {
 
       // Destroy task manager (stops cleanup interval)
       this.taskManager.destroy();
+
+      // Close the modern protocol adapter (aborts in-flight modern exchanges).
+      if (this.modernAdapter) {
+        await this.modernAdapter.close();
+        this.modernAdapter = undefined;
+      }
 
       for (const { server: sessionMcp, transport: legacyTransport } of this.legacySdkSseSessions.values()) {
         try {

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -44,6 +44,7 @@ import {
   TaskNotFoundError,
   TaskAlreadyTerminalError,
   TaskAugmentationRequiredError,
+  type TaskAccessContext,
 } from './task.js';
 import { triggerLifecycleHook } from './lifecycle.js';
 import {
@@ -786,7 +787,12 @@ export class NitroStackServer {
       // Task-augmented path: create task, run async, return immediately
       // ----------------------------------------------------------------
       if (isTaskAugmented) {
-        const taskData = this.taskManager.createTask(taskParam, name);
+        const accessContext: TaskAccessContext | undefined = sessionContext ? {
+          sessionId: (sessionContext as any).sessionId,
+          userId: (sessionContext as any).userId,
+          tenantId: (sessionContext as any).tenantId,
+        } : undefined;
+        const taskData = this.taskManager.createTask(taskParam, name, accessContext);
         const taskId = taskData.taskId;
 
         // Attach a TaskContext to the execution context so handlers can
@@ -910,7 +916,12 @@ export class NitroStackServer {
         throw { code: -32602, message: 'Invalid params: taskId is required' };
       }
       try {
-        return this.taskManager.getTask(taskId);
+        const accessContext: TaskAccessContext | undefined = sessionContext ? {
+          sessionId: (sessionContext as any).sessionId,
+          userId: (sessionContext as any).userId,
+          tenantId: (sessionContext as any).tenantId,
+        } : undefined;
+        return this.taskManager.getTask(taskId, accessContext);
       } catch (err) {
         if (err instanceof TaskNotFoundError) {
           throw { code: -32602, message: err.message };
@@ -930,7 +941,12 @@ export class NitroStackServer {
         throw { code: -32602, message: 'Invalid params: taskId is required' };
       }
       try {
-        const { result, error } = await this.taskManager.getResult(taskId);
+        const accessContext: TaskAccessContext | undefined = sessionContext ? {
+          sessionId: (sessionContext as any).sessionId,
+          userId: (sessionContext as any).userId,
+          tenantId: (sessionContext as any).tenantId,
+        } : undefined;
+        const { result, error } = await this.taskManager.getResult(taskId, accessContext);
         if (error) {
           // Re-throw the original error so the client gets the JSON-RPC error
           throw error;
@@ -963,7 +979,12 @@ export class NitroStackServer {
     this.registerCustomHandler(mcp, 'tasks/list', async (params) => {
       const { cursor } = (params || {}) as { cursor?: string };
       try {
-        return this.taskManager.listTasks(cursor);
+        const accessContext: TaskAccessContext | undefined = sessionContext ? {
+          sessionId: (sessionContext as any).sessionId,
+          userId: (sessionContext as any).userId,
+          tenantId: (sessionContext as any).tenantId,
+        } : undefined;
+        return this.taskManager.listTasks(cursor, 50, accessContext);
       } catch (err) {
         if (err instanceof TaskNotFoundError) {
           // Invalid cursor
@@ -983,7 +1004,12 @@ export class NitroStackServer {
         throw { code: -32602, message: 'Invalid params: taskId is required' };
       }
       try {
-        return this.taskManager.cancelTask(taskId);
+        const accessContext: TaskAccessContext | undefined = sessionContext ? {
+          sessionId: (sessionContext as any).sessionId,
+          userId: (sessionContext as any).userId,
+          tenantId: (sessionContext as any).tenantId,
+        } : undefined;
+        return this.taskManager.cancelTask(taskId, accessContext);
       } catch (err) {
         if (err instanceof TaskNotFoundError) {
           throw { code: -32602, message: err.message };

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -240,6 +240,7 @@ export class NitroStackServer {
       const { ModernProtocolAdapter } = await import('./protocol/modern-v2.adapter.js');
       this.modernAdapter = new ModernProtocolAdapter(this.buildProtocolRegistry(), {
         legacyMode: this.protocolEra === 'auto' ? 'stateless' : 'reject',
+        taskManager: this.taskManager,
       });
     }
     return this.modernAdapter;

--- a/typescript/packages/core/src/core/server.ts
+++ b/typescript/packages/core/src/core/server.ts
@@ -1611,7 +1611,7 @@ export class NitroStackServer {
 
       // 2. If modern protocol adapter is running, notify via modern adapter
       if (this.modernAdapter) {
-        (this.modernAdapter as any).notifyTaskStatus?.(taskData);
+        this.modernAdapter.notifyTaskStatus?.(taskData);
         return;
       }
 

--- a/typescript/packages/core/src/core/task.ts
+++ b/typescript/packages/core/src/core/task.ts
@@ -133,56 +133,116 @@ export interface TaskEntry {
 }
 
 // ============================================================================
+// Pluggable Task Store Abstraction
+// ============================================================================
+
+/**
+ * TaskStore interface for abstracting task state storage.
+ * Defaults to InMemoryTaskStore and allows drop-in distributed backends (Redis, PostgreSQL, DynamoDB)
+ * to support multi-replica horizontally scaled deployments.
+ */
+export interface TaskStore {
+    get(taskId: string): TaskEntry | undefined;
+    set(taskId: string, entry: TaskEntry): void;
+    delete(taskId: string): boolean;
+    has(taskId: string): boolean;
+    list(): TaskEntry[];
+    cleanupExpired?(now: number): number;
+    destroy?(): void;
+}
+
+/**
+ * In-memory implementation of TaskStore.
+ */
+export class InMemoryTaskStore implements TaskStore {
+    private tasks: Map<string, TaskEntry> = new Map();
+
+    get(taskId: string): TaskEntry | undefined {
+        return this.tasks.get(taskId);
+    }
+
+    set(taskId: string, entry: TaskEntry): void {
+        this.tasks.set(taskId, entry);
+    }
+
+    delete(taskId: string): boolean {
+        return this.tasks.delete(taskId);
+    }
+
+    has(taskId: string): boolean {
+        return this.tasks.has(taskId);
+    }
+
+    list(): TaskEntry[] {
+        return Array.from(this.tasks.values());
+    }
+
+    cleanupExpired(now: number): number {
+        let count = 0;
+        for (const [taskId, entry] of this.tasks.entries()) {
+            if (entry.data.ttl === null) continue;
+            if (!isTerminalStatus(entry.data.status)) continue;
+            const terminalTime = new Date(entry.data.lastUpdatedAt).getTime();
+            if (now - terminalTime > entry.data.ttl) {
+                this.tasks.delete(taskId);
+                count++;
+            }
+        }
+        return count;
+    }
+
+    destroy(): void {
+        this.tasks.clear();
+    }
+}
+
+// ============================================================================
 // Task Manager
 // ============================================================================
+
+export interface TaskManagerOptions {
+    logger: Logger;
+    /** Custom pluggable task store (default: InMemoryTaskStore) */
+    store?: TaskStore;
+    /** Default TTL in ms (default: 300000 = 5 minutes) */
+    defaultTtl?: number;
+    /** Default poll interval in ms (default: 2000 = 2 seconds) */
+    defaultPollInterval?: number;
+    /** Callback fired on every status change (for notifications) */
+    onStatusChange?: (taskData: TaskData) => void;
+}
 
 /**
  * TaskManager handles the full lifecycle of MCP tasks.
  * 
  * It provides:
- * - In-memory task storage with TTL-based cleanup
+ * - Pluggable task storage (in-memory or distributed) with TTL cleanup
  * - Task creation, status updates, and result retrieval
  * - Cancellation support
  * - Status change notifications via callbacks
- * 
- * @example
- * ```typescript
- * const taskManager = new TaskManager({ logger, defaultTtl: 60000 });
- * 
- * // Create a task for a long-running operation
- * const task = taskManager.createTask({ ttl: 120000 });
- * 
- * // Update status as work progresses
- * taskManager.updateStatus(task.taskId, 'working', 'Processing step 2 of 5');
- * 
- * // Complete with result
- * taskManager.completeTask(task.taskId, { data: 'result' });
- * ```
  */
 export class TaskManager {
-    private tasks: Map<string, TaskEntry> = new Map();
+    private store: TaskStore;
     private logger: Logger;
     private defaultTtl: number;
     private defaultPollInterval: number;
     private cleanupInterval?: ReturnType<typeof setInterval>;
     private onStatusChange?: (taskData: TaskData) => void;
 
-    constructor(options: {
-        logger: Logger;
-        /** Default TTL in ms (default: 300000 = 5 minutes) */
-        defaultTtl?: number;
-        /** Default poll interval in ms (default: 2000 = 2 seconds) */
-        defaultPollInterval?: number;
-        /** Callback fired on every status change (for notifications) */
-        onStatusChange?: (taskData: TaskData) => void;
-    }) {
+    constructor(options: TaskManagerOptions) {
         this.logger = options.logger;
+        this.store = options.store ?? new InMemoryTaskStore();
         this.defaultTtl = options.defaultTtl ?? 300000; // 5 minutes
         this.defaultPollInterval = options.defaultPollInterval ?? 2000;
         this.onStatusChange = options.onStatusChange;
 
         // Start periodic cleanup of expired tasks
         this.cleanupInterval = setInterval(() => this.cleanupExpiredTasks(), 30000);
+    }
+
+    /** Access the underlying TaskStore */
+    getStore(): TaskStore {
+        return this.store;
     }
 
     /**
@@ -225,7 +285,7 @@ export class TaskManager {
             sessionId,
         };
 
-        this.tasks.set(taskId, entry);
+        this.store.set(taskId, entry);
         this.logger.info(`Task created: ${taskId}`, { toolName, ownerId, tenantId, sessionId });
 
         return { ...data };
@@ -363,7 +423,7 @@ export class TaskManager {
      * List all tasks with optional cursor-based pagination and tenant/user filtering
      */
     listTasks(cursor?: string, limit: number = 50, context?: TaskAccessContext): { tasks: TaskData[]; nextCursor?: string } {
-        const allTasks = Array.from(this.tasks.values())
+        const allTasks = this.store.list()
             .filter(entry => {
                 if (!context) return true;
                 if (entry.tenantId && context.tenantId && entry.tenantId !== context.tenantId) return false;
@@ -395,7 +455,7 @@ export class TaskManager {
      * Check if a task exists
      */
     hasTask(taskId: string, context?: TaskAccessContext): boolean {
-        const entry = this.tasks.get(taskId);
+        const entry = this.store.get(taskId);
         if (!entry) return false;
         if (!context) return true;
         if (entry.tenantId && context.tenantId && entry.tenantId !== context.tenantId) return false;
@@ -411,8 +471,12 @@ export class TaskManager {
      */
     private cleanupExpiredTasks(): void {
         const now = Date.now();
-        for (const [taskId, entry] of this.tasks.entries()) {
-            if (entry.data.ttl === null) continue; // Unlimited TTL
+        if (typeof this.store.cleanupExpired === 'function') {
+            this.store.cleanupExpired(now);
+            return;
+        }
+        for (const entry of this.store.list()) {
+            if (entry.data.ttl === null) continue;
 
             // Active tasks in working or input_required status must not be evicted
             if (!isTerminalStatus(entry.data.status)) {
@@ -422,8 +486,8 @@ export class TaskManager {
             // Measure TTL from the terminal completion time (lastUpdatedAt), not createdAt
             const terminalTime = new Date(entry.data.lastUpdatedAt).getTime();
             if (now - terminalTime > entry.data.ttl) {
-                this.tasks.delete(taskId);
-                this.logger.debug(`Expired terminal task cleaned up: ${taskId}`);
+                this.store.delete(entry.data.taskId);
+                this.logger.debug(`Expired terminal task cleaned up: ${entry.data.taskId}`);
             }
         }
     }
@@ -432,7 +496,7 @@ export class TaskManager {
      * Get internal entry or throw
      */
     getEntry(taskId: string, context?: TaskAccessContext): TaskEntry {
-        const entry = this.tasks.get(taskId);
+        const entry = this.store.get(taskId);
         if (!entry) {
             throw new TaskNotFoundError(taskId);
         }
@@ -473,6 +537,9 @@ export class TaskManager {
         if (this.cleanupInterval) {
             clearInterval(this.cleanupInterval);
             this.cleanupInterval = undefined;
+        }
+        if (typeof this.store.destroy === 'function') {
+            this.store.destroy();
         }
     }
 }

--- a/typescript/packages/core/src/core/task.ts
+++ b/typescript/packages/core/src/core/task.ts
@@ -32,6 +32,18 @@ export function isTerminalStatus(status: TaskStatus): boolean {
 // ============================================================================
 
 /**
+ * Caller access context for task authorization and tenant isolation
+ */
+export interface TaskAccessContext {
+    /** User/Subject ID of the caller */
+    userId?: string;
+    /** Tenant ID of the caller */
+    tenantId?: string;
+    /** MCP Session ID of the caller */
+    sessionId?: string;
+}
+
+/**
  * Task data structure as per MCP spec
  */
 export interface TaskData {
@@ -49,6 +61,12 @@ export interface TaskData {
     ttl: number | null;
     /** Suggested time in milliseconds between status checks */
     pollInterval?: number;
+    /** User/Subject ID of the task creator */
+    ownerId?: string;
+    /** Tenant ID of the task creator */
+    tenantId?: string;
+    /** MCP Session ID of the task creator (in stateful mode) */
+    sessionId?: string;
 }
 
 /**
@@ -57,6 +75,12 @@ export interface TaskData {
 export interface TaskParams {
     /** Requested TTL in milliseconds */
     ttl?: number;
+    /** User ID */
+    ownerId?: string;
+    /** Tenant ID */
+    tenantId?: string;
+    /** Session ID */
+    sessionId?: string;
 }
 
 /**
@@ -85,7 +109,7 @@ export type TaskSupportLevel = 'required' | 'optional' | 'forbidden';
 /**
  * Internal task entry with execution details
  */
-interface TaskEntry {
+export interface TaskEntry {
     /** Task data (protocol-visible) */
     data: TaskData;
     /** The pending result (resolved when task completes) */
@@ -100,6 +124,12 @@ interface TaskEntry {
     resolveCompletion: () => void;
     /** Associated tool name */
     toolName?: string;
+    /** User/Subject ID */
+    ownerId?: string;
+    /** Tenant ID */
+    tenantId?: string;
+    /** Session ID */
+    sessionId?: string;
 }
 
 // ============================================================================
@@ -158,10 +188,14 @@ export class TaskManager {
     /**
      * Create a new task
      */
-    createTask(params?: TaskParams, toolName?: string): TaskData {
+    createTask(params?: TaskParams, toolName?: string, accessContext?: TaskAccessContext): TaskData {
         const taskId = uuidv4();
         const now = new Date().toISOString();
         const ttl = params?.ttl ?? this.defaultTtl;
+
+        const ownerId = accessContext?.userId || params?.ownerId;
+        const tenantId = accessContext?.tenantId || params?.tenantId;
+        const sessionId = accessContext?.sessionId || params?.sessionId;
 
         let resolveCompletion: () => void;
         const completionPromise = new Promise<void>((resolve) => {
@@ -175,6 +209,9 @@ export class TaskManager {
             lastUpdatedAt: now,
             ttl,
             pollInterval: this.defaultPollInterval,
+            ...(ownerId ? { ownerId } : {}),
+            ...(tenantId ? { tenantId } : {}),
+            ...(sessionId ? { sessionId } : {}),
         };
 
         const entry: TaskEntry = {
@@ -183,29 +220,55 @@ export class TaskManager {
             completionPromise,
             resolveCompletion: resolveCompletion!,
             toolName,
+            ownerId,
+            tenantId,
+            sessionId,
         };
 
         this.tasks.set(taskId, entry);
-        this.logger.info(`Task created: ${taskId}`, { toolName });
+        this.logger.info(`Task created: ${taskId}`, { toolName, ownerId, tenantId, sessionId });
 
         return { ...data };
     }
 
     /**
-     * Get task data by ID
-     * @throws Error if task not found
+     * Verify caller authorization against task owner/tenant/session metadata
+     * @throws TaskNotFoundError if access is denied (to avoid disclosing task existence across tenants)
      */
-    getTask(taskId: string): TaskData {
-        const entry = this.getEntry(taskId);
+    checkTaskAccess(entry: TaskEntry, context?: TaskAccessContext): void {
+        if (!context) return; // Unrestricted internal context
+
+        // Tenant isolation: if task has a tenantId and context has a tenantId, they must match
+        if (entry.tenantId && context.tenantId && entry.tenantId !== context.tenantId) {
+            throw new TaskNotFoundError(entry.data.taskId);
+        }
+
+        // Owner/User isolation: if task has an ownerId and context has a userId, they must match
+        if (entry.ownerId && context.userId && entry.ownerId !== context.userId) {
+            throw new TaskNotFoundError(entry.data.taskId);
+        }
+
+        // Session isolation: if task has a sessionId and context has a sessionId, they must match
+        if (entry.sessionId && context.sessionId && entry.sessionId !== context.sessionId) {
+            throw new TaskNotFoundError(entry.data.taskId);
+        }
+    }
+
+    /**
+     * Get task data by ID
+     * @throws Error if task not found or access denied
+     */
+    getTask(taskId: string, context?: TaskAccessContext): TaskData {
+        const entry = this.getEntry(taskId, context);
         return { ...entry.data };
     }
 
     /**
      * Update task status
-     * @throws Error if transition is invalid
+     * @throws Error if transition is invalid or access denied
      */
-    updateStatus(taskId: string, status: TaskStatus, statusMessage?: string): TaskData {
-        const entry = this.getEntry(taskId);
+    updateStatus(taskId: string, status: TaskStatus, statusMessage?: string, context?: TaskAccessContext): TaskData {
+        const entry = this.getEntry(taskId, context);
 
         // Validate transition
         this.validateTransition(entry.data.status, status);
@@ -234,27 +297,27 @@ export class TaskManager {
     /**
      * Complete a task with a successful result
      */
-    completeTask(taskId: string, result: unknown, statusMessage?: string): TaskData {
-        const entry = this.getEntry(taskId);
+    completeTask(taskId: string, result: unknown, statusMessage?: string, context?: TaskAccessContext): TaskData {
+        const entry = this.getEntry(taskId, context);
         entry.result = result;
-        return this.updateStatus(taskId, 'completed', statusMessage ?? 'Task completed successfully');
+        return this.updateStatus(taskId, 'completed', statusMessage ?? 'Task completed successfully', context);
     }
 
     /**
      * Fail a task with an error
      */
-    failTask(taskId: string, error: { code: number; message: string; data?: unknown }, statusMessage?: string): TaskData {
-        const entry = this.getEntry(taskId);
+    failTask(taskId: string, error: { code: number; message: string; data?: unknown }, statusMessage?: string, context?: TaskAccessContext): TaskData {
+        const entry = this.getEntry(taskId, context);
         entry.error = error;
-        return this.updateStatus(taskId, 'failed', statusMessage ?? `Task failed: ${error.message}`);
+        return this.updateStatus(taskId, 'failed', statusMessage ?? `Task failed: ${error.message}`, context);
     }
 
     /**
      * Cancel a task
-     * @throws Error if task is already in a terminal state
+     * @throws Error if task is already in a terminal state or access denied
      */
-    cancelTask(taskId: string): TaskData {
-        const entry = this.getEntry(taskId);
+    cancelTask(taskId: string, context?: TaskAccessContext): TaskData {
+        const entry = this.getEntry(taskId, context);
 
         if (isTerminalStatus(entry.data.status)) {
             throw new TaskAlreadyTerminalError(taskId, entry.data.status);
@@ -263,15 +326,15 @@ export class TaskManager {
         // Signal cancellation
         entry.abortController.abort();
 
-        return this.updateStatus(taskId, 'cancelled', 'The task was cancelled by request.');
+        return this.updateStatus(taskId, 'cancelled', 'The task was cancelled by request.', context);
     }
 
     /**
      * Get the result of a completed task.
      * If the task is still working, this blocks until it reaches a terminal state.
      */
-    async getResult(taskId: string): Promise<{ result?: unknown; error?: { code: number; message: string; data?: unknown } }> {
-        const entry = this.getEntry(taskId);
+    async getResult(taskId: string, context?: TaskAccessContext): Promise<{ result?: unknown; error?: { code: number; message: string; data?: unknown } }> {
+        const entry = this.getEntry(taskId, context);
 
         // If not terminal, wait for completion
         if (!isTerminalStatus(entry.data.status)) {
@@ -279,7 +342,7 @@ export class TaskManager {
         }
 
         // Re-fetch after awaiting (status may have changed)
-        const current = this.getEntry(taskId);
+        const current = this.getEntry(taskId, context);
 
         if (current.error) {
             return { error: current.error };
@@ -291,16 +354,23 @@ export class TaskManager {
     /**
      * Get the AbortSignal for a task (useful for cancellation-aware handlers)
      */
-    getAbortSignal(taskId: string): AbortSignal {
-        const entry = this.getEntry(taskId);
+    getAbortSignal(taskId: string, context?: TaskAccessContext): AbortSignal {
+        const entry = this.getEntry(taskId, context);
         return entry.abortController.signal;
     }
 
     /**
-     * List all tasks with optional cursor-based pagination
+     * List all tasks with optional cursor-based pagination and tenant/user filtering
      */
-    listTasks(cursor?: string, limit: number = 50): { tasks: TaskData[]; nextCursor?: string } {
+    listTasks(cursor?: string, limit: number = 50, context?: TaskAccessContext): { tasks: TaskData[]; nextCursor?: string } {
         const allTasks = Array.from(this.tasks.values())
+            .filter(entry => {
+                if (!context) return true;
+                if (entry.tenantId && context.tenantId && entry.tenantId !== context.tenantId) return false;
+                if (entry.ownerId && context.userId && entry.ownerId !== context.userId) return false;
+                if (entry.sessionId && context.sessionId && entry.sessionId !== context.sessionId) return false;
+                return true;
+            })
             .map(e => ({ ...e.data }))
             .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
@@ -324,8 +394,14 @@ export class TaskManager {
     /**
      * Check if a task exists
      */
-    hasTask(taskId: string): boolean {
-        return this.tasks.has(taskId);
+    hasTask(taskId: string, context?: TaskAccessContext): boolean {
+        const entry = this.tasks.get(taskId);
+        if (!entry) return false;
+        if (!context) return true;
+        if (entry.tenantId && context.tenantId && entry.tenantId !== context.tenantId) return false;
+        if (entry.ownerId && context.userId && entry.ownerId !== context.userId) return false;
+        if (entry.sessionId && context.sessionId && entry.sessionId !== context.sessionId) return false;
+        return true;
     }
 
     /**
@@ -347,11 +423,12 @@ export class TaskManager {
     /**
      * Get internal entry or throw
      */
-    private getEntry(taskId: string): TaskEntry {
+    getEntry(taskId: string, context?: TaskAccessContext): TaskEntry {
         const entry = this.tasks.get(taskId);
         if (!entry) {
             throw new TaskNotFoundError(taskId);
         }
+        this.checkTaskAccess(entry, context);
         return entry;
     }
 

--- a/typescript/packages/core/src/core/task.ts
+++ b/typescript/packages/core/src/core/task.ts
@@ -479,6 +479,23 @@ export class TaskContext {
     }
 
     /**
+     * Push an intermediate task update (MCP 2026-07-28 `tasks/update`).
+     *
+     * On the modern path this records progress that the client observes via
+     * `tasks/get`; the optional `data` is attached to the status message.
+     * Behaves like `updateProgress` on the legacy path so handlers are written
+     * once.
+     */
+    update(message: string, data?: unknown): void {
+        const suffix = data !== undefined ? ` ${JSON.stringify(data)}` : '';
+        try {
+            this.taskManager.updateStatus(this._taskId, 'working', `${message}${suffix}`);
+        } catch {
+            // Task may have been cancelled/cleaned up — ignore
+        }
+    }
+
+    /**
      * Get the current task data
      */
     getTaskData(): TaskData {

--- a/typescript/packages/core/src/core/task.ts
+++ b/typescript/packages/core/src/core/task.ts
@@ -406,16 +406,24 @@ export class TaskManager {
 
     /**
      * Cleanup expired tasks
+     * Only terminal tasks (completed, failed, cancelled) are evicted after their TTL expires.
+     * Active tasks (working, input_required) are never evicted while execution is ongoing.
      */
     private cleanupExpiredTasks(): void {
         const now = Date.now();
         for (const [taskId, entry] of this.tasks.entries()) {
             if (entry.data.ttl === null) continue; // Unlimited TTL
 
-            const createdTime = new Date(entry.data.createdAt).getTime();
-            if (now - createdTime > entry.data.ttl) {
+            // Active tasks in working or input_required status must not be evicted
+            if (!isTerminalStatus(entry.data.status)) {
+                continue;
+            }
+
+            // Measure TTL from the terminal completion time (lastUpdatedAt), not createdAt
+            const terminalTime = new Date(entry.data.lastUpdatedAt).getTime();
+            if (now - terminalTime > entry.data.ttl) {
                 this.tasks.delete(taskId);
-                this.logger.debug(`Expired task cleaned up: ${taskId}`);
+                this.logger.debug(`Expired terminal task cleaned up: ${taskId}`);
             }
         }
     }

--- a/typescript/packages/core/src/core/tool.ts
+++ b/typescript/packages/core/src/core/tool.ts
@@ -300,17 +300,23 @@ export class Tool<TInput = unknown, TOutput = unknown> {
       try {
         const zodToJsonSchemaModule = await import('zod-to-json-schema');
         const zodToJsonSchema = zodToJsonSchemaModule.zodToJsonSchema || zodToJsonSchemaModule.default;
-        return zodToJsonSchema(schema, {
+        const json = zodToJsonSchema(schema, {
           $refStrategy: 'none',
           target: 'jsonSchema7',
         }) as JsonSchema;
+        json.additionalProperties = true;
+        return json;
       } catch (_error) {
         // Silently fall back to permissive schema — console output is
         // disabled in MCP servers as it breaks the JSON-RPC stdio protocol.
         return { type: 'object', properties: {}, additionalProperties: true };
       }
     }
-    return schema as JsonSchema;
+    const json = { ...(schema as JsonSchema) };
+    if (json.type === 'object' && json.additionalProperties === undefined) {
+      json.additionalProperties = true;
+    }
+    return json;
   }
 
   /**
@@ -324,6 +330,7 @@ export class Tool<TInput = unknown, TOutput = unknown> {
     if (!jsonSchema.type) {
       jsonSchema = { ...jsonSchema, type: 'object' };
     }
+    jsonSchema.additionalProperties = true;
 
     // Convert output schema if present and ensure type: "object"
     let outputJsonSchema: { type: 'object';[key: string]: unknown } | undefined;
@@ -349,6 +356,7 @@ export class Tool<TInput = unknown, TOutput = unknown> {
     const finalSchema: McpTool['inputSchema'] = {
       ...restSchema,
       type: 'object' as const,
+      additionalProperties: true,
     };
 
     const mcpTool: McpToolWithMeta = {

--- a/typescript/packages/core/src/core/tool.ts
+++ b/typescript/packages/core/src/core/tool.ts
@@ -93,6 +93,16 @@ export interface ToolOptions<TInput = unknown, TOutput = unknown> {
    * Tool visibility (MCP Apps mode).
    */
   visibility?: 'visible' | 'hidden';
+  /**
+   * SEP-2549 cache hint emitted on the 2026-07-28 `tools/list` result.
+   * Ignored on the legacy path.
+   */
+  cacheHint?: { ttlMs?: number; cacheScope?: 'public' | 'private' };
+  /**
+   * Cache lifetime in seconds, typically propagated from `@Cache({ ttl })`.
+   * Used as a fallback cache hint on the 2026-07-28 path.
+   */
+  cacheTtlSeconds?: number;
 }
 
 export class Tool<TInput = unknown, TOutput = unknown> {
@@ -112,6 +122,10 @@ export class Tool<TInput = unknown, TOutput = unknown> {
   isInitial?: boolean;
   /** Task support level for this tool */
   taskSupport: TaskSupportLevel;
+  /** SEP-2549 cache hint (2026-07-28 path only). */
+  cacheHint?: { ttlMs?: number; cacheScope?: 'public' | 'private' };
+  /** Cache lifetime in seconds (fallback cache hint source). */
+  cacheTtlSeconds?: number;
   private handler: ToolHandler<TInput, TOutput>;
   private guards: GuardConstructor[];
   private middlewares: MiddlewareConstructor[];
@@ -140,6 +154,8 @@ export class Tool<TInput = unknown, TOutput = unknown> {
     this.isInitial = options.isInitial;
     this.taskSupport = options.taskSupport ?? 'forbidden';
     this.visibility = options.visibility || 'visible';
+    this.cacheHint = options.cacheHint;
+    this.cacheTtlSeconds = options.cacheTtlSeconds;
   }
 
   /**

--- a/typescript/packages/core/src/core/transports/streamable-http.ts
+++ b/typescript/packages/core/src/core/transports/streamable-http.ts
@@ -34,6 +34,12 @@ import { dirname, join } from 'path';
 export interface SessionContext {
   /** Raw HTTP Authorization header from the most recent request on this session. */
   authHeader?: string;
+  /** Active session ID */
+  sessionId?: string;
+  /** Authenticated user ID */
+  userId?: string;
+  /** Authenticated tenant ID */
+  tenantId?: string;
 }
 
 /**
@@ -421,6 +427,16 @@ export class StreamableHttpTransport {
       if (authHeader) {
         session.sessionContext.authHeader = authHeader;
       }
+      if (sessionId) {
+        session.sessionContext.sessionId = sessionId;
+      }
+      const reqAuth = (req as any).auth;
+      if (reqAuth?.userId && !session.sessionContext.userId) {
+        session.sessionContext.userId = reqAuth.userId;
+      }
+      if (reqAuth?.tenantId && !session.sessionContext.tenantId) {
+        session.sessionContext.tenantId = reqAuth.tenantId;
+      }
 
       // Refresh activity so the idle sweeper only reaps genuinely stale sessions.
       session.lastActivity = Date.now();
@@ -428,6 +444,16 @@ export class StreamableHttpTransport {
       // Cast around the SDK's expected node req/res types: Express augments
       // Request with nitrostack's own `auth` shape which differs from the SDK's.
       await session.transport.handleRequest(req as any, res as any, req.body);
+
+      // In stateful mode, promote initialized session and bind sessionId to context
+      if (session.transport.sessionId) {
+        const sid = session.transport.sessionId;
+        session.sessionContext.sessionId = sid;
+        if (!this.mcpSessions.has(sid)) {
+          this.pendingSessions.delete(session);
+          this.mcpSessions.set(sid, session);
+        }
+      }
     } catch (error: unknown) {
       console.error('MCP request error:', error);
       // If we created a session for this request but handling it failed (e.g. a
@@ -473,6 +499,7 @@ export class StreamableHttpTransport {
         // Session is now live: promote from pending to the tracked map.
         this.pendingSessions.delete(session);
         this.mcpSessions.set(sid, session);
+        session.sessionContext.sessionId = sid;
       },
     });
     session.transport = transport;

--- a/typescript/packages/core/src/core/transports/streamable-http.ts
+++ b/typescript/packages/core/src/core/transports/streamable-http.ts
@@ -123,6 +123,14 @@ export class StreamableHttpTransport {
   private _routesRegistered = false;
   private mcpServerFactory?: McpServerFactory;
   private legacySseHandler?: LegacySseHandler;
+  /**
+   * When set, the MCP endpoint (POST/GET/DELETE) is delegated to this handler
+   * instead of the legacy per-session SDK path. Used by the modern
+   * (2026-07-28) protocol adapter, which serves stateless requests itself.
+   */
+  private modernHandler?: (req: Request, res: Response) => void;
+  /** Protocol revision advertised on the health endpoint and startup logs. */
+  private protocolVersionLabel = '2025-06-18';
   private mcpSessions: Map<string, McpSession> = new Map();
   // Sessions that have been created but have not yet completed `initialize`
   // (no session id assigned yet). Tracked separately so they count against the
@@ -173,6 +181,21 @@ export class StreamableHttpTransport {
    */
   setLegacySseHandler(handler: LegacySseHandler): void {
     this.legacySseHandler = handler;
+  }
+
+  /**
+   * Delegate the MCP endpoint to a modern (2026-07-28) stateless handler
+   * instead of the legacy per-session SDK path. Must be called before `start()`.
+   */
+  setModernHandler(handler: (req: Request, res: Response) => void): void {
+    this.modernHandler = handler;
+  }
+
+  /**
+   * Set the protocol revision label used on `/mcp/health` and startup logs.
+   */
+  setProtocolVersionLabel(label: string): void {
+    this.protocolVersionLabel = label;
   }
 
   /**
@@ -233,8 +256,11 @@ export class StreamableHttpTransport {
       this.app.use((req, res, next) => {
         res.setHeader('Access-Control-Allow-Origin', '*');
         res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
-        res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Accept, Authorization, Mcp-Session-Id, MCP-Protocol-Version, Last-Event-ID');
-        res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id');
+        // Allow both 2025-era (Mcp-Session-Id) and 2026-07-28 (Mcp-Method,
+        // Mcp-Name, Mcp-Param-*) request headers; extra allowed headers are
+        // harmless for legacy clients.
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Accept, Authorization, Mcp-Session-Id, MCP-Protocol-Version, Mcp-Method, Mcp-Name, Mcp-Param-*, Last-Event-ID');
+        res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id, MCP-Protocol-Version, Mcp-Method, Mcp-Name');
 
         // Handle OPTIONS immediately
         if (req.method === 'OPTIONS') {
@@ -280,18 +306,29 @@ export class StreamableHttpTransport {
     }
 
     // MCP endpoint - POST (client->server messages), GET (server->client SSE
-    // stream) and DELETE (session termination) are all delegated to the official
-    // SDK Streamable HTTP transport, which owns the protocol semantics.
-    this.app.post(endpoint, (req, res) => this.handleMcpRequest(req, res));
-    this.app.get(endpoint, (req, res) => this.handleMcpRequest(req, res));
-    this.app.delete(endpoint, (req, res) => this.handleMcpRequest(req, res));
+    // stream) and DELETE (session termination).
+    //
+    // On the modern (2026-07-28) path the endpoint is delegated to the modern
+    // stateless handler, which owns the wire semantics (server/discover,
+    // per-request envelope, cache hints). Otherwise it is delegated to the
+    // official SDK Streamable HTTP transport (sessionful 2025-era).
+    if (this.modernHandler) {
+      const modern = this.modernHandler;
+      this.app.post(endpoint, (req, res) => modern(req, res));
+      this.app.get(endpoint, (req, res) => modern(req, res));
+      this.app.delete(endpoint, (req, res) => modern(req, res));
+    } else {
+      this.app.post(endpoint, (req, res) => this.handleMcpRequest(req, res));
+      this.app.get(endpoint, (req, res) => this.handleMcpRequest(req, res));
+      this.app.delete(endpoint, (req, res) => this.handleMcpRequest(req, res));
+    }
 
     // Health check
     this.app.get(`${endpoint}/health`, (req, res) => {
       res.json({
         status: 'ok',
         transport: 'streamable-http',
-        version: '2025-06-18',
+        version: this.protocolVersionLabel,
         sessions: this.mcpSessions.size,
         uptime: process.uptime(),
       });
@@ -549,8 +586,8 @@ export class StreamableHttpTransport {
           this.server = server;
 
           console.error(`🌐 MCP Streamable HTTP transport listening on http://${this.options.host}:${this.options.port}${this.options.endpoint}`);
-          console.error(`   Protocol: MCP 2025-06-18`);
-          console.error(`   Sessions: ${this.options.enableSessions ? 'enabled' : 'disabled'}`);
+          console.error(`   Protocol: MCP ${this.protocolVersionLabel}`);
+          console.error(`   Sessions: ${this.modernHandler ? 'stateless (modern)' : this.options.enableSessions ? 'enabled' : 'disabled'}`);
 
           resolve();
         });

--- a/typescript/packages/core/src/core/types.ts
+++ b/typescript/packages/core/src/core/types.ts
@@ -84,6 +84,28 @@ export interface McpServerConfig {
   extensions?: Record<string, Record<string, unknown>>;
 }
 
+/**
+ * Options passed to `server.start(options)` to explicitly specify or override
+ * transport and network settings.
+ */
+export interface ServerStartOptions {
+  /**
+   * Transport mode:
+   * - 'stdio': Pure standard I/O (dev tools, Claude Desktop, local subagent)
+   * - 'http': Streamable HTTP (stateless 2026-07-28 or sessionful legacy)
+   * - 'dual': Simultaneous STDIO + HTTP listening
+   */
+  transport?: 'stdio' | 'http' | 'dual';
+  /** HTTP server port (when using http or dual transport) */
+  port?: number;
+  /** HTTP server host (when using http or dual transport) */
+  host?: string;
+  /** MCP endpoint base path (default: '/mcp') */
+  endpoint?: string;
+  /** Enable CORS headers on HTTP endpoints (default: true) */
+  enableCors?: boolean;
+}
+
 // ============================================================================
 // Tool Types
 // ============================================================================

--- a/typescript/packages/core/src/core/types.ts
+++ b/typescript/packages/core/src/core/types.ts
@@ -66,6 +66,22 @@ export interface McpServerConfig {
     maxRequests: number;
     windowMs: number;
   };
+  /**
+   * MCP protocol era to serve. Additive and optional — env var
+   * `NITRO_MCP_PROTOCOL_VERSION` always wins over this value.
+   *
+   * - unset / `2025-06-18` / `2025-11-25` / `legacy` — current sessionful path (default)
+   * - `2026-07-28` / `modern` — stateless 2026-07-28 wire
+   * - `auto` — serve both eras from one process (for validation)
+   */
+  protocolVersion?: string;
+  /**
+   * Extra MCP extensions to advertise on the 2026-07-28 `server/discover`
+   * capabilities map (SEP-2133), keyed by reverse-DNS extension id. NitroStack
+   * already derives `io.modelcontextprotocol/app` and
+   * `io.modelcontextprotocol/tasks` automatically from what the app registers.
+   */
+  extensions?: Record<string, Record<string, unknown>>;
 }
 
 // ============================================================================
@@ -165,6 +181,11 @@ export interface ResourceDefinition {
     cacheable?: boolean;
     cacheMaxAge?: number;
   };
+  /**
+   * SEP-2549 cache hint emitted on the 2026-07-28 `resources/read` /
+   * `resources/list` results. Ignored on the legacy path.
+   */
+  cacheHint?: { ttlMs?: number; cacheScope?: 'public' | 'private' };
 }
 
 /**
@@ -331,7 +352,46 @@ export interface ExecutionContext {
     updateProgress(message: string): void;
     requestInput(message: string): void;
     throwIfCancelled(): void;
+    /**
+     * Push an intermediate task update (2026-07-28 `tasks/update`). Available
+     * on the modern path; a no-op on the legacy path.
+     */
+    update?(message: string, data?: JsonValue): void;
   };
+
+  // ==========================================================================
+  // MCP 2026-07-28 additions (populated only on the modern protocol path;
+  // undefined on the legacy 2025-era path). All optional and additive.
+  // ==========================================================================
+
+  /**
+   * The negotiated protocol version for this request
+   * (e.g. `2026-07-28`). Undefined on the legacy path.
+   */
+  protocolVersion?: string;
+  /**
+   * Opaque multi-round-trip state echoed by the client on a retried request
+   * (SEP-2322). Read alongside `inputResponses`.
+   */
+  requestState?: JsonValue;
+  /**
+   * Client-supplied answers to a prior `inputRequired(...)` (SEP-2322), keyed
+   * by the ids the server assigned. Untrusted input — validate before use.
+   */
+  inputResponses?: Record<string, JsonValue>;
+  /**
+   * W3C Trace Context lifted from the request `_meta` envelope (SEP-414):
+   * `traceparent`, `tracestate`, `baggage`.
+   */
+  trace?: {
+    traceparent?: string;
+    tracestate?: string;
+    baggage?: string;
+  };
+  /** Client identity from the per-request `_meta` envelope (SEP-2575). */
+  clientInfo?: { name?: string; version?: string;[key: string]: JsonValue | undefined };
+  /** Client capabilities from the per-request `_meta` envelope (SEP-2575). */
+  clientCapabilities?: Record<string, JsonValue>;
 }
 
 // ============================================================================

--- a/typescript/packages/core/src/core/types.ts
+++ b/typescript/packages/core/src/core/types.ts
@@ -70,9 +70,9 @@ export interface McpServerConfig {
    * MCP protocol era to serve. Additive and optional — env var
    * `NITRO_MCP_PROTOCOL_VERSION` always wins over this value.
    *
-   * - unset / `2025-06-18` / `2025-11-25` / `legacy` — current sessionful path (default)
+   * - unset / `auto` — serve both eras from one process with modern engine & stateless legacy fallback (default)
    * - `2026-07-28` / `modern` — stateless 2026-07-28 wire
-   * - `auto` — serve both eras from one process (for validation)
+   * - `2025-06-18` / `2025-11-25` / `legacy` — sessionful legacy path
    */
   protocolVersion?: string;
   /**

--- a/typescript/packages/core/src/core/types.ts
+++ b/typescript/packages/core/src/core/types.ts
@@ -317,6 +317,8 @@ export interface PromptMessage {
  * Authentication context attached to execution context
  */
 export interface AuthContext {
+  /** Whether the request is authenticated */
+  authenticated?: boolean;
   /** User or client identifier */
   subject?: string;
   /** Granted scopes/permissions */
@@ -331,6 +333,9 @@ export interface AuthContext {
   iss?: string;
   /** Custom claims */
   claims?: Record<string, JsonValue>;
+  /** Token introspection info */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tokenInfo?: any;
   /** Full decoded token payload (for backward compatibility) */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   tokenPayload?: any;


### PR DESCRIPTION
## Description

This PR implements the official **Model Context Protocol (MCP) `2026-07-28` specification** across `@nitrostack/core` while maintaining 100% backward compatibility for existing 2025-era sessionful servers.

It introduces a dual-adapter architecture, a robust task orchestration engine (`TaskManager` / `TaskStore`), multi-channel notification routing, hardened OAuth 2.1 & Client ID Metadata Document (CIMD) resolution, Multi-Round-Trip Requests (MRTR) for interactive elicitation, full JSON Schema 2020-12 translation, W3C trace context propagation, cache hints, and comprehensive configuration support across starter templates (including Pizza and OAuth Flight Booking templates).

---

## System Architecture Diagram

```mermaid
flowchart TD
    subgraph Clients["MCP Clients"]
        C1["Modern MCP Client (2026-07-28)\n(NitroStudio / Claude / Cursor)"]
        C2["Legacy MCP Client (2025-06-18)\n(Sessionful SSE / HTTP)"]
    end

    subgraph Transport["Transport Layer (HTTP / STDIO)"]
        TH["Streamable HTTP Transport (/mcp)"]
        TS["StdIO Transport"]
        SEL{"Protocol Era Selector\n(NITRO_MCP_PROTOCOL_VERSION)"}
    end

    subgraph Adapters["Protocol Adapters"]
        MA["ModernProtocolAdapter (v2)\n(@modelcontextprotocol/server@2.0.0)\nStateless per-request dispatch"]
        LA["Legacy Adapter (v1)\n(@modelcontextprotocol/sdk@1.x)\nSessionful SSE / Handshakes"]
    end

    subgraph Security["Auth & Interception Layer"]
        OG["OAuthGuard & Token Extractor\n(Bearer Header / _meta.authorization / URL Query)"]
        CIMD["CIMD & SSRF Resolver\n(HTTPS, RFC 6890 validation, 5 KiB cap, RFC 9207 iss check)"]
        SAN["Argument Sanitizer\n(Strips _meta from tool arguments)"]
    end

    subgraph Tasks["Task Orchestration (SEP-2663)"]
        TINT["Task Wire Interceptor\n(tasks/get, tasks/cancel, pre-dispatch)"]
        TM["TaskManager\n(Lifecycle, Access Control, Cancellation Safety)"]
        TS_STORE[("Pluggable TaskStore\n(InMemoryTaskStore / Custom Store)")]
        NR["Multi-Channel Notification Router\n(Legacy SSE / Modern Subscriptions / STDIO)"]
    end

    subgraph Features["Protocol Features & Schema Bridge"]
        MRTR["MRTR Elicitation Engine\n(inputRequired / acceptedContent / requestState)"]
        SCH["JSON Schema 2020-12 Bridge\n(Zod -> Schema 2020-12 / additionalProperties)"]
        OBS["Observability & Caching\n(W3C Trace Context / Cache Hints ttlMs)"]
    end

    subgraph Registry["NitroStack Application Registry"]
        TOOLS["@Tool Handlers"]
        RES["@Resource Handlers"]
        PROMPTS["@Prompt Handlers"]
        WIDGETS["@Widget / UI Templates"]
    end

    C1 -->|"stateless HTTP (_meta / server/discover)"| TH
    C2 -->|"legacy JSON-RPC (initialize / Mcp-Session-Id)"| TH
    C1 -.->|"stdio stream"| TS
    C2 -.->|"stdio stream"| TS

    TH --> SEL
    TS --> SEL

    SEL -->|"era: auto (default) | modern"| MA
    SEL -->|"era: legacy (explicit 2025-06-18)"| LA

    MA --> OG
    OG --> CIMD
    MA --> TINT
    TINT --> TM
    TM <--> TS_STORE
    TM --> NR

    MA --> SAN
    MA --> SCH
    MA --> MRTR
    MA --> OBS

    SAN --> TOOLS
    OBS --> TOOLS
    OBS --> RES
    SCH --> PROMPTS
    TOOLS --> WIDGETS
    RES --> WIDGETS
```

---

## Protocol Auto Support & Default Behavior

NitroStack features built-in **runtime protocol version resolution** with **`auto` mode as the default** when unset:

* **Unset / `NITRO_MCP_PROTOCOL_VERSION=auto` (Default)**:
  Enables the modern stateless engine while configuring the underlying adapter with `legacyMode: 'stateless'`. A single `/mcp` HTTP endpoint seamlessly serves **both** modern 2026-07-28 clients (using per-request `_meta`, `server/discover`, and method headers) and legacy 2025 JSON-RPC clients (translating `initialize` handshakes statelessly).
* **`NITRO_MCP_PROTOCOL_VERSION=2026-07-28` (or `modern`, `latest`)**:
  Enforces pure modern stateless MCP 2.0 operation (`legacyMode: 'reject'`).
* **`NITRO_MCP_PROTOCOL_VERSION=2025-06-18` (or `legacy`)**:
  Explicitly selects the 2025-era sessionful wire powered by `@modelcontextprotocol/sdk` v1.
* **Precedence Order**:
  `process.env.NITRO_MCP_PROTOCOL_VERSION` **>** `@McpApp({ protocolVersion })` / `McpServerConfig` **>** Default `auto` mode.

---

## Key Changes & Enhancements

### 1. Stateless Core & Protocol Versioning (SEP-2575, SEP-2567, SEP-2243)
- **Dual Adapter Architecture**: Introduced `ModernProtocolAdapter` (`src/core/protocol/modern-v2.adapter.ts`) integrating `@modelcontextprotocol/server@2.0.0` alongside the legacy 2025 adapter.
- **Protocol Selector**: Added `src/core/protocol/version.ts` for dynamic runtime resolution (`auto` default, `2026-07-28`, `2025-06-18`).
- **Discovery Endpoint**: Implemented `server/discover` endpoint advertising server metadata, capabilities, and versioned extensions.
- **Stateless HTTP Transport**: Removed `Mcp-Session-Id` header requirements; each request is self-contained with a per-request `_meta` envelope (`protocolVersion`, `clientCapabilities`, `clientInfo`).
- **Header Validation & CORS**: Enforced validation for `MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`, and `Mcp-Param-*` headers with CORS support.
- **Heartbeat & Middleware Compatibility**: Added built-in `ping` method handler on modern adapter and enabled pre-parsed `req.body` handling for Express `json()` middleware.

### 2. Task Orchestration & Storage Abstraction (SEP-2663)
- **Pluggable Task Storage**: Introduced `TaskStore` interface and `InMemoryTaskStore` implementation with `Server.setTaskStore()` for custom persistence backends.
- **Task Lifecycle & Safety**: Implemented `TaskManager` supporting creation, status transitions (`working`, `completed`, `failed`, `cancelled`), stateful session tracking, pagination, and cancellation safety checks.
- **Multi-Tenant Authorization**: Added `TaskAccessContext` metadata enforcement and `TaskUnauthorizedError` for tenant-isolated task access.
- **TTL Eviction Protection**: Preserves active tasks during eviction sweeps and calculates TTL expiration strictly from terminal completion timestamps.
- **Wire Interception & Multi-Channel Notifications**: Built pre-dispatch wire interception in `ModernProtocolAdapter` for task-augmented tool calls, rejection of legacy task methods (`tasks/result`, `tasks/list`), and multi-channel task status notification routing (`notifyTaskStatus`) across modern adapters, legacy SSE, and STDIO transports.

### 3. Hardened OAuth 2.1 & CIMD Authentication (RFC 9207, RFC 7517, SEP-2468, SEP-837, SEP-2352)
- **Client ID Metadata Document (CIMD)**: Implemented secure CIMD resolution with HTTPS enforcement, redirect prohibition, 5 KiB maximum response payload cap, timeout/AbortSignal support, and URL validation.
- **SSRF Protection**: Added RFC 6890 special-use and private IP range validation preventing SSRF attacks during CIMD fetching.
- **Standardized OAuthGuard**: Unified token extraction across HTTP Authorization Bearer headers, modern `_meta.authorization` envelopes, URL query parameters, and execution context.
- **Argument Sanitization**: Automatically strips `_meta` metadata keys from tool arguments before invoking user business logic.
- **Claims Mapping & Scope Resolution**: Automatically maps verified JWT payload claims into `ExecutionContext.auth` / `ExecutionContext.user` and prioritizes environment variables (`PORT`, `OAUTH_SCOPES`, `RESOURCE_URI`, `AUTH_SERVER_URL`) over static module configuration.
- **RFC 9207 & Anti-Mixup**: Added anti-mixup issuer validation (`iss`), loopback redirect URI native app inference (`application_type: "native"`), and issuer-bound token storage.

### 4. Multi-Round-Trip Requests (MRTR) (SEP-2322)
- Added `inputRequired()` and `acceptedContent()` in `src/core/protocol/features/mrtr.ts`.
- Enabled multi-turn server-to-client elicitation with `resultType: "input_required"`, `inputRequests`, and signed opaque `requestState`.

### 5. JSON Schema 2020-12 & Schema Normalization (SEP-2106)
- Implemented schema bridge in `src/core/protocol/features/schema.ts` converting Zod and JSON schemas to full JSON Schema 2020-12 specification (preserving `$defs`, `$ref`, `oneOf`/`anyOf`).
- Allowed `additionalProperties` in tool input schemas to prevent validation errors for contextual and framework parameters.
- Added argument schema registration and regression tests for modern MCP prompts.

### 6. Cache Hints, Trace Context & Widgets (SEP-2549, SEP-414)
- Implemented cache hints (`ttlMs`, `cacheScope`) on list/read/discover responses via `src/core/protocol/features/cache-hints.ts`.
- Ingested and propagated W3C Trace Context (`traceparent`, `tracestate`, `baggage`) into `ExecutionContext.trace`.
- Preserved widget metadata (`ui/template`, `openai/outputTemplate`, widget CSP, description, borders, domain) on modern tool registration and fixed bundled HTML widget filename resolution.

---

## Environment Configuration (`.env`) for Templates

### 1. Pizza Template (`typescript-pizzaz` / `05-stateless-pizza`)

```env
# =============================================================================
# NitroStack Server Configuration (Stateless Pizza MCP App)
# =============================================================================
NITRO_LOG_LEVEL=info
NITROSTACK_APP_MODE=universal

# Server Transport Configuration
# Values: http | stdio | dual (defaults to 'stdio' in dev, 'dual' in prod)
MCP_TRANSPORT_TYPE=http
PORT=3000
HOST=localhost
ENABLE_CORS=true

# MCP Protocol Version Selection
#   - Unset / auto: Serves both 2026-07-28 stateless & legacy 2025 clients on one endpoint (default)
#   - 2026-07-28  : Enforces pure modern stateless MCP protocol
#   - 2025-06-18  : Selects legacy sessionful wire
NITRO_MCP_PROTOCOL_VERSION=auto

# Mapbox Configuration (Optional - for interactive pizza store maps)
NEXT_PUBLIC_MAPBOX_TOKEN=pk.your_mapbox_token_here
```

### 2. OAuth Flight Booking Template (`typescript-oauth` / `04-stateless-auth`)

```env
# =============================================================================
# NitroStack Server Transport Configuration (Stateless Flight Booking MCP)
# =============================================================================
NITRO_LOG_LEVEL=info
NITROSTACK_APP_MODE=universal

# MCP Protocol Version Selection
# Unset defaults to 'auto' (serves stateless MCP 2.0 engine while allowing legacy client fallback)
NITRO_MCP_PROTOCOL_VERSION=auto

# Server Transport Configuration
# Values: http | stdio | dual
MCP_TRANSPORT_TYPE=http
PORT=3008
HOST=localhost
ENABLE_CORS=true

# =============================================================================
# OAuth 2.1 Server Security Configuration
# =============================================================================
# OAUTH_REQUIRED controls whether authentication is enforced.
#   - false: Permissive (for local development)
#   - true : Fail-closed — all protected tools reject requests without a valid Bearer token
OAUTH_REQUIRED=true

# Resource URI & Audience (Must match Auth0 API Identifier)
RESOURCE_URI=http://localhost:3000/mcp
TOKEN_AUDIENCE=http://localhost:3000/mcp

# Auth0 Authorization Server Tenant URL
AUTH_SERVER_URL=https://dev-jrf0vcwukzw1ux6z.us.auth0.com

# Cryptographic JWKS Signature Verification (RFC 7517)
JWKS_URI=https://dev-jrf0vcwukzw1ux6z.us.auth0.com/.well-known/jwks.json

# Expected Token Issuer (RFC 9207 Anti-Mixup Validation)
TOKEN_ISSUER=https://dev-jrf0vcwukzw1ux6z.us.auth0.com/

# Dynamic Client Registration / Static Client Credentials (CIMD / DCR)
OAUTH_ENABLE_CLIENT_REGISTRATION=true
OAUTH_CLIENT_ID=00Rwdc79aofEkA82EZ8kqzpVGiTEFQJE
OAUTH_CLIENT_SECRET=your_oauth_client_secret_here

# Optional Token Introspection (Alternative to JWKS signature verification)
# INTROSPECTION_ENDPOINT=https://dev-jrf0vcwukzw1ux6z.us.auth0.com/oauth/token/introspect
# INTROSPECTION_CLIENT_SECRET=your_introspection_secret

# =============================================================================
# CogNerd & Duffel Flight API Integration Settings
# =============================================================================
COGNERD_API_BASE_URL=https://api.cognerd.ai
COGNERD_SCOPE=read:visibility write:visibility admin read write
COGNERD_CLIENT_ID=00Rwdc79aofEkA82EZ8kqzpVGiTEFQJE
COGNERD_MOCK_MODE=true

# Duffel API Integration (Required for Live Flight Search & Booking)
DUFFEL_API_KEY=duffel_test__Me8tLY5SLkuP7aAmR3yyN4GUnbejztpIBqzN1KGbik

# Mapbox Configuration (Optional - for flight route visualization)
NEXT_PUBLIC_MAPBOX_TOKEN=pk.your_mapbox_token_here
```

---

## Type of Change

- [x] feat: New feature
- [x] fix: Bug fix
- [x] docs: Documentation update
- [x] refactor: Internal code change
- [x] test: Test-only changes
- [ ] chore: Build, CI, or tooling changes

---

## Verification & Testing

- [x] `npm run lint`
- [x] `npm test` — **60 test suites passed, 707 unit and integration tests passed**
- [x] Transport smoke tests executed (`stdio-smoke-test.mjs`, `stateless-http-lifecycle.test.ts`)
- [x] Task lifecycle & eviction suite validated (`tasks.integration.test.ts`, `stateful-task.integration.test.ts`, `task.test.ts`)
- [x] OAuth 2.1, CIMD resolution, and SSRF security tests validated (`auth-hardening.test.ts`)
- [x] Modern protocol handler and prompt regression suites validated (`modern-handler.test.ts`, `modern-prompt.test.ts`, `selector.test.ts`)

---

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [x] I have added/updated tests where appropriate
- [x] I have updated docs and starter templates where appropriate
- [x] I have kept this PR focused and scoped
- [x] I have used conventional commits
